### PR TITLE
fix(observer-daemon): preserve retry behavior when Claude CLI fails

### DIFF
--- a/skills/arc-observing/scripts/observer-daemon.sh
+++ b/skills/arc-observing/scripts/observer-daemon.sh
@@ -135,13 +135,11 @@ Each file: {id}.md with YAML frontmatter + markdown body.
   while [ "$retry_count" -le "$max_retries" ] && [ "$analysis_success" = false ]; do
     if command -v claude &>/dev/null; then
       # Capture stdout and stderr separately
-      claude_output=$(echo "$prompt" | claude --model haiku --max-turns 3 --print 2>&1)
-      local exit_code=$?
-
-      if [ "$exit_code" -eq 0 ]; then
+      if claude_output=$(echo "$prompt" | claude --model haiku --max-turns 3 --print 2>&1); then
         analysis_success=true
         log_msg "Claude analysis completed successfully"
       else
+        local exit_code=$?
         log_msg "ERROR: claude analysis failed (exit code: ${exit_code})"
         if [ "$retry_count" -lt "$max_retries" ]; then
           retry_count=$((retry_count + 1))


### PR DESCRIPTION
### Motivation
- The daemon runs under `set -euo pipefail`, so a failing `claude` invocation inside a command substitution would cause the script to exit before the retry logic could run. 
- Ensure transient Claude CLI failures are handled by the existing retry/backoff path instead of terminating the observer daemon.

### Description
- Updated `skills/arc-observing/scripts/observer-daemon.sh` to run the Claude call inside a conditional assignment using `if claude_output=$(...); then ... else ... fi` so non-zero exits flow to the `else` branch rather than exiting the shell. 
- Capture the `exit_code` inside the `else` block and preserve existing error logging and retry/backoff behavior. 
- No changes to the retry policy, logging, or downstream verification logic (instinct file checks and bubble-up) were made.

### Testing
- Ran a syntax check with `bash -n skills/arc-observing/scripts/observer-daemon.sh`, which completed successfully. 
- Verified the modified conditional pattern preserves the intended retry/logging control flow by inspection of the `analyze_project` function.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca4b7275883338248ab065534931f)