### PR TITLE
docs: fix outdated storage docs and wrong skill command names

### DIFF
--- a/hooks/compact-suggester/README.md
+++ b/hooks/compact-suggester/README.md
@@ -14,10 +14,14 @@ Runs on `PostToolUse` for ALL tools (matcher: `.*`)
 
 ## Storage
 
-Counter stored in temp directory:
+Single JSON state file in temp directory:
 ```
-$TMPDIR/arcforge-tool-count-<project>-<date>
+$TMPDIR/arcforge-compact-state-<sessionId>
 ```
+
+Format: `{ "tools": number, "reads": number, "writes": number }`
+
+All three counters (tool calls, read-tool count, write-tool count) are stored in one file to minimize I/O (1 read + 1 write per hook invocation).
 
 ## Output Examples
 

--- a/skills/arc-journaling/SKILL.md
+++ b/skills/arc-journaling/SKILL.md
@@ -7,7 +7,7 @@ description: Use when user explicitly requests /diary, when PreCompact hook trig
 
 ## Overview
 
-Capture session reflections as structured diary entries for the **learning cycle** (diary → reflect → instincts). This is for deliberate reflection and pattern extraction — NOT for session continuity. For saving/resuming work across sessions, use `/sessions save` and `/sessions resume` instead.
+Capture session reflections as structured diary entries for the **learning cycle** (diary → reflect → instincts). This is for deliberate reflection and pattern extraction — NOT for session continuity. For saving/resuming work across sessions, use `/arc-managing-sessions save` and `/arc-managing-sessions resume` instead.
 
 ## Quick Reference
 

--- a/skills/arc-managing-sessions/SKILL.md
+++ b/skills/arc-managing-sessions/SKILL.md
@@ -21,11 +21,11 @@ User-controlled session saves for continuity across conversations. Save what mat
 
 | Task                    | Command                                                       |
 | ----------------------- | ------------------------------------------------------------- |
-| **Save session**        | `/sessions save [alias]`                                      |
-| **Resume session**      | `/sessions resume [alias]`                                    |
-| **List sessions**       | `/sessions list [--limit N] [--date YYYY-MM-DD] [--query id]` |
-| **Create alias**        | `/sessions alias <id> <name>`                                 |
-| **List saved sessions** | `/sessions aliases`                                           |
+| **Save session**        | `/arc-managing-sessions save [alias]`                                      |
+| **Resume session**      | `/arc-managing-sessions resume [alias]`                                    |
+| **List sessions**       | `/arc-managing-sessions list [--limit N] [--date YYYY-MM-DD] [--query id]` |
+| **Create alias**        | `/arc-managing-sessions alias <id> <name>`                                 |
+| **List saved sessions** | `/arc-managing-sessions aliases`                                           |
 
 ## Infrastructure Commands
 
@@ -37,7 +37,7 @@ User-controlled session saves for continuity across conversations. Save what mat
 
 ## Subcommands
 
-### `/sessions save [alias]`
+### `/arc-managing-sessions save [alias]`
 
 Save the current session with enrichment.
 
@@ -62,7 +62,7 @@ node "${SKILL_ROOT}/scripts/sessions.js" save <alias> [summary] [whatWorked] [wh
 
 **Important**: Do NOT just run the script mechanically. First, reflect on the conversation and write the enrichment content yourself based on what actually happened. Then call the script with the enrichment values, or write the session file directly using the `generateSession` function's output as a template and fill in the `<!-- TO BE ENRICHED -->` sections.
 
-### `/sessions resume [alias]`
+### `/arc-managing-sessions resume [alias]`
 
 Load a saved session and present a structured briefing.
 
@@ -81,7 +81,7 @@ node "${SKILL_ROOT}/scripts/sessions.js" resume [alias]
 
 **Critical**: After showing the briefing, do NOT start working automatically. Wait for the user to confirm what to do next.
 
-### `/sessions list`
+### `/arc-managing-sessions list`
 
 Browse sessions with metadata. Shows both auto-tracked sessions (from hooks) and user-saved sessions.
 
@@ -97,7 +97,7 @@ Browse sessions with metadata. Shows both auto-tracked sessions (from hooks) and
 node "${SKILL_ROOT}/scripts/sessions.js" list [--limit N] [--date YYYY-MM-DD] [--query id]
 ```
 
-### `/sessions alias <id> <name>`
+### `/arc-managing-sessions alias <id> <name>`
 
 Create an alias for easy reference.
 
@@ -107,7 +107,7 @@ Create an alias for easy reference.
 node "${SKILL_ROOT}/scripts/sessions.js" alias <session-path> <name>
 ```
 
-### `/sessions aliases`
+### `/arc-managing-sessions aliases`
 
 List all session aliases.
 
@@ -124,14 +124,14 @@ node "${SKILL_ROOT}/scripts/sessions.js" aliases
 ├── aliases.json                          # Project-scoped alias registry
 ├── {YYYY-MM-DD}/
 │   ├── {sessionId}.json                  # Auto-saved session metrics
-│   ├── session-{alias}.md                # User-saved session (from /sessions save)
+│   ├── session-{alias}.md                # User-saved session (from /arc-managing-sessions save)
 │   ├── diary-{sessionId}.md              # Diary entry (from /diary)
 ```
 
 ## Common Mistakes
 
 - Running the save script without reflecting first — always write the enrichment content based on conversation context before calling the script
-- Starting work after `/sessions resume` without waiting for user confirmation
+- Starting work after `/arc-managing-sessions resume` without waiting for user confirmation
 - Saving too frequently — save at meaningful milestones, not after every exchange
 - Leaving `<!-- TO BE ENRICHED -->` placeholders — always fill in all sections
 
@@ -139,5 +139,5 @@ node "${SKILL_ROOT}/scripts/sessions.js" aliases
 
 1. **User-controlled**: Sessions are only saved when the user asks — no auto-injection of stale context
 2. **Transcript + Memory**: Combine hard data (transcript parsing) with Claude's understanding (enrichment)
-3. **Wait before working**: After `/sessions resume`, always wait for user confirmation
+3. **Wait before working**: After `/arc-managing-sessions resume`, always wait for user confirmation
 4. **No native memory overlap**: This skill handles continuity; native auto-memory handles preferences/feedback


### PR DESCRIPTION
## Summary
- **compact-suggester README**: update storage path from `arcforge-tool-count` to `arcforge-compact-state`, document unified JSON format `{ tools, reads, writes }`
- **arc-managing-sessions SKILL.md**: replace all `/sessions` references with correct `/arc-managing-sessions` command name — Claude was outputting nonexistent commands to users
- **arc-journaling SKILL.md**: fix cross-reference to session commands

## Test plan
- [ ] `npm test` passes (docs-only changes)
- [ ] `/arc-managing-sessions list` loads with correct command names in prompt