### PR TITLE
docs: v1.2.0 changelog, documentation completeness, and skill test coverage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "arcforge",
       "description": "Skill-based workflow engine for AI coding agents: planning, TDD, worktree orchestration, and session learning",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "source": "./",
       "author": {
         "name": "Gregory Ho"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arcforge",
   "description": "Skill-based workflow engine for AI coding agents: planning, TDD, worktree orchestration, and session learning",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": {
     "name": "Gregory Ho"
   },

--- a/.opencode/plugins/arcforge.js
+++ b/.opencode/plugins/arcforge.js
@@ -79,7 +79,7 @@ ${content}
 
 export default {
   name: 'arcforge',
-  version: '1.1.2',
+  version: '1.2.0',
 
   'experimental.chat.system.transform': async (_input, output) => {
     const bootstrap = getBootstrapContent();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Skill-based autonomous agent toolkit for Codex, Codex, Gemini CLI, and OpenCode.
+Skill-based autonomous agent toolkit for Claude Code, Codex, Gemini CLI, and OpenCode.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,67 @@
 All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.2.0] - 2026-03-31
+
+### Added
+
+- **arc-compacting** skill: Strategic manual compaction timing at workflow phase boundaries
+- **arc-evaluating** skill: Measure whether skills, agents, or workflows change AI agent behavior — with progressive-loading references (`cli-and-metrics.md`, `common-mistakes-catalog.md`, `grading-and-execution.md`)
+- **arc-looping** skill: Autonomous loop execution with cross-session DAG task coordination
+- **arc-managing-sessions** skill: Session save/resume with alias support and cooperative auto-memory coexistence
+- **arc-researching** skill: Autonomous hypothesis-driven experimentation for metric optimization ("fixed judge + free player" pattern)
+- 9 scoped rule files in `.claude/rules/` — extracted from monolithic CLAUDE.md for context-aware loading: architecture, coding-standards, git-workflow, hooks, plugin, security, skills, templates-commands-agents, testing
+- 9 new agent definitions in `agents/`: debugger, eval-comparator, eval-grader, implementer, loop-operator, planner, quality-reviewer, spec-reviewer, verifier
+- `AGENTS.md`: Agent catalog for Codex platform discovery
+- Eval infrastructure: per-assertion code grading engine (`eval-graders.js`), statistics aggregation (`eval-stats.js`), core eval engine (`eval.js`), transcript parser (`transcript.js`)
+- Eval dashboard: `eval-dashboard.js` + `eval-dashboard-ui.html` — web UI with collapsible artifacts panel and audit trail
+- Eval scenarios: 11 new scenarios (debug-investigate-first, debug-stop-at-three, diary-quality, eval-grader-selection, eval-scenario-splitting, eval-trap-design, hook-inject-skills, instinct-adherence, reflect-pattern-detection, tdd-compliance) + eval skill-files for instinct testing
+- Eval benchmarks: JSON snapshots for 2026-03-19, 2026-03-20, 2026-03-23
+- Research dashboard: `research-dashboard.js` + `research-dashboard.html` — live monitoring with SSE and inline SVG charts
+- Loop execution engine: `scripts/loop.js` for autonomous cross-session execution
+- Session management: `session-aliases.js` for alias-based session tracking, `session-utils.js` expanded with new helpers
+- `commands/sessions.md`: Thin delegation wrapper for session management
+- `docs/guide/hooks-system.md`: Comprehensive hooks I/O visibility rules and contributor guide
+- `hooks/log_lightweight/`: Refactored Python logging into 6-module package (config, dispatcher, io_writer, state, tokens, tools)
+- `hooks/run-hook.cmd`: Windows-compatible hook dispatcher
+- `arc-writing-skills/agents/`: 4 eval subagent definitions (description-tester, skill-analyzer, skill-comparator, skill-grader) + `references/eval-schemas.md` and `testing-skills-with-subagents.md`
+- Tests: `e2e-hooks.test.js` (36 behavioral tests with real Claude Code fixtures), `observe.test.js`, `pre-compact.test.js`, `quality-check.test.js`, `coordinator.test.js`, `eval-dashboard.test.js`, `eval-integration.test.js`, `eval-stats.test.js`, `eval.test.js`, `locking.test.js`, `loop.test.js`, `package-manager.test.js`, `research-dashboard.test.js`, `session-aliases.test.js`, `session-listing.test.js`, `transcript.test.js`, `utils.test.js`, `test-models.js`, `test-yaml-parser.js`, `test_eval_agents_contract.py`, `test_eval_scenario_format.py`, `test_skill_arc_evaluating.py`
+
+### Changed
+
+- `CLAUDE.md`: Slimmed from 69 to 28 lines — bulk content extracted to `.claude/rules/` for scoped loading
+- `arc-evaluating/SKILL.md`: 8 targeted improvements from research loop — restructured for token budget with progressive-loading references; added "competence proxy" and "skill formalizes existing behavior" to Common Mistakes
+- `arc-agent-driven/SKILL.md`: Enhanced with eval-aware subagent dispatching
+- `arc-writing-skills/SKILL.md`: Updated to reference new eval agents and testing-with-subagents guide
+- `arc-brainstorming/SKILL.md`, `arc-observing/SKILL.md`, `arc-planning/SKILL.md`, `arc-refining/SKILL.md`, `arc-using/SKILL.md`: Minor refinements (cross-references, SKILL_ROOT, eval hooks)
+- Hooks output visibility: user-facing messages switched from stderr (invisible in Claude Code) to `systemMessage` JSON format across observe, pre-compact, quality-check, and compact-suggester hooks
+- `hooks/compact-suggester/main.js`: Refactored to unified `{ tools, reads, writes }` JSON state; separated compact counter from diary counter
+- `hooks/session-tracker/inject-context.js`: Major refactoring for session alias support and cooperative auto-memory
+- `hooks/session-tracker/end.js`: Enhanced session finalization with alias tracking
+- `hooks/log-lightweight.py`: Refactored from monolithic 887-line file into 6-module package under `hooks/log_lightweight/`
+- `scripts/cli.js`: Added `arc eval dashboard`, `arc research dashboard`, loop commands, and session management subcommands
+- `scripts/lib/coordinator.js`: Enhanced DAG coordination with new status helpers
+- `scripts/lib/models.js`: Added TaskStatus export from dag-schema
+- `scripts/lib/dag-schema.js`: Added TaskStatus enum export
+- `scripts/lib/utils.js`: Added new utility functions for eval and session support
+- `README.md`: Updated skill descriptions and documentation links
+- `CONTRIBUTING.md`: Updated hook architecture section
+
+### Fixed
+
+- **Hook stdin crash**: `log-lightweight` dispatcher crashed on empty stdin — now handles gracefully
+- **Hook field name**: SessionStart event sends `source` field, not `trigger` — fixed across all hooks that read session start reason
+- **Hook output invisible**: stderr output not visible to users in Claude Code — switched to `systemMessage` JSON protocol
+- **Counter collision**: compact-suggester and diary hooks shared a counter, causing incorrect compaction timing — separated into independent counters
+- `hooks/compact-suggester/README.md`: Corrected storage path documentation (`arcforge-tool-count` → `arcforge-compact-state`)
+- `skills/arc-managing-sessions/SKILL.md`: Fixed command name references (`/sessions` → `/arc-managing-sessions`)
+- `skills/arc-journaling/SKILL.md`: Fixed cross-reference to session commands
+
+### Removed
+
+- `.serena/memories/`: 4 legacy memory files (code_style_and_conventions, project_overview, suggested_commands, task_completion_checklist) — replaced by `.claude/rules/`
+- `hooks/lib/package-manager.js`, `hooks/lib/thresholds.js`, `hooks/lib/utils.js`: Removed hook-local re-exports — hooks now import directly from `scripts/lib/`
+
 ## [1.1.2] - 2026-02-14
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,10 +238,10 @@ hooks/
 
 ### Shared Utilities
 
-Use `hooks/lib/utils.js` for common operations:
+Import from `scripts/lib/utils.js` (canonical location) for common operations:
 - `readStdinSync()` — read stdin for hook chaining
-- `log(msg)` — log to stderr (visible in Claude Code)
-- `execCommand(cmd, args)` — safe execution (no shell injection)
+- `readFileSafe(path, default)` — safe file read with fallback
+- `writeFileSafe(path, content)` — safe file write with directory creation
 
 ### Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arcforge
 
-[![Version](https://img.shields.io/badge/version-1.1.2-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI](https://github.com/GregoryHo/arcforge/actions/workflows/ci.yml/badge.svg)](https://github.com/GregoryHo/arcforge/actions/workflows/ci.yml)
 
@@ -173,12 +173,14 @@ a starting skill, but you can invoke any skill directly.
 - **arc-verifying** - Verification mindset (evidence before claims)
 - **arc-debugging** - Systematic debugging with four phases
 - **arc-writing-skills** - Create and edit skills using TDD principles
+- **arc-compacting** - Strategic manual compaction timing at workflow phase boundaries
 
 ### Execution Layer
 
 - **arc-tdd** - Test-driven development (RED → GREEN → REFACTOR cycle)
 - **arc-agent-driven** - Automated execution with subagent per task and two-stage review
 - **arc-executing-tasks** - Human-in-the-loop execution with checkpoints
+- **arc-looping** - Autonomous cross-session loop execution
 
 ### Session & Learning Layer
 
@@ -187,11 +189,14 @@ a starting skill, but you can invoke any skill directly.
 - **arc-learning** - Extract reusable patterns from sessions
 - **arc-observing** - Tool call observation for behavioral pattern detection
 - **arc-recalling** - Manual instinct creation from session insights
+- **arc-managing-sessions** - Session save/resume with alias support
+- **arc-researching** - Autonomous hypothesis-driven experimentation
 
 ### Review Layer
 
 - **arc-requesting-review** - When and how to request code review
 - **arc-receiving-review** - How to handle review feedback with technical rigor
+- **arc-evaluating** - Measure whether skills and workflows change agent behavior
 
 ### Review Templates
 

--- a/docs/guide/architecture-overview.txt
+++ b/docs/guide/architecture-overview.txt
@@ -7,7 +7,7 @@
 │                                                                                              │
 │  arcforge/                                                                               │
 │  ├── scripts/                     # Node.js CLI and core engine                              │
-│  │   ├── cli.js                   # CLI entry point (10 commands)                           │
+│  │   ├── cli.js                   # CLI entry point (14 commands)                           │
 │  │   └── lib/                     # Supporting modules                                      │
 │  │       ├── coordinator.js       # DAG orchestration engine                                │
 │  │       ├── dag-schema.js        # Schema validation                                       │
@@ -22,10 +22,16 @@
 │  │       ├── instinct-writer.js   # Instinct file creation                                  │
 │  │       ├── pending-actions.js   # Deferred action queue                                   │
 │  │       ├── session-utils.js     # Session/diary path helpers                              │
+│  │       ├── session-aliases.js   # Session alias management                                │
+│  │       ├── transcript.js        # Transcript parsing for eval                             │
+│  │       ├── eval.js              # Core eval engine                                        │
+│  │       ├── eval-graders.js      # Per-assertion code grading                              │
+│  │       ├── eval-stats.js        # Eval statistics aggregation                             │
+│  │       ├── research-dashboard.js # Research experiment dashboard                          │
 │  │       ├── thresholds.js        # Session evaluation thresholds                           │
 │  │       └── utils.js             # Cross-platform file/JSON utilities                      │
 │  │                                                                                          │
-│  ├── skills/                      # Markdown skill definitions (24 skills)                  │
+│  ├── skills/                      # Markdown skill definitions (29 skills)                  │
 │  │   ├── arc-using/           # Entry point skill                                       │
 │  │   ├── arc-brainstorming/      # Ideation                                                │
 │  │   ├── arc-refining/         # Spec generation                                         │
@@ -49,15 +55,29 @@
 │  │   ├── arc-reflecting/        # Diary analysis for patterns                           │
 │  │   ├── arc-learning/          # Pattern extraction from sessions                      │
 │  │   ├── arc-observing/         # Tool call observation                                 │
-│  │   └── arc-recalling/         # Manual instinct creation                              │
+│  │   ├── arc-recalling/         # Manual instinct creation                              │
+│  │   ├── arc-compacting/        # Strategic compaction timing                           │
+│  │   ├── arc-evaluating/        # Skill/workflow evaluation                             │
+│  │   ├── arc-looping/           # Autonomous loop execution                             │
+│  │   ├── arc-managing-sessions/ # Session save/resume                                   │
+│  │   └── arc-researching/       # Hypothesis-driven experimentation                     │
 │  │                                                                                          │
 │  ├── templates/                   # Subagent prompt templates                               │
 │  │   ├── implementer-prompt.md    # TDD implementer subagent                                │
 │  │   ├── spec-reviewer-prompt.md  # Spec compliance reviewer                                │
 │  │   └── quality-reviewer-prompt.md  # Code quality reviewer                                │
 │  │                                                                                          │
-│  ├── agents/                      # Persistent agent definitions                            │
-│  │   └── code-reviewer.md         # Code review agent                                       │
+│  ├── agents/                      # Persistent agent definitions (10 agents)                │
+│  │   ├── code-reviewer.md         # Code review agent                                       │
+│  │   ├── debugger.md              # Debugging specialist                                    │
+│  │   ├── eval-comparator.md       # A/B eval comparison                                     │
+│  │   ├── eval-grader.md           # Rubric-based eval grading                               │
+│  │   ├── implementer.md           # TDD implementer                                         │
+│  │   ├── loop-operator.md         # Loop health monitoring                                  │
+│  │   ├── planner.md               # Architecture analysis                                   │
+│  │   ├── quality-reviewer.md      # Code quality review                                     │
+│  │   ├── spec-reviewer.md         # Spec compliance review                                  │
+│  │   └── verifier.md              # Acceptance criteria verification                        │
 │  │                                                                                          │
 │  ├── docs/                        # Documentation                                           │
 │  │   ├── guide/                   # Architecture and workflow guides                        │

--- a/docs/guide/cli-reference.txt
+++ b/docs/guide/cli-reference.txt
@@ -41,9 +41,42 @@
 │  │  ├── reboot                       # Generate 5-Question context                     │    │
 │  │  │   └── (no options)                                                               │    │
 │  │  │                                                                                  │    │
-│  │  └── sync                         # Synchronize state                               │    │
-│  │      └── --direction, -d          # from-base|to-base|both|scan                     │    │
-│  │                                   # (auto-detected if omitted)                      │    │
+│  │  ├── sync                         # Synchronize state                               │    │
+│  │  │   └── --direction, -d          # from-base|to-base|both|scan                     │    │
+│  │  │                                # (auto-detected if omitted)                      │    │
+│  │  │                                                                                  │    │
+│  │  ├── schema                       # Show dag.yaml schema                            │    │
+│  │  │   ├── --json                   # Output as JSON instead of YAML                  │    │
+│  │  │   └── --example                # Show complete example instead of schema         │    │
+│  │  │                                                                                  │    │
+│  │  ├── eval <subcommand>            # Run evaluations and benchmarks                  │    │
+│  │  │   ├── list                     # List all eval scenarios                         │    │
+│  │  │   ├── run <name>               # Run k trials of a scenario                     │    │
+│  │  │   │   ├── --k N               # Number of trials                                │    │
+│  │  │   │   └── --model NAME        # Model to use                                    │    │
+│  │  │   ├── ab <name>                # A/B test skill or workflow                      │    │
+│  │  │   │   ├── --skill-file PATH   # Skill file for A/B eval                         │    │
+│  │  │   │   ├── --k N               # Number of trials                                │    │
+│  │  │   │   ├── --model NAME        # Model to use                                    │    │
+│  │  │   │   └── --interleave        # Interleave baseline/treatment trials             │    │
+│  │  │   ├── compare <name>           # Compare baseline vs treatment                   │    │
+│  │  │   │   └── --model NAME        # Model to use                                    │    │
+│  │  │   ├── report [name]            # Show benchmark report                           │    │
+│  │  │   │   └── --model NAME        # Model to use                                    │    │
+│  │  │   ├── history                  # List benchmark snapshots                        │    │
+│  │  │   └── dashboard                # Start live web dashboard                        │    │
+│  │  │       └── --port N             # Dashboard port (default: 3333)                  │    │
+│  │  │                                                                                  │    │
+│  │  ├── research <subcommand>        # Research experiment tools                       │    │
+│  │  │   └── dashboard                # Start live research dashboard                   │    │
+│  │  │       ├── --results PATH       # Path to results.tsv (default: results.tsv)      │    │
+│  │  │       ├── --config PATH        # Path to research-config.md                      │    │
+│  │  │       └── --port N             # Server port (default: 3000)                     │    │
+│  │  │                                                                                  │    │
+│  │  └── loop                         # Run autonomous execution loop                   │    │
+│  │      ├── --pattern PATTERN        # sequential|dag (default: sequential)            │    │
+│  │      ├── --max-runs N             # Maximum iterations (default: 50)                │    │
+│  │      └── --max-cost N             # Maximum cost in dollars                         │    │
 │  │                                                                                     │    │
 │  │  Global Option:                                                                     │    │
 │  │  └── --project, -p PATH           # Project root (applies to all commands)          │    │
@@ -292,6 +325,122 @@
 │  │  Errors:                                                                            │    │
 │  │    - "Cannot use --direction scan in worktree"                                      │    │
 │  │    - "Cannot use --direction from-base/to-base/both in base project"                │    │
+│  │                                                                                     │    │
+│  └─────────────────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────────────────┐    │
+│  │  schema - Show DAG Schema (顯示 DAG 結構定義)                                        │    │
+│  │  ─────────────────────────────────────────────────────────────────────────────────  │    │
+│  │                                                                                     │    │
+│  │  Usage: arcforge schema [OPTIONS]                                               │    │
+│  │                                                                                     │    │
+│  │  Options:                                                                           │    │
+│  │    --json       Output as JSON instead of YAML                                      │    │
+│  │    --example    Show a complete dag.yaml example instead of the schema              │    │
+│  │                                                                                     │    │
+│  │  Behavior:                                                                          │    │
+│  │    1. Loads schema or example from dag-schema module                                │    │
+│  │    2. Outputs in YAML format by default, JSON if --json specified                   │    │
+│  │                                                                                     │    │
+│  │  Output:                                                                            │    │
+│  │    YAML or JSON representation of the dag.yaml schema or example                    │    │
+│  │                                                                                     │    │
+│  └─────────────────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────────────────┐    │
+│  │  eval - Run Evaluations (執行評估)                                                    │    │
+│  │  ─────────────────────────────────────────────────────────────────────────────────  │    │
+│  │                                                                                     │    │
+│  │  Usage: arcforge eval <subcommand> [OPTIONS]                                    │    │
+│  │                                                                                     │    │
+│  │  Subcommands:                                                                       │    │
+│  │    list                List all eval scenarios                                      │    │
+│  │    run <name>          Run k trials of a scenario                                   │    │
+│  │    ab <name>           A/B test: baseline vs treatment                              │    │
+│  │    compare <name>      Compare baseline vs treatment results                        │    │
+│  │    report [name]       Show benchmark report (all or specific)                      │    │
+│  │    history             List benchmark snapshots                                     │    │
+│  │    dashboard           Start live web dashboard                                     │    │
+│  │                                                                                     │    │
+│  │  Options (run, ab):                                                                 │    │
+│  │    --k N               Number of trials per condition                               │    │
+│  │    --model NAME        Model to use for trials                                      │    │
+│  │                                                                                     │    │
+│  │  Options (ab only):                                                                 │    │
+│  │    --skill-file PATH   Path to skill file for skill-scope A/B eval                  │    │
+│  │    --interleave        Interleave baseline and treatment trials                     │    │
+│  │                                                                                     │    │
+│  │  Options (dashboard):                                                               │    │
+│  │    --port N            Dashboard port (default: 3333)                               │    │
+│  │                                                                                     │    │
+│  │  Behavior:                                                                          │    │
+│  │    run:  Spawns k trials, grades each, writes results to JSONL                      │    │
+│  │    ab:   Runs baseline (no skill) and treatment (with skill), compares              │    │
+│  │    compare: Reads existing results and shows statistical comparison                 │    │
+│  │    report:  Aggregates results into pass@k metrics with verdicts                    │    │
+│  │    dashboard: Starts HTTP server with live eval results                             │    │
+│  │                                                                                     │    │
+│  │  Output (run):                                                                      │    │
+│  │    "Trial N/k: PASS|FAIL (score: X.XX)"                                            │    │
+│  │    "Result: pass@k = X.XX (N/k passed)"                                            │    │
+│  │                                                                                     │    │
+│  │  Errors:                                                                            │    │
+│  │    - "Scenario not found: <name>"                                                   │    │
+│  │    - "No results found for scenario: <name>" (compare/report)                       │    │
+│  │                                                                                     │    │
+│  └─────────────────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────────────────┐    │
+│  │  research - Research Experiment Tools (研究實驗工具)                                   │    │
+│  │  ─────────────────────────────────────────────────────────────────────────────────  │    │
+│  │                                                                                     │    │
+│  │  Usage: arcforge research dashboard [OPTIONS]                                   │    │
+│  │                                                                                     │    │
+│  │  Options:                                                                           │    │
+│  │    --results PATH    Path to results.tsv file (default: results.tsv)                │    │
+│  │    --config PATH     Path to research-config.md (default: research-config.md)       │    │
+│  │    --port N          Server port (default: 3000)                                    │    │
+│  │                                                                                     │    │
+│  │  Behavior:                                                                          │    │
+│  │    1. Resolves results and config paths relative to project root                    │    │
+│  │    2. Starts HTTP server with live research dashboard                               │    │
+│  │    3. Dashboard shows experiment history, metrics over time, current state           │    │
+│  │                                                                                     │    │
+│  │  Output:                                                                            │    │
+│  │    "Research dashboard running at http://localhost:<port>"                           │    │
+│  │                                                                                     │    │
+│  │  Errors:                                                                            │    │
+│  │    - Usage error if subcommand is not "dashboard"                                   │    │
+│  │                                                                                     │    │
+│  └─────────────────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────────────────┐    │
+│  │  loop - Run Autonomous Execution Loop (執行自動迴圈)                                   │    │
+│  │  ─────────────────────────────────────────────────────────────────────────────────  │    │
+│  │                                                                                     │    │
+│  │  Usage: arcforge loop [OPTIONS]                                                 │    │
+│  │                                                                                     │    │
+│  │  Options:                                                                           │    │
+│  │    --pattern PATTERN    Execution pattern: sequential|dag (default: sequential)      │    │
+│  │    --max-runs N         Maximum iterations (default: 50)                            │    │
+│  │    --max-cost N         Maximum cost in dollars (no default — unlimited)             │    │
+│  │                                                                                     │    │
+│  │  Behavior:                                                                          │    │
+│  │    1. Reads dag.yaml to find pending tasks                                          │    │
+│  │    2. sequential: Processes one task at a time, stops on failure                    │    │
+│  │    3. dag: Uses parallelTasks() to find independent tasks, continues past failures  │    │
+│  │    4. Each iteration: spawn fresh Claude session, execute task, update DAG           │    │
+│  │    5. Writes state to .arcforge-loop.json after each iteration                      │    │
+│  │    6. Stops on: all complete, max-runs, cost limit, stall, or retry storm           │    │
+│  │                                                                                     │    │
+│  │  Output:                                                                            │    │
+│  │    "Loop started: pattern=<pattern>, max-runs=<N>"                                  │    │
+│  │    "Iteration N: <task_id> — PASS|FAIL"                                             │    │
+│  │    "Loop complete: <status> (N tasks completed)"                                    │    │
+│  │                                                                                     │    │
+│  │  Errors:                                                                            │    │
+│  │    - "Invalid pattern \"<pattern>\". Use \"sequential\" or \"dag\"."                │    │
+│  │    - "dag.yaml not found" if no DAG exists                                          │    │
 │  │                                                                                     │    │
 │  └─────────────────────────────────────────────────────────────────────────────────────┘    │
 │                                                                                              │
@@ -596,6 +745,28 @@
 │  │                                                                                     │    │
 │  │  # Use with different project path                                                  │    │
 │  │  $ arcforge -p /other/project status                                            │    │
+│  │                                                                                     │    │
+│  │  # Show dag.yaml schema                                                             │    │
+│  │  $ arcforge schema                                                              │    │
+│  │  $ arcforge schema --json                                                       │    │
+│  │  $ arcforge schema --example                                                    │    │
+│  │                                                                                     │    │
+│  │  # Run evaluations                                                                  │    │
+│  │  $ arcforge eval list                                                           │    │
+│  │  $ arcforge eval run tdd-compliance --k 5                                       │    │
+│  │  $ arcforge eval ab tdd-compliance --skill-file skills/arc-tdd/SKILL.md         │    │
+│  │  $ arcforge eval compare tdd-compliance                                         │    │
+│  │  $ arcforge eval report                                                         │    │
+│  │  $ arcforge eval dashboard --port 4000                                          │    │
+│  │                                                                                     │    │
+│  │  # Research experiment dashboard                                                    │    │
+│  │  $ arcforge research dashboard                                                  │    │
+│  │  $ arcforge research dashboard --results data/results.tsv --port 8080           │    │
+│  │                                                                                     │    │
+│  │  # Run autonomous loops                                                             │    │
+│  │  $ arcforge loop --pattern sequential --max-runs 20                             │    │
+│  │  $ arcforge loop --pattern dag --max-runs 50                                    │    │
+│  │  $ arcforge loop --max-cost 10 --max-runs 100                                   │    │
 │  │                                                                                     │    │
 │  └─────────────────────────────────────────────────────────────────────────────────────┘    │
 │                                                                                              │

--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -35,15 +35,15 @@ What are you trying to do?
 
 ## Skill Categories
 
-arcforge's 24 skills are organized into 6 categories:
+arcforge's 29 skills are organized into 6 categories:
 
 | Category | Skills | Purpose |
 |----------|--------|---------|
 | **Planning** | arc-brainstorming, arc-refining, arc-writing-tasks, arc-planning | Explore, specify, break down |
-| **Execution** | arc-executing-tasks, arc-agent-driven, arc-implementing, arc-dispatching-parallel | Build and ship |
-| **Coordination** | arc-using, arc-using-worktrees, arc-coordinating, arc-finishing, arc-finishing-epic | Route, isolate, integrate |
-| **Quality** | arc-tdd, arc-debugging, arc-verifying, arc-requesting-review, arc-receiving-review | Test, debug, verify, review |
-| **Learning** | arc-journaling, arc-reflecting, arc-learning, arc-observing, arc-recalling | Capture, extract, evolve |
+| **Execution** | arc-executing-tasks, arc-agent-driven, arc-implementing, arc-dispatching-parallel, arc-looping | Build and ship |
+| **Coordination** | arc-using, arc-using-worktrees, arc-coordinating, arc-finishing, arc-finishing-epic, arc-compacting, arc-managing-sessions | Route, isolate, integrate |
+| **Quality** | arc-tdd, arc-debugging, arc-verifying, arc-requesting-review, arc-receiving-review, arc-evaluating | Test, debug, verify, review |
+| **Learning** | arc-journaling, arc-reflecting, arc-learning, arc-observing, arc-recalling, arc-researching | Capture, extract, evolve |
 | **Meta** | arc-writing-skills | Create and maintain skills |
 
 **How skills flow through a project:**
@@ -64,8 +64,9 @@ arcforge's 24 skills are organized into 6 categories:
   tdd (during execution)    journaling            writing-skills
   debugging (on failure)    reflecting
   verifying (before done)   learning
-  requesting-review         observing
-  receiving-review          recalling
+  evaluating (skill eval)   observing
+  requesting-review         recalling
+  receiving-review          researching
 ```
 
 ---

--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -251,6 +251,28 @@ arcforge's 29 skills are organized into 6 categories:
 
 ---
 
+### arc-looping
+
+**Purpose:** Run arcforge workflows autonomously across sessions — each iteration spawns a fresh Claude session while DAG and git persist state.
+
+**When to use:** When tasks can run fully unattended across sessions with no human judgment needed per task.
+
+**Key workflow:**
+1. Verify DAG exists (from arc-planning) and baseline tests pass
+2. Choose loop pattern: sequential (safest, one task at a time) or DAG (parallel-aware)
+3. Set bounds: `--max-runs` and optional `--max-cost`
+4. Start loop: `node scripts/cli.js loop --pattern sequential --max-runs 20`
+5. Each iteration: read dag.yaml, spawn fresh Claude session, execute task, update DAG
+6. Stop on: all complete, max-runs hit, cost limit, stall detected, or retry storm
+
+**Artifacts:**
+- Input: `dag.yaml` (required, must be committed)
+- Output: `.arcforge-loop.json` (loop state tracking), committed code per completed task
+
+**Related:** arc-planning --> **arc-looping** --> arc-finishing or arc-finishing-epic
+
+---
+
 ### Coordination Skills
 
 ---
@@ -294,6 +316,27 @@ arcforge's 29 skills are organized into 6 categories:
 - Output: `.worktrees/<epic-name>/` directory, `.arcforge-epic` marker file
 
 **Related:** arc-planning --> **arc-using-worktrees** --> arc-implementing or arc-executing-tasks
+
+---
+
+### arc-compacting
+
+**Purpose:** Guide compaction decisions at logical workflow boundaries instead of letting auto-compaction fire mid-task.
+
+**When to use:** When the compact-suggester hook fires, when transitioning between workflow phases, or when a long session has accumulated stale context.
+
+**Key workflow:**
+1. Check phase transition — compact between phases (when state is persisted to files), not during
+2. Pre-compact: save decisions to files/memory, run `/diary` if session was substantial
+3. Check for un-committed work — ensure valuable changes are committed
+4. Compact with focused seed text: `/compact Focus on implementing [next task]`
+5. Post-compact: run `arcforge reboot`, re-read needed files
+
+**Artifacts:**
+- Input: session context, rule files, memory files
+- Output: compacted context focused on next phase
+
+**Related:** compact-suggester hook --> **arc-compacting** --> arc-agent-driven, arc-planning
 
 ---
 
@@ -355,6 +398,26 @@ arcforge's 29 skills are organized into 6 categories:
 - Output: merged epic, PR, preserved branch, or discarded work + DAG updated
 
 **Related:** arc-implementing --> **arc-finishing-epic** --> arc-coordinating status
+
+---
+
+### arc-managing-sessions
+
+**Purpose:** User-controlled session saves for continuity across conversations — save what matters, resume when needed.
+
+**When to use:** When saving session state for cross-conversation handoff, resuming a previous session, listing session history, or managing session aliases.
+
+**Key workflow:**
+1. **Save:** Reflect on conversation, write enrichment (summary, what worked/failed, blockers, next step), save to session file
+2. **Resume:** Resolve alias, read session file, present structured briefing, WAIT for user confirmation
+3. **List:** Browse sessions with filters (`--limit`, `--date`, `--query`)
+4. **Alias:** Create friendly names for easy session reference
+
+**Artifacts:**
+- Input: current session data from `~/.claude/sessions/{project}/{date}/{sessionId}.json`
+- Output: `~/.claude/sessions/{project}/{date}/session-{alias}.md`, `aliases.json`
+
+**Related:** any skill --> **arc-managing-sessions** (when continuity is needed)
 
 ---
 
@@ -423,6 +486,28 @@ arcforge's 29 skills are organized into 6 categories:
 - Output: verified status with evidence (test output, build output, etc.)
 
 **Related:** embedded in all skills as a mindset, especially arc-finishing, arc-finishing-epic, arc-tdd
+
+---
+
+### arc-evaluating
+
+**Purpose:** Measure whether skills, agents, and workflows actually change AI agent behavior — unit tests for AI agent behavior.
+
+**When to use:** Before shipping a new skill, after modifying an existing one, or when comparing alternative approaches.
+
+**Key workflow:**
+1. Confirm eval scope with user: skill (behavior change), agent (task outcome), or workflow (toolkit effect)
+2. Define the question first: "What are you trying to learn?"
+3. Design scenario with assertions and grader type (code, model, or human)
+4. Run scenario validity preflight (expected baseline failure, ceiling/floor risk, answer leakage)
+5. Run eval trials (`arc eval run` or `arc eval ab` for A/B comparison)
+6. Grade results, track in JSONL, report verdict: SHIP / NEEDS WORK / BLOCKED
+
+**Artifacts:**
+- Input: scenario files in `evals/scenarios/`
+- Output: benchmark results in `evals/benchmarks/latest.json`, eval reports
+
+**Related:** arc-brainstorming --> **arc-evaluating** --> arc-writing-skills (for shipping)
 
 ---
 
@@ -572,6 +657,28 @@ arcforge's 29 skills are organized into 6 categories:
 - Output: `~/.claude/instincts/{project}/<id>.md`
 
 **Related:** user insight --> **arc-recalling** --> instinct saved for arc-observing lifecycle
+
+---
+
+### arc-researching
+
+**Purpose:** Autonomous hypothesis-driven experimentation to optimize any measurable metric — build times, algorithm efficiency, prompt quality, or any target with a numeric signal.
+
+**When to use:** When optimizing a measurable metric through free-form experimentation rather than a predefined task list.
+
+**Key workflow:**
+1. Phase 1 (Interactive): Analyze target, propose `research-config.md` contract (scope, goal, evaluation, constraints), lock with user
+2. Phase 2: Create research branch, run evaluation, establish baseline metric, start dashboard
+3. Phase 3 (Autonomous loop): Hypothesize, implement, commit, run, extract metric, keep or revert, log to `results.tsv`
+4. Decision rules: improved = keep, same/worse = revert, crash = log + revert
+5. Stuck protocol: 3+ failures in same direction, change direction entirely
+6. Phase 4: Report baseline, best result, improvement %, experiment counts
+
+**Artifacts:**
+- Input: measurable metric, target files, evaluation command
+- Output: `research-config.md` (locked contract), `results.tsv` (untracked), `research/{tag}` branch
+
+**Related:** arc-brainstorming --> **arc-researching** --> manual cherry-pick to main
 
 ---
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -9,9 +9,6 @@ hooks/
 ├── hooks.json              # Hook configuration
 ├── run-hook.cmd            # Bash dispatcher
 ├── README.md
-├── lib/                    # Shared utilities
-│   ├── utils.js            # File ops, JSON helpers, command detection
-│   └── package-manager.js  # PM detection (npm/pnpm/yarn/bun)
 ├── inject-skills/          # Injects arc-using skill at session start
 │   ├── main.sh
 │   └── README.md
@@ -138,7 +135,7 @@ function main() {
   process.stdout.write(stdin);
 
   // Your logic here
-  // Warnings go to stderr (visible in Claude Code)
+  // log() goes to stderr — internal diagnostics only (invisible to users)
   log('[my-hook] Something happened');
 }
 
@@ -178,18 +175,20 @@ main();
 
 ## Shared Utilities
 
-### lib/utils.js
+Hooks import from `scripts/lib/` (canonical source). Key functions:
+
+### scripts/lib/utils.js
 
 - `escapeForJson(str)` - Safe JSON string escaping
 - `fileExists(path)` - Check file existence
-- `readFileSafe(path)` - Read file, returns null on error
+- `readFileSafe(path, default)` - Read file, returns default on error
 - `writeFileSafe(path, content)` - Write file with directory creation
-- `execCommand(cmd, args)` - Safe command execution (no shell injection)
 - `readStdinSync()` - Read all stdin content
-- `log(msg)` - Log to stderr (visible to user, not sent to Claude)
+- `log(msg)` - Log to stderr (internal diagnostics only — invisible to users)
+- `output(obj)` - Write JSON to stdout (`{ systemMessage }` for user-visible output)
 - `outputContext(context, eventName)` - Output structured hook response for Claude
 
-### lib/package-manager.js
+### scripts/lib/package-manager.js
 
 - `detectPackageManager(dir)` - Detect npm/pnpm/yarn/bun from lock files
 - `getPmExecCommand(binary, pm)` - Get exec command for a binary

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcforge-hooks",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Claude Code hooks for arcforge",
   "scripts": {
     "test": "node --test __tests__/*.test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcforge",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Skill-based autonomous agent toolkit for Claude Code, Codex, Gemini CLI, and OpenCode",
   "license": "MIT",
   "author": {

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -2,7 +2,7 @@
  * Cross-platform utilities for Claude Code scripts and hooks
  * Provides file operations, JSON handling, and command detection
  *
- * NOTE: This is the canonical location. hooks/lib/utils.js should import from here.
+ * NOTE: This is the canonical location. Hooks import directly from here.
  */
 
 const fs = require('node:fs');

--- a/tests/skills/test_skill_arc_compacting.py
+++ b/tests/skills/test_skill_arc_compacting.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+
+def _read_skill() -> str:
+    skill_path = Path("skills/arc-compacting/SKILL.md")
+    return skill_path.read_text(encoding="utf-8")
+
+
+def _parse_frontmatter(text: str) -> dict:
+    if not text.startswith("---\n"):
+        raise AssertionError("missing frontmatter start")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise AssertionError("missing frontmatter end")
+    front = text[4:end].strip().splitlines()
+    data = {}
+    for line in front:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def test_arc_compacting_frontmatter():
+    text = _read_skill()
+    front = _parse_frontmatter(text)
+
+    assert front.get("name") == "arc-compacting"
+    assert front.get("description", "").startswith("Guide for")
+    assert len((front.get("name", "") + front.get("description", ""))) < 1024
+
+    # No @ symbols in skill content
+    assert "@" not in text
+
+
+def test_arc_compacting_has_phase_boundary_guidance():
+    """Test skill guides compaction at workflow phase boundaries."""
+    text = _read_skill()
+
+    # Must reference phase transitions
+    assert "phase" in text.lower()
+
+    # Must have decision guide for when to compact
+    assert "Decision Guide" in text or "When to Use" in text
+
+    # Must mention what persists vs what's lost
+    assert "Persists" in text or "Survives" in text
+
+
+def test_arc_compacting_has_pre_post_compact_steps():
+    """Test skill has before/during/after compacting guidance."""
+    text = _read_skill()
+
+    # Must mention running diary before compacting
+    assert "/diary" in text or "diary" in text.lower()
+
+    # Must mention arcforge reboot after compacting
+    assert "arcforge reboot" in text
+
+    # Must mention saving/persisting state before compact
+    assert "commit" in text.lower() or "persist" in text.lower()
+
+
+def test_arc_compacting_references_related_skills():
+    """Test skill references relevant arcforge components."""
+    text = _read_skill()
+
+    # Must reference compact-suggester hook
+    assert "compact-suggester" in text
+
+    # Must reference at least one other skill
+    assert "arc-agent-driven" in text or "arc-planning" in text

--- a/tests/skills/test_skill_arc_looping.py
+++ b/tests/skills/test_skill_arc_looping.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+
+def _read_skill() -> str:
+    skill_path = Path("skills/arc-looping/SKILL.md")
+    return skill_path.read_text(encoding="utf-8")
+
+
+def _parse_frontmatter(text: str) -> dict:
+    if not text.startswith("---\n"):
+        raise AssertionError("missing frontmatter start")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise AssertionError("missing frontmatter end")
+    front = text[4:end].strip().splitlines()
+    data = {}
+    for line in front:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def test_arc_looping_frontmatter():
+    text = _read_skill()
+    front = _parse_frontmatter(text)
+
+    assert front.get("name") == "arc-looping"
+    assert front.get("description", "").startswith("Guide for")
+    assert len((front.get("name", "") + front.get("description", ""))) < 1024
+
+    # No @ symbols in skill content
+    assert "@" not in text
+
+
+def test_arc_looping_has_loop_patterns():
+    """Test skill documents sequential and DAG loop patterns."""
+    text = _read_skill()
+
+    # Must document both patterns
+    assert "sequential" in text.lower()
+    assert "dag" in text.lower() or "DAG" in text
+
+    # Must mention max-runs limit
+    assert "--max-runs" in text
+
+
+def test_arc_looping_has_state_tracking():
+    """Test skill documents loop state file and stop conditions."""
+    text = _read_skill()
+
+    # Must reference state file
+    assert ".arcforge-loop.json" in text
+
+    # Must document stop conditions
+    assert "stall" in text.lower()
+
+    # Must reference dag.yaml as input
+    assert "dag.yaml" in text
+
+
+def test_arc_looping_has_monitoring():
+    """Test skill documents how to monitor running loops."""
+    text = _read_skill()
+
+    # Must reference loop-operator agent for monitoring
+    assert "loop-operator" in text
+
+    # Must document retry storm detection
+    assert "retry" in text.lower()
+
+
+def test_arc_looping_references_related_skills():
+    """Test skill references upstream and downstream skills."""
+    text = _read_skill()
+
+    # Must reference arc-planning as prerequisite
+    assert "arc-planning" in text
+
+    # Must reference finishing skills
+    assert "arc-finishing" in text

--- a/tests/skills/test_skill_arc_managing_sessions.py
+++ b/tests/skills/test_skill_arc_managing_sessions.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+
+def _read_skill() -> str:
+    skill_path = Path("skills/arc-managing-sessions/SKILL.md")
+    return skill_path.read_text(encoding="utf-8")
+
+
+def _parse_frontmatter(text: str) -> dict:
+    if not text.startswith("---\n"):
+        raise AssertionError("missing frontmatter start")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise AssertionError("missing frontmatter end")
+    front = text[4:end].strip().splitlines()
+    data = {}
+    for line in front:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def test_arc_managing_sessions_frontmatter():
+    text = _read_skill()
+    front = _parse_frontmatter(text)
+
+    assert front.get("name") == "arc-managing-sessions"
+    assert front.get("description", "").startswith("Use when")
+    assert len((front.get("name", "") + front.get("description", ""))) < 1024
+
+    # No @ symbols in skill content
+    assert "@" not in text
+
+
+def test_arc_managing_sessions_has_subcommands():
+    """Test skill documents save, resume, list, and alias operations."""
+    text = _read_skill()
+
+    # Must document all four operations
+    assert "save" in text.lower()
+    assert "resume" in text.lower()
+    assert "list" in text.lower()
+    assert "alias" in text.lower()
+
+
+def test_arc_managing_sessions_has_enrichment():
+    """Test skill requires enrichment content, not mechanical script execution."""
+    text = _read_skill()
+
+    # Must mention enrichment or reflection
+    assert "enrich" in text.lower() or "reflect" in text.lower()
+
+    # Must mention what worked / what failed
+    assert "What Worked" in text or "what worked" in text.lower()
+    assert "What Failed" in text or "what failed" in text.lower()
+
+
+def test_arc_managing_sessions_has_session_paths():
+    """Test skill documents session file storage layout."""
+    text = _read_skill()
+
+    # Must reference session storage path
+    assert "~/.claude/sessions" in text or ".claude/sessions" in text
+
+    # Must reference aliases.json
+    assert "aliases.json" in text
+
+
+def test_arc_managing_sessions_has_wait_rule():
+    """Test skill enforces waiting for user confirmation after resume."""
+    text = _read_skill()
+
+    # Must explicitly say to wait after resume
+    assert "wait" in text.lower() and "confirm" in text.lower()

--- a/tests/skills/test_skill_arc_researching.py
+++ b/tests/skills/test_skill_arc_researching.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+
+def _read_skill() -> str:
+    skill_path = Path("skills/arc-researching/SKILL.md")
+    return skill_path.read_text(encoding="utf-8")
+
+
+def _parse_frontmatter(text: str) -> dict:
+    if not text.startswith("---\n"):
+        raise AssertionError("missing frontmatter start")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise AssertionError("missing frontmatter end")
+    front = text[4:end].strip().splitlines()
+    data = {}
+    for line in front:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def test_arc_researching_frontmatter():
+    text = _read_skill()
+    front = _parse_frontmatter(text)
+
+    assert front.get("name") == "arc-researching"
+    assert front.get("description", "").startswith("Use when")
+    assert len((front.get("name", "") + front.get("description", ""))) < 1024
+
+    # No @ symbols in skill content
+    assert "@" not in text
+
+
+def test_arc_researching_has_hypothesis_driven_loop():
+    """Test skill documents the autonomous experiment loop."""
+    text = _read_skill()
+
+    # Must document hypothesis-driven approach
+    assert "hypothes" in text.lower()
+
+    # Must document the experiment loop
+    assert "LOOP" in text or "loop" in text.lower()
+
+    # Must document baseline establishment
+    assert "baseline" in text.lower()
+
+
+def test_arc_researching_has_research_config():
+    """Test skill documents the research contract."""
+    text = _read_skill()
+
+    # Must reference research-config.md
+    assert "research-config.md" in text
+
+    # Must reference results tracking
+    assert "results.tsv" in text
+
+
+def test_arc_researching_has_revert_on_failure():
+    """Test skill enforces reverting failed experiments."""
+    text = _read_skill()
+
+    # Must document revert behavior
+    assert "revert" in text.lower() or "reset" in text.lower()
+
+    # Must document decision rules
+    assert "improved" in text.lower() or "keep" in text.lower()
+    assert "discard" in text.lower() or "worse" in text.lower()
+
+
+def test_arc_researching_has_stuck_protocol():
+    """Test skill documents what to do when stuck."""
+    text = _read_skill()
+
+    # Must have stuck/direction-change protocol
+    assert "stuck" in text.lower() or "direction" in text.lower()
+
+    # Must mention iron laws or immutable evaluation
+    assert "Iron Law" in text or "NEVER modify" in text or "immutable" in text.lower()
+
+
+def test_arc_researching_has_completion_format():
+    """Test skill has structured completion output."""
+    text = _read_skill()
+
+    # Must have completion format
+    assert "RESEARCH COMPLETE" in text or "Completion Format" in text


### PR DESCRIPTION
## Summary

- Bump version to 1.2.0 across all platform manifests (package.json, plugin.json, marketplace.json, arcforge.js)
- Add CHANGELOG.md entry for v1.2.0 covering 5 new skills, eval infrastructure, loop engine, and session management
- Add 5 missing detailed catalog entries to skills-reference.md (arc-compacting, arc-evaluating, arc-looping, arc-managing-sessions, arc-researching) — catalog now covers all 29 skills
- Document 4 new CLI commands (schema, eval, research, loop) in cli-reference.txt with command tree, reference entries, and usage examples
- Add 4 pytest test files for skills that lacked dedicated coverage (arc-compacting, arc-looping, arc-managing-sessions, arc-researching)
- Bump hooks/package.json version from 1.0.0 to 1.2.0 to match root
- Fix outdated references in architecture-overview.txt, hooks/README.md, and CONTRIBUTING.md

## Test plan

- [x] `npm run test:skills` — all 160 pytest tests pass (20 new)
- [x] `npm run lint` — no new warnings
- [x] `npm test` — all 4 test runners pass
- [x] skills-reference.md has 29 detailed entries matching 29 category table entries
- [x] cli-reference.txt documents all 14 commands (10 existing + 4 new)