### PR TITLE
fix(skills): arc-maintaining-obsidian operational robustness

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arcforge",
   "description": "Skill-based workflow engine for AI coding agents: planning, TDD, worktree orchestration, and session learning",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Gregory Ho"
   },

--- a/.opencode/plugins/arcforge.js
+++ b/.opencode/plugins/arcforge.js
@@ -79,7 +79,7 @@ ${content}
 
 export default {
   name: 'arcforge',
-  version: '1.3.0',
+  version: '1.3.1',
 
   'experimental.chat.system.transform': async (_input, output) => {
     const bootstrap = getBootstrapContent();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.3.1] - 2026-04-08
+
+### Fixed
+
+- **arc-maintaining-obsidian**: Added Mode Entry Gate — each mode (ingest/query/audit) must read its reference file before executing, preventing improvised schemas and missed pipeline steps
+- **arc-maintaining-obsidian**: Raw Source ingest now enforces "raw first, wiki second" — saves immutable original to `Raw/` before creating the wiki Source note, preserving the ability to re-extract and verify
+- **arc-maintaining-obsidian**: URL extraction defaults to Defuddle over WebFetch — WebFetch returns AI-interpreted HTML while Defuddle renders in a real browser and extracts clean markdown faithful to the original
+- **arc-maintaining-obsidian**: Vault-only answers now extend to surrounding commentary — no general knowledge backfill in framing, insights, or comparisons around vault results
+- **arc-maintaining-obsidian**: LINT now requires verify-before-fix — findings are hypotheses, not facts; must read the actual file before acting on reported issues
+- **arc-maintaining-obsidian**: LINT warns about YAML multi-line list false positives — `tags:` with no inline value is not empty if followed by indented `  -` items
+- **arc-maintaining-obsidian**: Added broken wikilink resolution strategy — checks Raw Source backing, reference count, and offers plain text conversion instead of creating unsourced stub entities
+- **arc-maintaining-obsidian**: Excalidraw `.md` drawings (with `excalidraw-plugin: parsed` frontmatter) now correctly skipped during LINT audit
+- **arc-maintaining-obsidian**: Raw Source frontmatter template added (`source_url`, `source_author`, `fetched`) for traceability of immutable originals
+
 ## [1.3.0] - 2026-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcforge",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Skill-based autonomous agent toolkit for Claude Code, Codex, Gemini CLI, and OpenCode",
   "license": "MIT",
   "author": {

--- a/skills/arc-maintaining-obsidian/SKILL.md
+++ b/skills/arc-maintaining-obsidian/SKILL.md
@@ -77,6 +77,7 @@ Delegate format correctness to kepano's skills — this skill knows the workflow
 - Canvas creation → `obsidian:json-canvas`
 - Vault operations → `obsidian:obsidian-cli`
 - Excalidraw diagrams → `arc-diagramming-obsidian`
+- URL content extraction → `obsidian:defuddle` (Defuddle first, WebFetch only for APIs/raw text)
 
 **obsidian-cli path safety:** Use `file=` (name-based, like wikilinks) for notes with special characters (`&`, spaces, CJK). Use `path=` only for clean paths without shell-sensitive characters.
 

--- a/skills/arc-maintaining-obsidian/SKILL.md
+++ b/skills/arc-maintaining-obsidian/SKILL.md
@@ -21,6 +21,20 @@ Determine the mode from user intent:
 
 When intent is ambiguous, ask: "Do you want to create a note, search your vault, or run an audit?"
 
+### Mode Entry Gate
+
+Each mode depends on reference knowledge that isn't in the SKILL.md body — extraction methods, search strategies, audit checks. Reading the wrong reference (or none) causes cascading errors: wrong schemas, skipped pipeline steps, mishandled sources.
+
+Before executing any mode, read its reference file:
+
+| Mode | Read first | What it provides |
+|---|---|---|
+| **Ingest** | `references/page-templates.md` | Frontmatter schemas, extraction methods per file type, Raw Source ingest flow |
+| **Query** | `references/search-strategies.md` | Search strategy by question type, output format adaptation |
+| **Audit** | `references/audit-checks.md` | Full check list, GROW thresholds, EVOLVE checks |
+
+This is a gate, not a suggestion — the reference file contains information the mode needs to execute correctly. Skip it and you'll improvise schemas, miss pipeline steps, or use the wrong extraction method.
+
 ## Shared Context
 
 ### Vault Path
@@ -106,7 +120,12 @@ Apply the template from `references/page-templates.md`, write to vault. Write re
 - Tier 2 (spatial): Canvas — delegate to `json-canvas`
 - Tier 3 (visual): Excalidraw — delegate to `arc-diagramming-obsidian`
 
-**Raw Source Ingest:** Non-Markdown files (Excalidraw, PDF, HTML, images, URLs) are detected, extracted, and ingested as Source notes. Originals stay immutable. Read `references/page-templates.md` for extraction methods.
+**Raw Source Ingest — Raw first, wiki second.** When the source is a URL, file, or non-Markdown artifact, the pipeline has two distinct writes:
+
+1. **Save the raw content** to `Raw/` (or leave it where it is if already in the vault). This is the immutable original — the thing you can diff against later when the source is updated.
+2. **Create the wiki Source note** with `source_url` pointing back to the Raw file. This is your summary and extraction — the wiki layer's interpretation of the original.
+
+Skipping step 1 and writing directly to the wiki layer conflates "what the source said" with "what I understood" — and you lose the ability to re-extract or verify later. See `references/page-templates.md` for extraction methods per file type and the exact `source_url` schema.
 
 ### Propagate
 
@@ -152,7 +171,7 @@ Orient → Search → Read → Synthesize → (File Back)
 
 Read `references/search-strategies.md` for output format adaptation (prose, tables, timelines, Marp, Canvas).
 
-**Vault-only answers.** Never fall back to general knowledge. Missing knowledge is a gap signal: *"Your vault has no notes about X. Want to add sources via ingest?"* Gaps feed the audit GROW cycle.
+**Vault-only answers — including surrounding commentary.** Never fall back to general knowledge, not just in the direct answer but in any framing, insights, or comparisons you provide around it. If the vault has notes on topic A but not topic B, don't fill in B from general knowledge and present a comparison — that creates a false sense of completeness. Instead, name the gap: *"Your vault covers A but has nothing on B. Want to add sources for B via ingest?"* Gaps feed the audit GROW cycle and are more valuable surfaced than papered over.
 
 ### File Back
 

--- a/skills/arc-maintaining-obsidian/SKILL.md
+++ b/skills/arc-maintaining-obsidian/SKILL.md
@@ -184,6 +184,14 @@ Only LINK modifies existing notes. LINT and GROW never modify.
 
 Read `references/audit-checks.md` for the full check list. Core checks: schema compliance, orphan detection, stale sources, tag hygiene, untyped notes, index.md generation, log.md consistency, and EVOLVE checks (field usage analysis, type fit analysis, tag drift).
 
+**Verify before fix:** LINT findings are hypotheses, not facts. Before fixing any reported issue, read the actual file to confirm. Common false positive: YAML multi-line lists (`tags:\n  - a\n  - b`) look empty to line-by-line extraction but contain values on subsequent indented lines. Always verify frontmatter by reading the file, not by trusting extraction output.
+
+**Broken wikilink resolution:** When LINT finds links to non-existent notes, choose based on context:
+- **Has Raw Source backing** → create the entity via ingest (the link reflects real knowledge)
+- **No Raw Source, referenced from 3+ notes** → flag for user decision (may warrant a new source)
+- **No Raw Source, referenced from 1-2 notes** → convert to plain text (preserves relationship without creating unsourced stubs)
+Never create stub entity notes without source backing — these were identified as an anti-pattern in prior audits.
+
 LINT generates/updates `index.md` in vault root — organized by page type, one wikilink per note with summary. This is what query mode reads first in Orient.
 
 ### GROW — Gap Analysis

--- a/skills/arc-maintaining-obsidian/references/audit-checks.md
+++ b/skills/arc-maintaining-obsidian/references/audit-checks.md
@@ -10,6 +10,7 @@ The auditor operates on the **wiki layer** — plain Markdown notes (`.md`) that
 ### What to skip
 - **Plugin-managed folders** — Detect dynamically. If the Excalidraw plugin is installed, read its script folder via `obsidian eval code="app.plugins.plugins['obsidian-excalidraw-plugin'].settings.scriptFolderPath"` and exclude that folder. Apply the same pattern for any plugin that stores non-note files.
 - **Raw Source files** — Non-Markdown files (`.excalidraw.md`, `.html`, `.pdf`, `.png`, `.jpg`, `.canvas`) are Raw Sources, not wiki-layer notes.
+- **Excalidraw drawings stored as `.md`** — Some Excalidraw drawings use plain `.md` extension instead of `.excalidraw.md`. Detect by checking frontmatter for `excalidraw-plugin: parsed`. These are Raw Sources, not wiki-layer notes — skip them in LINT and exclude from the index. During GROW, treat them the same as `.excalidraw.md` files (check for un-ingested content via `## Text Elements`).
 
 ## LINK Checks
 
@@ -36,6 +37,18 @@ When invoked with `link --file=<path>`, run LINK on only that one note. Same res
   - Synthesis: `type`, `created`, `sources`, `tags`, `aliases`
   - MOC: `type`, `created`, `scope`, `tags`, `aliases`
   - Decision: `type`, `created`, `status`, `tags`, `aliases`
+
+**YAML format caution:** Obsidian uses two equivalent list formats. Both are valid — check for both before reporting "missing" or "empty" fields:
+```yaml
+# Inline (single line)
+tags: [arcforge, tdd]
+
+# Block (multi-line, indented with -)
+tags:
+  - arcforge
+  - tdd
+```
+A field like `tags:` with no inline value is NOT empty if the next lines are indented `  - ` items. Read the full frontmatter block, not just the key's line.
 
 ### Orphan Detection
 - Notes with zero inbound or outbound links

--- a/skills/arc-maintaining-obsidian/references/page-templates.md
+++ b/skills/arc-maintaining-obsidian/references/page-templates.md
@@ -143,6 +143,24 @@ Logs do not create a new file. Append to daily note via obsidian-cli:
 
 ## Raw Source Ingest
 
+### Raw Source Frontmatter
+
+Raw Sources are immutable originals, but they need minimal metadata for traceability. When saving a new Raw Source to the vault, include this frontmatter:
+
+```yaml
+---
+source_url: ""
+source_author: ""
+fetched: YYYY-MM-DD
+---
+```
+
+- `source_url` — Original URL or "local" for files already in the vault
+- `source_author` — Author or organization name
+- `fetched` — Date the content was captured (not the content's publication date)
+
+The body is the raw content exactly as extracted — no summarization, no restructuring. The Wiki-layer Source note handles interpretation.
+
 ### What is a Raw Source?
 
 In Karpathy's model, anything that isn't a typed wiki-layer Markdown note is a Raw Source — immutable originals that should be ingested into the wiki layer as text. Common types:
@@ -163,8 +181,10 @@ In Karpathy's model, anything that isn't a typed wiki-layer Markdown note is a R
 | `.html` | Use `defuddle` skill or read raw HTML |
 | `.pdf` | Read with Claude's PDF reader |
 | `.png` / `.jpg` | Describe with Claude's vision |
-| URL | Use `defuddle` skill or WebFetch |
+| URL | **Defuddle first** (`defuddle parse <url> --md`). Only fall back to WebFetch for APIs or raw text endpoints. |
 | `.md` (in Raw/) | Read full content — already markdown, no extraction needed |
+
+**Why Defuddle over WebFetch for URLs:** WebFetch fetches raw HTML and runs it through an AI summarization layer — the output is AI-interpreted, not the original content. For SPA/client-rendered sites (React, Obsidian docs, etc.) it often gets only the JavaScript shell. Defuddle renders the page in a real browser and extracts the DOM as clean markdown, preserving tables, code blocks, and structure without AI interpretation. Raw Sources must be faithful to the original — AI-processed content defeats the purpose of an immutable source layer.
 
 ### Ingest Output
 

--- a/tests/skills/test_skill_arc_maintaining_obsidian.py
+++ b/tests/skills/test_skill_arc_maintaining_obsidian.py
@@ -224,6 +224,46 @@ def test_audit_has_batch_mode():
     assert "--all" in text
 
 
+# --- LINT Operational Robustness ---
+
+
+def test_lint_has_verify_before_fix():
+    """LINT must require verification of findings before applying fixes."""
+    text = _read_skill().lower()
+    has_verify = "verify before fix" in text or "verify" in text and "before fix" in text
+    assert has_verify, "LINT must warn to verify findings before acting on them"
+
+
+def test_lint_warns_about_yaml_multiline_format():
+    """LINT must warn about YAML multi-line list format false positives."""
+    ref = _read_reference("audit-checks.md").lower()
+    has_yaml_warning = "multi-line" in ref or "multiline" in ref or "block" in ref
+    has_indent_note = "indent" in ref or "  -" in ref
+    assert has_yaml_warning, "audit-checks must warn about YAML multi-line format"
+    assert has_indent_note, "audit-checks must show indented list syntax"
+
+
+def test_lint_has_broken_link_resolution_strategy():
+    """LINT must provide decision criteria for broken wikilinks."""
+    text = _read_skill().lower()
+    has_raw_source_check = "raw source" in text and ("backing" in text or "backed" in text)
+    has_plain_text_option = "plain text" in text or "convert to plain" in text
+    assert has_raw_source_check, "broken link resolution must check for Raw Source backing"
+    assert has_plain_text_option, "broken link resolution must offer plain text conversion"
+
+
+def test_lint_prohibits_unsourced_stub_entities():
+    """LINT must not create entity notes without source backing."""
+    text = _read_skill().lower()
+    has_prohibition = (
+        "never create stub" in text
+        or "without source backing" in text
+        or "unsourced stub" in text
+        or "anti-pattern" in text
+    )
+    assert has_prohibition, "LINT must prohibit creating stub entities without sources"
+
+
 # --- Shared Context ---
 
 


### PR DESCRIPTION
## Summary

- **Mode Entry Gate**: each mode (ingest/query/audit) must read its reference file before executing — prevents improvised schemas and missed pipeline steps
- **Raw-first ingest**: enforces two-step write (save immutable original to `Raw/`, then create wiki Source note) — preserves re-extraction and verification ability
- **Defuddle-first URL extraction**: defaults to Defuddle over WebFetch for faithful raw content extraction from rendered pages
- **Vault-only commentary scope**: no general knowledge backfill in framing, insights, or comparisons — name the gap instead
- **LINT verify-before-fix**: findings are hypotheses; must read actual file before acting (catches YAML multi-line list false positives)
- **Broken wikilink resolution**: checks Raw Source backing and reference count; offers plain text conversion instead of creating unsourced stub entities
- **Excalidraw `.md` detection**: skip drawings with `excalidraw-plugin: parsed` frontmatter during LINT audit
- **Raw Source frontmatter template**: `source_url`, `source_author`, `fetched` fields for traceability
- **Version bump**: 1.3.0 → 1.3.1 across plugin.json, package.json, arcforge.js

## Test plan

- [ ] `npm test` — all 4 runners pass (217 tests)
- [ ] `npm run lint` — no errors
- [ ] New pytest tests cover: verify-before-fix, YAML multiline warning, broken link resolution, unsourced stub prohibition