### PR TITLE
feat(learning): three-type evolution and resistance-based confidence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "arcforge",
       "description": "Skill-based workflow engine for AI coding agents: planning, TDD, worktree orchestration, and session learning",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "source": "./",
       "author": {
         "name": "Gregory Ho"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arcforge",
   "description": "Skill-based workflow engine for AI coding agents: planning, TDD, worktree orchestration, and session learning",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "Gregory Ho"
   },

--- a/.opencode/plugins/arcforge.js
+++ b/.opencode/plugins/arcforge.js
@@ -79,7 +79,7 @@ ${content}
 
 export default {
   name: 'arcforge',
-  version: '1.1.0',
+  version: '1.1.2',
 
   'experimental.chat.system.transform': async (_input, output) => {
     const bootstrap = getBootstrapContent();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.1.2] - 2026-02-14
+
+### Added
+
+- `scripts/lib/evolve.js`: Three-type evolution engine — classifies instinct clusters into skills, commands, or agents via domain+confidence rules with keyword tiebreaker
+- `learn.js generate` command: Creates skill, command, or agent scaffolds from clustered instincts (`--type`, `--name`, `--dry-run`)
+- `learn.js list` command: Shows previously evolved artifacts from JSONL tracking log
+- `session-utils.js`: `getEvolvedLogPath()` helper for `~/.claude/evolved/evolved.jsonl`
+- Resistance-based confidence: `MANUAL_CONTRADICT_DELTA`, `MANUAL_DECAY_PER_WEEK`, `RESISTANT_SOURCES` for source-aware scoring
+- Tests: `evolve.test.js` (358 lines), `confidence.test.js` additions (118 lines), `learn.test.js` (135 lines)
+
+### Changed
+
+- `confidence.js`: `applyContradiction()` accepts optional `source` — manual/reflection instincts receive half-strength contradiction (-0.05 vs -0.10)
+- `confidence.js`: `runDecayCycle()` applies source-aware decay — resistant sources decay at 50% rate
+- `instinct.js`: passes `frontmatter.source` to `applyContradiction()` for resistance-based scoring
+- `learn.js`: Extracted helpers, removed duplication, derived constants from centralized modules
+
+### Fixed
+
+- `learn.js generate`: Refuses to overwrite existing artifacts — exits with error instead of silently clobbering
+- `learn.js generate`: `--name` sanitized to prevent path traversal (`/`, `\`, `..`)
+- `learn.js generate`: `--type` validated against allowed values (skill, command, agent)
+- `learn.js generate`: Empty slug fallback uses domain name instead of broken paths
+- `learn.js`: Evolution deduplication scoped to project to prevent cross-project false positives
+
 ## [1.1.1] - 2026-02-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arcforge
 
-[![Version](https://img.shields.io/badge/version-1.1.1-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.1.2-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI](https://github.com/GregoryHo/arcforge/actions/workflows/ci.yml/badge.svg)](https://github.com/GregoryHo/arcforge/actions/workflows/ci.yml)
 

--- a/docs/guide/architecture-overview.txt
+++ b/docs/guide/architecture-overview.txt
@@ -16,6 +16,7 @@
 │  │       ├── locking.js           # File-based DAG locking                                  │
 │  │       ├── package-manager.js   # PM detection (npm/pnpm/yarn/bun)                        │
 │  │       ├── confidence.js        # Confidence scoring for instincts                        │
+│  │       ├── evolve.js            # Instinct-to-artifact evolution (skill/cmd/agent)         │
 │  │       ├── fingerprint.js       # Trigger fingerprinting (Jaccard)                        │
 │  │       ├── global-index.js      # Cross-project instinct bubble-up                        │
 │  │       ├── instinct-writer.js   # Instinct file creation                                  │

--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -542,7 +542,7 @@ arcforge's 24 skills are organized into 6 categories:
 1. Capture: hooks record every tool call to observations.jsonl
 2. Analysis: background daemon detects patterns (10+ observations required)
 3. Creation: instincts saved as `.md` files with YAML frontmatter
-4. Lifecycle: confirm (+0.05) / contradict (-0.10) / decay (-0.02/week)
+4. Lifecycle: confirm (+0.05) / contradict (-0.10, -0.05 for manual/reflection) / decay (-0.02/week, -0.01 for manual/reflection)
 5. Loading: instincts with confidence >= 0.7 auto-loaded into context
 
 **Artifacts:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arcforge",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arcforge",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "bin": {
         "arcforge": "scripts/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcforge",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Skill-based autonomous agent pipeline for Claude Code, Codex, Gemini CLI, and OpenCode",
   "license": "MIT",
   "author": {

--- a/scripts/lib/confidence.js
+++ b/scripts/lib/confidence.js
@@ -26,8 +26,9 @@ const REFLECT_MAX_CONFIDENCE = 0.85;
 const MIN_CONFIDENCE = 0.1;
 
 // Resistance-based confidence: manual/reflection instincts decay slower
-const MANUAL_CONTRADICT_DELTA = -0.05; // Half of -0.10
-const MANUAL_DECAY_PER_WEEK = 0.01; // Half of 0.02
+const RESISTANT_DECAY_RATIO = 0.5;
+const MANUAL_CONTRADICT_DELTA = CONTRADICT_DELTA * RESISTANT_DECAY_RATIO;
+const MANUAL_DECAY_PER_WEEK = DECAY_PER_WEEK * RESISTANT_DECAY_RATIO;
 const RESISTANT_SOURCES = new Set(['manual', 'reflection']);
 
 // ─────────────────────────────────────────────
@@ -201,7 +202,7 @@ function runDecayCycle(dirPath, archiveSubdir = 'archived') {
 
     // Source-aware decay: resistant sources decay at half rate
     const decay = RESISTANT_SOURCES.has(frontmatter.source)
-      ? baseDecay * (MANUAL_DECAY_PER_WEEK / DECAY_PER_WEEK)
+      ? baseDecay * RESISTANT_DECAY_RATIO
       : baseDecay;
     const newConfidence = clampConfidence(frontmatter.confidence - decay);
 

--- a/scripts/lib/confidence.js
+++ b/scripts/lib/confidence.js
@@ -25,6 +25,11 @@ const MAX_CONFIDENCE = 0.9;
 const REFLECT_MAX_CONFIDENCE = 0.85;
 const MIN_CONFIDENCE = 0.1;
 
+// Resistance-based confidence: manual/reflection instincts decay slower
+const MANUAL_CONTRADICT_DELTA = -0.05; // Half of -0.10
+const MANUAL_DECAY_PER_WEEK = 0.01; // Half of 0.02
+const RESISTANT_SOURCES = new Set(['manual', 'reflection']);
+
 // ─────────────────────────────────────────────
 // Frontmatter Parsing
 // ─────────────────────────────────────────────
@@ -134,9 +139,12 @@ function applyConfirmation(confidence) {
 
 /**
  * Apply contradiction to confidence score.
+ * @param {number} confidence - Current confidence
+ * @param {string} [source] - Instinct source (manual, reflection, session-observation)
  */
-function applyContradiction(confidence) {
-  return Math.max(MIN_CONFIDENCE, (confidence || INITIAL) + CONTRADICT_DELTA);
+function applyContradiction(confidence, source) {
+  const delta = RESISTANT_SOURCES.has(source) ? MANUAL_CONTRADICT_DELTA : CONTRADICT_DELTA;
+  return Math.max(MIN_CONFIDENCE, (confidence || INITIAL) + delta);
 }
 
 /**
@@ -188,9 +196,13 @@ function runDecayCycle(dirPath, archiveSubdir = 'archived') {
 
     if (frontmatter.confidence === undefined) continue;
 
-    const decay = calculateDecay(frontmatter.last_confirmed, now);
-    if (decay <= 0) continue;
+    const baseDecay = calculateDecay(frontmatter.last_confirmed, now);
+    if (baseDecay <= 0) continue;
 
+    // Source-aware decay: resistant sources decay at half rate
+    const decay = RESISTANT_SOURCES.has(frontmatter.source)
+      ? baseDecay * (MANUAL_DECAY_PER_WEEK / DECAY_PER_WEEK)
+      : baseDecay;
     const newConfidence = clampConfidence(frontmatter.confidence - decay);
 
     if (shouldArchive(newConfidence)) {
@@ -230,6 +242,9 @@ module.exports = {
   MAX_CONFIDENCE,
   REFLECT_MAX_CONFIDENCE,
   MIN_CONFIDENCE,
+  MANUAL_CONTRADICT_DELTA,
+  MANUAL_DECAY_PER_WEEK,
+  RESISTANT_SOURCES,
   // Parsing
   parseConfidenceFrontmatter,
   updateConfidenceFrontmatter,

--- a/scripts/lib/evolve.js
+++ b/scripts/lib/evolve.js
@@ -59,12 +59,17 @@ function classifyCluster(cluster) {
 
   // Primary rule 2: 3+ instincts + very high confidence → agent
   if (items.length >= 3 && avgConfidence >= 0.75) {
-    reasons.push(`Cluster size ${items.length} >= 3 with avg confidence ${avgConfidence.toFixed(2)} >= 0.75`);
+    reasons.push(
+      `Cluster size ${items.length} >= 3 with avg confidence ${avgConfidence.toFixed(2)} >= 0.75`,
+    );
     return { type: 'agent', confidence: avgConfidence, reasons };
   }
 
   // Tiebreaker: keyword ratio
-  const allTriggers = items.map((i) => getTrigger(i)).join(' ').toLowerCase();
+  const allTriggers = items
+    .map((i) => getTrigger(i))
+    .join(' ')
+    .toLowerCase();
   const tokens = allTriggers.split(/\s+/);
 
   let behavioralCount = 0;
@@ -82,11 +87,15 @@ function classifyCluster(cluster) {
 
   if (actionCount > 0 && behavioralCount > 0) {
     if (behavioralCount > actionCount * 2) {
-      reasons.push(`Keyword tiebreaker: ${behavioralCount} behavioral vs ${actionCount} action → skill`);
+      reasons.push(
+        `Keyword tiebreaker: ${behavioralCount} behavioral vs ${actionCount} action → skill`,
+      );
       return { type: 'skill', confidence: avgConfidence, reasons };
     }
     if (actionCount > behavioralCount * 2) {
-      reasons.push(`Keyword tiebreaker: ${actionCount} action vs ${behavioralCount} behavioral → command`);
+      reasons.push(
+        `Keyword tiebreaker: ${actionCount} action vs ${behavioralCount} behavioral → command`,
+      );
       return { type: 'command', confidence: avgConfidence, reasons };
     }
   }
@@ -144,6 +153,10 @@ function generateName(cluster, type) {
     cleaned = cleaned.substring(0, maxLen).replace(/-+$/, '');
   }
 
+  if (!cleaned) {
+    cleaned = (cluster.domain || 'evolved').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  }
+
   return type === 'skill' ? `arc-${cleaned}` : cleaned;
 }
 
@@ -171,11 +184,14 @@ function generateSkill(cluster, name) {
     description += `. Covers: ${uniqueSuffixes}`;
   }
   if (description.length > 1024) {
-    description = description.substring(0, 1021) + '...';
+    description = `${description.substring(0, 1021)}...`;
   }
 
   const triggerBullets = triggers.map((t) => `- ${t}`).join('\n');
-  const instinctBodies = items.map((i) => i.body || '').filter(Boolean).join('\n\n---\n\n');
+  const instinctBodies = items
+    .map((i) => i.body || '')
+    .filter(Boolean)
+    .join('\n\n---\n\n');
   const sourceList = items
     .map((i) => `- ${i.id} (${Math.round(getConfidence(i) * 100)}%)`)
     .join('\n');
@@ -214,9 +230,8 @@ function generateCommand(cluster, cmdName, skillName) {
   const domain = cluster.domain || 'uncategorized';
   const triggers = (cluster.items || []).map(getTrigger).filter(Boolean);
 
-  const description = triggers.length > 0
-    ? triggers[0].replace(/^when\s+/i, '')
-    : `${domain} automation`;
+  const description =
+    triggers.length > 0 ? triggers[0].replace(/^when\s+/i, '') : `${domain} automation`;
 
   const content = `---
 description: "${description}"
@@ -240,9 +255,10 @@ function generateAgent(cluster, name) {
   const domain = cluster.domain || 'uncategorized';
   const triggers = items.map(getTrigger).filter(Boolean);
 
-  const description = triggers.length > 0
-    ? triggers.map((t) => t.replace(/^when\s+/i, '')).join(', ')
-    : `${domain} specialist`;
+  const description =
+    triggers.length > 0
+      ? triggers.map((t) => t.replace(/^when\s+/i, '')).join(', ')
+      : `${domain} specialist`;
 
   // Derive workflow steps from instinct action sections
   const actions = items
@@ -252,9 +268,10 @@ function generateAgent(cluster, name) {
     })
     .filter(Boolean);
 
-  const workflowSteps = actions.length > 0
-    ? actions.map((a, idx) => `${idx + 1}. ${a}`).join('\n')
-    : '1. Analyze the task\n2. Execute the appropriate pattern\n3. Verify results';
+  const workflowSteps =
+    actions.length > 0
+      ? actions.map((a, idx) => `${idx + 1}. ${a}`).join('\n')
+      : '1. Analyze the task\n2. Execute the appropriate pattern\n3. Verify results';
 
   const content = `---
 name: ${name}
@@ -296,7 +313,7 @@ function recordEvolution(entry, logPath) {
     timestamp: new Date().toISOString(),
   };
 
-  fs.appendFileSync(logPath, JSON.stringify(record) + '\n', 'utf-8');
+  fs.appendFileSync(logPath, `${JSON.stringify(record)}\n`, 'utf-8');
 }
 
 /**

--- a/scripts/lib/evolve.js
+++ b/scripts/lib/evolve.js
@@ -334,11 +334,12 @@ function readEvolutionLog(logPath) {
 /**
  * Check if a set of instinct IDs has already been evolved.
  */
-function isAlreadyEvolved(instinctIds, logPath) {
+function isAlreadyEvolved(instinctIds, logPath, project) {
   const entries = readEvolutionLog(logPath);
   const idSet = new Set(instinctIds);
 
   return entries.some((entry) => {
+    if (project && entry.project && entry.project !== project) return false;
     const entrySet = new Set(entry.instincts || []);
     if (entrySet.size !== idSet.size) return false;
     for (const id of idSet) {

--- a/scripts/lib/evolve.js
+++ b/scripts/lib/evolve.js
@@ -1,0 +1,333 @@
+/**
+ * Evolve — Type classification, name generation, templates, tracking
+ *
+ * Evolves instinct clusters into skills, commands, or agents.
+ * Inspired by continuous-learning-v2's cmd_evolve().
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { buildTriggerFingerprint, STOP_WORDS } = require('./fingerprint');
+
+// ─────────────────────────────────────────────
+// Type Classification
+// ─────────────────────────────────────────────
+
+const COMMAND_DOMAINS = new Set(['workflow', 'automation']);
+
+const BEHAVIORAL_KEYWORDS = new Set(['always', 'prefer', 'avoid', 'never', 'before']);
+const ACTION_PREFIXES = ['when starting', 'when running', 'when creating', 'when i need'];
+
+/**
+ * Classify a cluster into skill, command, or agent.
+ *
+ * Primary rules (checked in order, first match wins):
+ * 1. workflow/automation domain + avg confidence >= 0.7 → command
+ * 2. size >= 3 + avg confidence >= 0.75 → agent
+ * 3. Default → skill
+ *
+ * Tiebreaker: keyword ratio (behavioral vs action tokens).
+ */
+function classifyCluster(cluster) {
+  const items = cluster.items || [];
+  const domain = cluster.domain || '';
+  const reasons = [];
+
+  const avgConfidence =
+    items.length > 0 ? items.reduce((sum, i) => sum + (i.confidence || i.frontmatter?.confidence || 0), 0) / items.length : 0;
+
+  // Primary rule 1: workflow/automation domain + high confidence → command
+  if (COMMAND_DOMAINS.has(domain) && avgConfidence >= 0.7) {
+    reasons.push(`Domain "${domain}" with avg confidence ${avgConfidence.toFixed(2)} >= 0.7`);
+    return { type: 'command', confidence: avgConfidence, reasons };
+  }
+
+  // Primary rule 2: 3+ instincts + very high confidence → agent
+  if (items.length >= 3 && avgConfidence >= 0.75) {
+    reasons.push(`Cluster size ${items.length} >= 3 with avg confidence ${avgConfidence.toFixed(2)} >= 0.75`);
+    return { type: 'agent', confidence: avgConfidence, reasons };
+  }
+
+  // Tiebreaker: keyword ratio
+  const allTriggers = items.map((i) => i.trigger || i.frontmatter?.trigger || '').join(' ').toLowerCase();
+  const tokens = allTriggers.split(/\s+/);
+
+  let behavioralCount = 0;
+  let actionCount = 0;
+
+  for (const token of tokens) {
+    if (BEHAVIORAL_KEYWORDS.has(token)) behavioralCount++;
+  }
+
+  for (const prefix of ACTION_PREFIXES) {
+    const regex = new RegExp(prefix, 'gi');
+    const matches = allTriggers.match(regex);
+    if (matches) actionCount += matches.length;
+  }
+
+  if (actionCount > 0 && behavioralCount > 0) {
+    if (behavioralCount > actionCount * 2) {
+      reasons.push(`Keyword tiebreaker: ${behavioralCount} behavioral vs ${actionCount} action → skill`);
+      return { type: 'skill', confidence: avgConfidence, reasons };
+    }
+    if (actionCount > behavioralCount * 2) {
+      reasons.push(`Keyword tiebreaker: ${actionCount} action vs ${behavioralCount} behavioral → command`);
+      return { type: 'command', confidence: avgConfidence, reasons };
+    }
+  }
+
+  // Default → skill
+  reasons.push('Default classification: skill');
+  return { type: 'skill', confidence: avgConfidence, reasons };
+}
+
+// ─────────────────────────────────────────────
+// Name Generation
+// ─────────────────────────────────────────────
+
+/**
+ * Generate a name from a cluster's triggers.
+ *
+ * For single-instinct clusters: clean the trigger directly.
+ * For multi-instinct clusters: use most common tokens via buildTriggerFingerprint.
+ */
+function generateName(cluster, type) {
+  const items = cluster.items || [];
+  let raw = '';
+
+  if (items.length === 1) {
+    raw = items[0].trigger || items[0].frontmatter?.trigger || items[0].id || '';
+  } else {
+    // Collect all trigger tokens, find most frequent
+    const tokenCounts = {};
+    for (const item of items) {
+      const trigger = item.trigger || item.frontmatter?.trigger || '';
+      const fp = buildTriggerFingerprint(trigger);
+      for (const token of fp) {
+        tokenCounts[token] = (tokenCounts[token] || 0) + 1;
+      }
+    }
+
+    // Sort by frequency descending, take top 3
+    const sorted = Object.entries(tokenCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([token]) => token);
+
+    raw = sorted.join(' ');
+  }
+
+  // Clean: strip leading "when ", sanitize to kebab-case
+  let cleaned = raw
+    .toLowerCase()
+    .replace(/^when\s+/i, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  // Truncate to 30 chars (accounting for arc- prefix for skills)
+  const maxLen = type === 'skill' ? 26 : 30; // arc- is 4 chars
+  if (cleaned.length > maxLen) {
+    cleaned = cleaned.substring(0, maxLen).replace(/-+$/, '');
+  }
+
+  return type === 'skill' ? `arc-${cleaned}` : cleaned;
+}
+
+// ─────────────────────────────────────────────
+// Templates
+// ─────────────────────────────────────────────
+
+/**
+ * Generate a skill SKILL.md from a cluster.
+ */
+function generateSkill(cluster, name) {
+  const items = cluster.items || [];
+  const domain = cluster.domain || 'uncategorized';
+  const triggers = items.map((i) => i.trigger || i.frontmatter?.trigger || '').filter(Boolean);
+
+  // Build description: "Use when <common prefix>. Covers: <unique suffixes>"
+  const commonPrefix = triggers.length > 0 ? triggers[0].replace(/^when\s+/i, '') : domain;
+  const uniqueSuffixes = triggers
+    .slice(1)
+    .map((t) => t.replace(/^when\s+/i, ''))
+    .join(', ');
+
+  let description = `Use when ${commonPrefix}`;
+  if (uniqueSuffixes) {
+    description += `. Covers: ${uniqueSuffixes}`;
+  }
+  if (description.length > 1024) {
+    description = description.substring(0, 1021) + '...';
+  }
+
+  const triggerBullets = triggers.map((t) => `- ${t}`).join('\n');
+  const instinctBodies = items.map((i) => i.body || '').filter(Boolean).join('\n\n---\n\n');
+  const sourceList = items
+    .map((i) => {
+      const conf = i.confidence || i.frontmatter?.confidence || 0;
+      return `- ${i.id} (${Math.round(conf * 100)}%)`;
+    })
+    .join('\n');
+
+  const content = `---
+name: ${name}
+description: "${description}"
+---
+<!-- Generated scaffold — refine before deployment -->
+
+## Overview
+Evolved from ${items.length} instincts in the ${domain} domain.
+
+## When to Use
+${triggerBullets}
+
+## Key Patterns
+${instinctBodies}
+
+## Source Instincts
+${sourceList}
+`;
+
+  return {
+    path: `skills/${name}/SKILL.md`,
+    content,
+    type: 'skill',
+  };
+}
+
+/**
+ * Generate a command .md from a cluster.
+ * Commands always produce a backing skill too (arcforge convention).
+ */
+function generateCommand(cluster, cmdName, skillName) {
+  const domain = cluster.domain || 'uncategorized';
+  const triggers = (cluster.items || []).map((i) => i.trigger || i.frontmatter?.trigger || '').filter(Boolean);
+
+  const description = triggers.length > 0
+    ? triggers[0].replace(/^when\s+/i, '')
+    : `${domain} automation`;
+
+  const content = `---
+description: "${description}"
+disable-model-invocation: true
+---
+Invoke the ${skillName} skill and follow it exactly as presented to you
+`;
+
+  return {
+    path: `commands/${cmdName}.md`,
+    content,
+    type: 'command',
+  };
+}
+
+/**
+ * Generate an agent .md from a cluster.
+ */
+function generateAgent(cluster, name) {
+  const items = cluster.items || [];
+  const domain = cluster.domain || 'uncategorized';
+  const triggers = items.map((i) => i.trigger || i.frontmatter?.trigger || '').filter(Boolean);
+
+  const description = triggers.length > 0
+    ? triggers.map((t) => t.replace(/^when\s+/i, '')).join(', ')
+    : `${domain} specialist`;
+
+  // Derive workflow steps from instinct action sections
+  const actions = items
+    .map((i) => {
+      const match = (i.body || '').match(/## Action\n+([\s\S]*?)(?=\n##|$)/);
+      return match ? match[1].trim() : null;
+    })
+    .filter(Boolean);
+
+  const workflowSteps = actions.length > 0
+    ? actions.map((a, idx) => `${idx + 1}. ${a}`).join('\n')
+    : '1. Analyze the task\n2. Execute the appropriate pattern\n3. Verify results';
+
+  const content = `---
+name: ${name}
+description: "${description}"
+model: inherit
+---
+<!-- Generated scaffold — refine before deployment -->
+
+## Role
+Specialized agent for the ${domain} domain.
+
+## Workflow
+${workflowSteps}
+
+## Source Instincts
+${items.map((i) => `- ${i.id}`).join('\n')}
+`;
+
+  return {
+    path: `agents/${name}.md`,
+    content,
+    type: 'agent',
+  };
+}
+
+// ─────────────────────────────────────────────
+// Evolution Tracking
+// ─────────────────────────────────────────────
+
+/**
+ * Record an evolution event to the JSONL log.
+ */
+function recordEvolution(entry, logPath) {
+  const dir = path.dirname(logPath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const record = {
+    ...entry,
+    timestamp: new Date().toISOString(),
+  };
+
+  fs.appendFileSync(logPath, JSON.stringify(record) + '\n', 'utf-8');
+}
+
+/**
+ * Read all evolution log entries.
+ */
+function readEvolutionLog(logPath) {
+  if (!fs.existsSync(logPath)) return [];
+
+  const content = fs.readFileSync(logPath, 'utf-8').trim();
+  if (!content) return [];
+
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+/**
+ * Check if a set of instinct IDs has already been evolved.
+ */
+function isAlreadyEvolved(instinctIds, logPath) {
+  const entries = readEvolutionLog(logPath);
+  const idSet = new Set(instinctIds);
+
+  return entries.some((entry) => {
+    const entrySet = new Set(entry.instincts || []);
+    if (entrySet.size !== idSet.size) return false;
+    for (const id of idSet) {
+      if (!entrySet.has(id)) return false;
+    }
+    return true;
+  });
+}
+
+module.exports = {
+  classifyCluster,
+  generateName,
+  generateSkill,
+  generateCommand,
+  generateAgent,
+  recordEvolution,
+  readEvolutionLog,
+  isAlreadyEvolved,
+};

--- a/scripts/lib/session-utils.js
+++ b/scripts/lib/session-utils.js
@@ -174,6 +174,14 @@ function getInstinctsGlobalIndex() {
   return path.join(CLAUDE_DIR, 'instincts', 'global-index.jsonl');
 }
 
+/**
+ * Get evolved log path for tracking instinct-to-artifact evolution.
+ * @returns {string} ~/.claude/evolved/evolved.jsonl
+ */
+function getEvolvedLogPath() {
+  return path.join(CLAUDE_DIR, 'evolved', 'evolved.jsonl');
+}
+
 module.exports = {
   getDiaryPath,
   saveDiary,
@@ -189,4 +197,5 @@ module.exports = {
   getInstinctsArchivedDir,
   getGlobalInstinctsDir,
   getInstinctsGlobalIndex,
+  getEvolvedLogPath,
 };

--- a/skills/arc-learning/scripts/learn.js
+++ b/skills/arc-learning/scripts/learn.js
@@ -272,7 +272,7 @@ function cmdGenerate(project, flags) {
 
   // Check if already evolved
   const logPath = getEvolvedLogPath();
-  if (isAlreadyEvolved(instinctIds, logPath)) {
+  if (isAlreadyEvolved(instinctIds, logPath, project)) {
     console.error('These instincts have already been evolved. Use --name to create a different artifact.');
     return;
   }
@@ -290,6 +290,12 @@ function cmdGenerate(project, flags) {
     : classifyCluster(cluster);
 
   const type = classification.type;
+
+  // Sanitize --name to prevent path traversal
+  if (nameOverride && (/[\/\\]/.test(nameOverride) || nameOverride.includes('..'))) {
+    console.error(`Invalid --name "${nameOverride}". Name must not contain path separators or "..".`);
+    return;
+  }
 
   // Generate name — skills already have arc- prefix from generateName
   const baseName = nameOverride || generateName(cluster, type);

--- a/skills/arc-learning/scripts/learn.js
+++ b/skills/arc-learning/scripts/learn.js
@@ -277,6 +277,13 @@ function cmdGenerate(project, flags) {
     return;
   }
 
+  // Validate type override
+  const VALID_TYPES = new Set(['skill', 'command', 'agent']);
+  if (typeOverride && !VALID_TYPES.has(typeOverride)) {
+    console.error(`Invalid --type "${typeOverride}". Must be one of: ${[...VALID_TYPES].join(', ')}`);
+    return;
+  }
+
   // Classify
   const classification = typeOverride
     ? { type: typeOverride, confidence: 0, reasons: [`Type override: ${typeOverride}`] }

--- a/skills/arc-learning/scripts/learn.js
+++ b/skills/arc-learning/scripts/learn.js
@@ -326,6 +326,17 @@ function cmdGenerate(project, flags) {
     return;
   }
 
+  // Check for existing files before writing (prevent accidental overwrites)
+  const existing = files.filter((f) => fs.existsSync(path.resolve(f.path)));
+  if (existing.length > 0) {
+    console.error('Refusing to overwrite existing files:');
+    for (const f of existing) {
+      console.error(`  ${f.path}`);
+    }
+    console.error('Use a different --name or remove the existing files first.');
+    return;
+  }
+
   // Write files
   for (const file of files) {
     const fullPath = path.resolve(file.path);

--- a/skills/arc-observing/SKILL.md
+++ b/skills/arc-observing/SKILL.md
@@ -41,7 +41,7 @@ fi
 2. **Analysis**: Background daemon reads observations (10+ required), calls Haiku to detect patterns
 3. **Creation**: Instincts saved as `.md` files with YAML frontmatter in `~/.claude/instincts/{project}/`
 4. **Loading**: Session start loads instincts with confidence >= 0.7 into Claude context
-5. **Lifecycle**: Confirm (+0.05) / Contradict (-0.10) / Decay (-0.02/week) / Archive (< 0.15)
+5. **Lifecycle**: Confirm (+0.05) / Contradict (-0.10, -0.05 for manual/reflection) / Decay (-0.02/week, -0.01 for manual/reflection) / Archive (< 0.15)
 
 ## Instinct Format
 
@@ -91,8 +91,8 @@ Always use Grep to find the exact location before using Edit.
 ```
 Auto-detected by daemon: confidence 0.5
 Confirmed → +0.05 (cap 0.9)
-Contradicted → -0.10 (floor 0.1)
-No activity → -0.02/week
+Contradicted → -0.10 (floor 0.1), -0.05 for manual/reflection sources
+No activity → -0.02/week, -0.01/week for manual/reflection sources
 
 >= 0.7 → Auto-loaded into Claude context
 0.3-0.7 → Listed as summary

--- a/skills/arc-observing/scripts/instinct.js
+++ b/skills/arc-observing/scripts/instinct.js
@@ -224,7 +224,7 @@ function cmdContradict(instinctId, project) {
   const { frontmatter } = parseConfidenceFrontmatter(content);
 
   const oldConfidence = frontmatter.confidence || 0.5;
-  const newConfidence = applyContradiction(oldConfidence);
+  const newConfidence = applyContradiction(oldConfidence, frontmatter.source);
   const contradictions = (frontmatter.contradictions || 0) + 1;
 
   const updated = updateConfidenceFrontmatter(content, {

--- a/tests/scripts/evolve.test.js
+++ b/tests/scripts/evolve.test.js
@@ -1,0 +1,359 @@
+// tests/scripts/evolve.test.js
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  classifyCluster,
+  generateName,
+  generateSkill,
+  generateCommand,
+  generateAgent,
+  recordEvolution,
+  readEvolutionLog,
+  isAlreadyEvolved,
+} = require('../../scripts/lib/evolve');
+
+// ─────────────────────────────────────────────
+// Test Fixtures
+// ─────────────────────────────────────────────
+
+function makeInstinct(id, overrides = {}) {
+  return {
+    id,
+    confidence: 0.7,
+    domain: 'testing',
+    trigger: `when ${id}`,
+    body: `## Action\nDo the thing for ${id}\n`,
+    frontmatter: {
+      id,
+      confidence: overrides.confidence || 0.7,
+      domain: overrides.domain || 'testing',
+      trigger: overrides.trigger || `when ${id}`,
+      source: overrides.source || 'session-observation',
+    },
+    ...overrides,
+  };
+}
+
+function makeCluster(overrides = {}) {
+  return {
+    domain: 'testing',
+    items: [
+      makeInstinct('test-a', { trigger: 'when running unit tests' }),
+      makeInstinct('test-b', { trigger: 'when running integration tests' }),
+      makeInstinct('test-c', { trigger: 'when checking test results' }),
+    ],
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────
+// classifyCluster
+// ─────────────────────────────────────────────
+
+describe('classifyCluster', () => {
+  it('classifies workflow-domain cluster with avg confidence >= 0.7 as command', () => {
+    const cluster = makeCluster({
+      domain: 'workflow',
+      items: [
+        makeInstinct('wf-a', { domain: 'workflow', confidence: 0.75 }),
+        makeInstinct('wf-b', { domain: 'workflow', confidence: 0.70 }),
+        makeInstinct('wf-c', { domain: 'workflow', confidence: 0.80 }),
+      ],
+    });
+    const result = classifyCluster(cluster);
+    expect(result.type).toBe('command');
+    expect(result.reasons).toBeInstanceOf(Array);
+    expect(result.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('classifies automation-domain cluster with avg confidence >= 0.7 as command', () => {
+    const cluster = makeCluster({
+      domain: 'automation',
+      items: [
+        makeInstinct('auto-a', { domain: 'automation', confidence: 0.8 }),
+        makeInstinct('auto-b', { domain: 'automation', confidence: 0.7 }),
+        makeInstinct('auto-c', { domain: 'automation', confidence: 0.75 }),
+      ],
+    });
+    const result = classifyCluster(cluster);
+    expect(result.type).toBe('command');
+  });
+
+  it('classifies 3+ instinct cluster with avg confidence >= 0.75 as agent', () => {
+    const cluster = makeCluster({
+      domain: 'debugging',
+      items: [
+        makeInstinct('dbg-a', { domain: 'debugging', confidence: 0.80 }),
+        makeInstinct('dbg-b', { domain: 'debugging', confidence: 0.75 }),
+        makeInstinct('dbg-c', { domain: 'debugging', confidence: 0.85 }),
+      ],
+    });
+    const result = classifyCluster(cluster);
+    expect(result.type).toBe('agent');
+  });
+
+  it('classifies small cluster (< 3) as skill (default)', () => {
+    const cluster = makeCluster({
+      items: [
+        makeInstinct('s-a', { confidence: 0.8 }),
+        makeInstinct('s-b', { confidence: 0.8 }),
+      ],
+    });
+    const result = classifyCluster(cluster);
+    expect(result.type).toBe('skill');
+  });
+
+  it('defaults to skill when no primary rule matches', () => {
+    const cluster = makeCluster({
+      domain: 'testing',
+      items: [
+        makeInstinct('lo-a', { domain: 'testing', confidence: 0.5 }),
+        makeInstinct('lo-b', { domain: 'testing', confidence: 0.55 }),
+        makeInstinct('lo-c', { domain: 'testing', confidence: 0.6 }),
+      ],
+    });
+    const result = classifyCluster(cluster);
+    expect(result.type).toBe('skill');
+  });
+
+  it('uses keyword ratio as tiebreaker when domain is ambiguous', () => {
+    // Action-heavy triggers → command via tiebreaker
+    const cluster = makeCluster({
+      domain: 'general',
+      items: [
+        makeInstinct('act-a', {
+          domain: 'general',
+          confidence: 0.72,
+          trigger: 'when starting a new project setup',
+        }),
+        makeInstinct('act-b', {
+          domain: 'general',
+          confidence: 0.70,
+          trigger: 'when running a deployment script',
+        }),
+        makeInstinct('act-c', {
+          domain: 'general',
+          confidence: 0.71,
+          trigger: 'when creating a new release',
+        }),
+      ],
+    });
+    const result = classifyCluster(cluster);
+    // With action-heavy triggers, should classify as command or skill
+    expect(['command', 'skill']).toContain(result.type);
+  });
+
+  it('returns reasons array explaining classification', () => {
+    const cluster = makeCluster();
+    const result = classifyCluster(cluster);
+    expect(result.reasons).toBeInstanceOf(Array);
+    expect(result.reasons.length).toBeGreaterThan(0);
+    result.reasons.forEach((r) => expect(typeof r).toBe('string'));
+  });
+});
+
+// ─────────────────────────────────────────────
+// generateName
+// ─────────────────────────────────────────────
+
+describe('generateName', () => {
+  it('generates arc-prefixed name for skills', () => {
+    const name = generateName(makeCluster(), 'skill');
+    expect(name).toMatch(/^arc-/);
+  });
+
+  it('generates plain name for commands (no arc- prefix)', () => {
+    const name = generateName(makeCluster(), 'command');
+    expect(name).not.toMatch(/^arc-/);
+  });
+
+  it('generates plain name for agents (no arc- prefix)', () => {
+    const name = generateName(makeCluster(), 'agent');
+    expect(name).not.toMatch(/^arc-/);
+  });
+
+  it('strips leading "when " from trigger text', () => {
+    const cluster = makeCluster({
+      items: [makeInstinct('x', { trigger: 'when debugging async tests' })],
+    });
+    const name = generateName(cluster, 'skill');
+    expect(name).not.toContain('when');
+  });
+
+  it('sanitizes to lowercase kebab-case, truncates to 30 chars', () => {
+    const cluster = makeCluster({
+      items: [
+        makeInstinct('x', {
+          trigger: 'when doing something Very Long And Complicated With Extra Words Here',
+        }),
+      ],
+    });
+    const name = generateName(cluster, 'skill');
+    expect(name).toMatch(/^[a-z0-9-]+$/);
+    expect(name.length).toBeLessThanOrEqual(30);
+  });
+
+  it('uses most common trigger tokens for clusters', () => {
+    const cluster = makeCluster({
+      items: [
+        makeInstinct('a', { trigger: 'when running unit tests' }),
+        makeInstinct('b', { trigger: 'when running integration tests' }),
+        makeInstinct('c', { trigger: 'when running e2e tests' }),
+      ],
+    });
+    const name = generateName(cluster, 'skill');
+    expect(name).toContain('running');
+  });
+});
+
+// ─────────────────────────────────────────────
+// generateSkill / generateCommand / generateAgent
+// ─────────────────────────────────────────────
+
+describe('generateSkill', () => {
+  it('produces valid frontmatter', () => {
+    const result = generateSkill(makeCluster(), 'arc-testing-patterns');
+    expect(result.content).toMatch(/^---\n/);
+    expect(result.content).toMatch(/name: arc-testing-patterns/);
+    expect(result.type).toBe('skill');
+  });
+
+  it('description starts with "Use when"', () => {
+    const result = generateSkill(makeCluster(), 'arc-testing-patterns');
+    const descMatch = result.content.match(/description: "(.+)"/);
+    expect(descMatch).toBeTruthy();
+    expect(descMatch[1]).toMatch(/^Use when/);
+  });
+
+  it('description <= 1024 chars', () => {
+    const result = generateSkill(makeCluster(), 'arc-testing-patterns');
+    const descMatch = result.content.match(/description: "(.+)"/);
+    expect(descMatch[1].length).toBeLessThanOrEqual(1024);
+  });
+
+  it('includes source instinct IDs', () => {
+    const result = generateSkill(makeCluster(), 'arc-testing-patterns');
+    expect(result.content).toContain('test-a');
+    expect(result.content).toContain('test-b');
+    expect(result.content).toContain('test-c');
+  });
+
+  it('returns correct path', () => {
+    const result = generateSkill(makeCluster(), 'arc-testing-patterns');
+    expect(result.path).toBe('skills/arc-testing-patterns/SKILL.md');
+  });
+});
+
+describe('generateCommand', () => {
+  it('produces valid frontmatter', () => {
+    const result = generateCommand(makeCluster(), 'testing-patterns', 'arc-testing-patterns');
+    expect(result.content).toMatch(/^---\n/);
+    expect(result.type).toBe('command');
+  });
+
+  it('has disable-model-invocation: true', () => {
+    const result = generateCommand(makeCluster(), 'testing-patterns', 'arc-testing-patterns');
+    expect(result.content).toContain('disable-model-invocation: true');
+  });
+
+  it('references backing skill name', () => {
+    const result = generateCommand(makeCluster(), 'testing-patterns', 'arc-testing-patterns');
+    expect(result.content).toContain('arc-testing-patterns');
+  });
+
+  it('returns correct path', () => {
+    const result = generateCommand(makeCluster(), 'testing-patterns', 'arc-testing-patterns');
+    expect(result.path).toBe('commands/testing-patterns.md');
+  });
+});
+
+describe('generateAgent', () => {
+  it('produces valid frontmatter', () => {
+    const result = generateAgent(makeCluster(), 'testing-patterns');
+    expect(result.content).toMatch(/^---\n/);
+    expect(result.type).toBe('agent');
+  });
+
+  it('has model: inherit', () => {
+    const result = generateAgent(makeCluster(), 'testing-patterns');
+    expect(result.content).toContain('model: inherit');
+  });
+
+  it('returns correct path', () => {
+    const result = generateAgent(makeCluster(), 'testing-patterns');
+    expect(result.path).toBe('agents/testing-patterns.md');
+  });
+});
+
+// ─────────────────────────────────────────────
+// recordEvolution / readEvolutionLog / isAlreadyEvolved
+// ─────────────────────────────────────────────
+
+describe('evolution tracking', () => {
+  const testDir = path.join(os.tmpdir(), `evolve-test-${Date.now()}`);
+  const testLogPath = path.join(testDir, 'evolved.jsonl');
+
+  beforeEach(() => {
+    fs.mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('recordEvolution appends JSONL entry', () => {
+    recordEvolution(
+      {
+        id: 'arc-testing',
+        type: 'skill',
+        instincts: ['i1', 'i2', 'i3'],
+        project: 'arcforge',
+        files: ['skills/arc-testing/SKILL.md'],
+      },
+      testLogPath,
+    );
+
+    const content = fs.readFileSync(testLogPath, 'utf-8');
+    const entry = JSON.parse(content.trim());
+    expect(entry.id).toBe('arc-testing');
+    expect(entry.type).toBe('skill');
+    expect(entry.instincts).toEqual(['i1', 'i2', 'i3']);
+    expect(entry.project).toBe('arcforge');
+    expect(entry.timestamp).toBeTruthy();
+  });
+
+  it('readEvolutionLog reads back entries', () => {
+    recordEvolution(
+      { id: 'a', type: 'skill', instincts: ['i1'], project: 'p1', files: [] },
+      testLogPath,
+    );
+    recordEvolution(
+      { id: 'b', type: 'command', instincts: ['i2'], project: 'p1', files: [] },
+      testLogPath,
+    );
+
+    const entries = readEvolutionLog(testLogPath);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].id).toBe('a');
+    expect(entries[1].id).toBe('b');
+  });
+
+  it('readEvolutionLog returns empty for missing file', () => {
+    const entries = readEvolutionLog(path.join(testDir, 'nonexistent.jsonl'));
+    expect(entries).toEqual([]);
+  });
+
+  it('isAlreadyEvolved detects already-evolved instinct sets', () => {
+    recordEvolution(
+      { id: 'x', type: 'skill', instincts: ['i1', 'i2', 'i3'], project: 'p1', files: [] },
+      testLogPath,
+    );
+
+    expect(isAlreadyEvolved(['i1', 'i2', 'i3'], testLogPath)).toBe(true);
+    expect(isAlreadyEvolved(['i1', 'i2'], testLogPath)).toBe(false);
+    expect(isAlreadyEvolved(['i4', 'i5'], testLogPath)).toBe(false);
+  });
+});

--- a/tests/scripts/evolve.test.js
+++ b/tests/scripts/evolve.test.js
@@ -59,8 +59,8 @@ describe('classifyCluster', () => {
       domain: 'workflow',
       items: [
         makeInstinct('wf-a', { domain: 'workflow', confidence: 0.75 }),
-        makeInstinct('wf-b', { domain: 'workflow', confidence: 0.70 }),
-        makeInstinct('wf-c', { domain: 'workflow', confidence: 0.80 }),
+        makeInstinct('wf-b', { domain: 'workflow', confidence: 0.7 }),
+        makeInstinct('wf-c', { domain: 'workflow', confidence: 0.8 }),
       ],
     });
     const result = classifyCluster(cluster);
@@ -86,7 +86,7 @@ describe('classifyCluster', () => {
     const cluster = makeCluster({
       domain: 'debugging',
       items: [
-        makeInstinct('dbg-a', { domain: 'debugging', confidence: 0.80 }),
+        makeInstinct('dbg-a', { domain: 'debugging', confidence: 0.8 }),
         makeInstinct('dbg-b', { domain: 'debugging', confidence: 0.75 }),
         makeInstinct('dbg-c', { domain: 'debugging', confidence: 0.85 }),
       ],
@@ -97,10 +97,7 @@ describe('classifyCluster', () => {
 
   it('classifies small cluster (< 3) as skill (default)', () => {
     const cluster = makeCluster({
-      items: [
-        makeInstinct('s-a', { confidence: 0.8 }),
-        makeInstinct('s-b', { confidence: 0.8 }),
-      ],
+      items: [makeInstinct('s-a', { confidence: 0.8 }), makeInstinct('s-b', { confidence: 0.8 })],
     });
     const result = classifyCluster(cluster);
     expect(result.type).toBe('skill');
@@ -131,7 +128,7 @@ describe('classifyCluster', () => {
         }),
         makeInstinct('act-b', {
           domain: 'general',
-          confidence: 0.70,
+          confidence: 0.7,
           trigger: 'when running a deployment script',
         }),
         makeInstinct('act-c', {
@@ -151,7 +148,9 @@ describe('classifyCluster', () => {
     const result = classifyCluster(cluster);
     expect(result.reasons).toBeInstanceOf(Array);
     expect(result.reasons.length).toBeGreaterThan(0);
-    result.reasons.forEach((r) => expect(typeof r).toBe('string'));
+    for (const r of result.reasons) {
+      expect(typeof r).toBe('string');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- **Three-type evolution system** (`scripts/lib/evolve.js`): instinct clusters can now evolve into skills, commands, or agents based on domain+confidence classification rules with keyword-ratio tiebreaker
- **Resistance-based confidence**: manual and reflection instincts decay at half rate (`RESISTANT_DECAY_RATIO = 0.5`) and receive halved contradiction deltas, preserving deliberately-created knowledge longer
- **Code simplification**: extracted accessor helpers (`getTrigger`/`getConfidence`), deduplicated `loadAllInstincts`, derived resistance constants from base values

## Changes

- New `scripts/lib/evolve.js` — classifyCluster, generateName, generateSkill/Command/Agent, evolution log (JSONL)
- Updated `scripts/lib/confidence.js` — resistance-aware decay and contradiction
- Updated `skills/arc-learning/scripts/learn.js` — `generate` command with --cluster/--type/--name/--dry-run flags, preview type recommendations, evolved history listing
- Updated `scripts/lib/session-utils.js` — `getEvolvedLogPath()` helper
- Updated `skills/arc-learning/SKILL.md` — generate command and classification docs
- Updated `scripts/arc-observing/scripts/instinct.js` — passes `frontmatter.source` to contradiction

## Test plan

- [x] 194 Jest tests pass (including new evolve.test.js, confidence.test.js, learn.test.js)
- [x] Hook tests pass
- [x] Node tests pass
- [x] 118 pytest skill validation tests pass