### PR TITLE
fix: consolidate arcforge state under ~/.arcforge/ (v1.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "arcforge",
       "description": "Skill-based workflow engine for AI coding agents: planning, TDD, worktree orchestration, and session learning",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "source": "./",
       "author": {
         "name": "Gregory Ho"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arcforge",
   "description": "Skill-based workflow engine for AI coding agents: planning, TDD, worktree orchestration, and session learning",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Gregory Ho"
   },

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -14,7 +14,7 @@ No database. All state as YAML, JSON, JSONL, or Markdown files:
 
 Epics run in their own git worktrees, each tracked via an `.arcforge-epic`
 marker file. Worktrees live at a home-based canonical location
-(`~/.arcforge-worktrees/<project>-<hash>-<epic>/`) computed by
+(`~/.arcforge/worktrees/<project>-<hash>-<epic>/`) computed by
 `scripts/lib/worktree-paths.js`; never hardcode worktree paths in skills,
 rules, or tests. See `docs/guide/worktree-workflow.md` for the full
 derivation rules and `skills/arc-using/SKILL.md` for the agent Worktree Rule.
@@ -68,5 +68,5 @@ agents/           # Specialized subagent definitions
 docs/             # Design docs, platform guides
 ```
 
-Worktrees live outside the repo at `~/.arcforge-worktrees/` — derived by
+Worktrees live outside the repo at `~/.arcforge/worktrees/` — derived by
 `scripts/lib/worktree-paths.js`, not a tracked directory.

--- a/.claude/skills/arc-releasing/SKILL.md
+++ b/.claude/skills/arc-releasing/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: arc-releasing
+description: Use this skill whenever the user (an arcforge contributor) says they want to bump arcforge's version, cut a release, "ship vX.Y.Z", "準備發版", "ready to release", or any equivalent intent on the arcforge repo itself — even if they don't use the word "release". Runs the canonical release workflow: pre-flight checks → vault ingest → outdated-doc audit → CHANGELOG → 5-file version bump → commit/push/PR → post-merge tag. Contributor-only; do NOT trigger inside projects that merely install arcforge as a plugin.
+---
+
+# arc-releasing
+
+You are helping an arcforge contributor ship a new version. The goal of this skill is zero silent drift between the canonical version files, the CHANGELOG, shipped documentation, and the Obsidian vault knowledge base. Those four surfaces get out of sync surprisingly easily — a prior release (v1.4.0) discovered that `marketplace.json` had been stuck two versions behind, and v1.4.1 discovered the observer daemon and the JS side had diverged state roots. The checklist below is designed to catch exactly those classes of drift before they ship.
+
+This is a **project-local, contributor-only** skill. It lives in `.claude/skills/` (not the shipped `skills/` directory) because releasing arcforge is a maintainer activity, not a user activity. If you see this skill trigger inside a project that merely *installs* arcforge, something is wrong — stop and tell the user.
+
+## Pre-Flight (before touching anything)
+
+Never start the release workflow on a broken branch.
+
+1. `npm run lint` — exit code 0 (warnings acceptable, errors are not)
+2. `npm test` — all 4 runners green
+3. `git status` clean of unrelated work-in-progress. Untracked lock files or editor droppings that belong in `.gitignore` must be addressed separately, never folded into the release commit
+4. `git log main..HEAD --oneline` — verify the commits listed match the intended release scope
+
+If any pre-flight fails, stop and tell the user. A broken release is worse than a delayed one, because it ships to users through the marketplace cache and is painful to recall.
+
+## Semver Decision — Always Ask the User
+
+Do NOT decide semver level unilaterally. After pre-flight, read `git log main..HEAD --oneline` and any design docs the branch touched, then present the user with the commit list plus a **recommendation** and ask them to confirm:
+
+```
+Here's what's on this branch since last release:
+  <commit list>
+
+Recommendation: patch / minor / major
+
+Reasoning: <why>
+
+Confirm the level before I proceed.
+```
+
+Guidelines for your recommendation:
+
+| Change shape | Suggest |
+|---|---|
+| Backward-compatible fixes, refactors, doc-only updates | **patch** (`1.x.y` → `1.x.y+1`) |
+| New skill, new CLI command, new backward-compatible feature | **minor** (`1.x.y` → `1.x+1.0`) |
+| Breaking change (removed/renamed shipped API, hook contract change, CLI flag rename) | **major** (`x.y.z` → `x+1.0.0`) |
+
+Branch prefix is a hint, not a rule: `fix/*` usually patches but can minor-bump if it added something. The final call is always the user's — your job is to make the call easy to judge, not to make it for them.
+
+## The Checklist
+
+Do these in order. Each step depends on the previous one being correct.
+
+### 1. Ingest the release into the Obsidian vault
+
+Invoke `/arcforge:arc-maintaining-obsidian` in **ingest** mode. Scope depends on the release shape — always propose scope before bulk-processing, because ingest is the most expensive step in the workflow:
+
+| Release shape | Ingest scope |
+|---|---|
+| Patch with an architectural decision inside (e.g., v1.4.1's `~/.arcforge/` consolidation) | Decision note + refresh Source notes whose content substantively changed + propagate + index/log + daily note |
+| Patch with only small fixes | Skip, or just append a single `log.md` entry |
+| Minor release (new skill or feature) | Full sync: new Source notes for new skills/guides, Decision notes for any architectural shifts, update affected MOCs, propagate cross-refs |
+| Major release | Everything above, plus update `MOC-ArcForge.md` to reflect the new surface |
+
+Ingest **before** the version bump. Once the version flips, reconstructing the "why this release existed" narrative for the vault becomes harder — git shows *what* changed, but the reasoning context has moved on.
+
+### 2. Audit outdated documents in shipped surface
+
+Branches that do migrations often miss a file or two. Grep for stale patterns that the branch was *supposed* to eliminate. The specific patterns depend on what the release contained — examples from recent releases:
+
+```bash
+# After a state-path migration:
+grep -rn "~/\.claude/instincts\|~/\.claude/diaryed\|~/\.claude/observations" skills/ docs/guide/ .claude-plugin/ hooks/
+
+# After a worktree path change:
+grep -rn "\.arcforge-worktrees/" skills/ docs/guide/ .claude-plugin/
+
+# Generic: version strings hardcoded outside canonical locations
+grep -rn "<old-version>" skills/ docs/guide/
+```
+
+Also check for renamed helpers, removed CLI flags, or deprecated config keys that the SKILL.md / rules / guides still mention.
+
+**Never rewrite past `CHANGELOG.md` entries.** They are history, and downstream users, the vault's Decision notes, and `git log vPREV..vCURRENT` workflows all depend on them being stable. If a past entry turns out wrong, add a correction inside the *new* release's entry. Stealth edits break provenance.
+
+Out-of-scope for this audit (do not modify):
+- `docs/plans/*` — design history
+- `.claude/rules/*` — contributor rules, not shipped surface
+- Tests that *deliberately blacklist* old patterns — they should still reference the old string, that's how they enforce the new convention
+
+### 3. Update `CHANGELOG.md`
+
+Insert a new section at the top, under the header block, **before** the previous release:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Fixed
+- ...
+
+### Changed
+- ...
+
+### Added
+- ...
+
+### Removed
+- ...
+```
+
+Include only sections that have entries. Order: Fixed → Changed → Added → Removed.
+
+**Write narrative, not file lists.** The reader of this entry six months from now needs to know: what broke, why it broke, how the fix works, and what they can now do (or stop worrying about) as a result. "Updated `session-utils.js`" is useless. "Diary enricher had silently failed for 30 days because Claude Code v2.1.78+ blocks nested Writes inside `~/.claude/` — moved state to `~/.arcforge/`, 91 stubs now enrich" is reference-grade. This is the text that shows up on the marketplace release page; treat it as a user-facing artifact.
+
+### 4. Bump the version in **all 5 canonical locations**
+
+| File | Where in the file |
+|---|---|
+| `package.json` | top-level `"version"` field |
+| `.claude-plugin/plugin.json` | top-level `"version"` field (canonical per `.claude/rules/plugin.md`) |
+| `.claude-plugin/marketplace.json` | `plugins[0].version` |
+| `.opencode/plugins/arcforge.js` | `version:` property inside the default export |
+| `README.md` | version badge URL (shields.io, near line 3) |
+
+Verify with a single grep after bumping:
+
+```bash
+grep -rn "X\.Y\.Z" package.json .claude-plugin/ .opencode/plugins/arcforge.js README.md
+```
+
+Expect **exactly 5 hits**. Fewer means a split-brain bump (dangerous — different platforms disagree about the current version). More means a stale copy elsewhere that also needs attention.
+
+`package-lock.json` top-level `"version"` is known-stale at an older value. Leave it unless you're doing a dedicated lockfile refresh; never combine that with a release commit, since mixed diffs make rollback painful.
+
+### 5. Commit, push, open PR
+
+- Commit message: `chore(release): vX.Y.Z` with a brief body summarizing scope
+- Stage exactly the 6 release files (5 version locations + `CHANGELOG.md`). Avoid `git add -A` — it tends to pull in lock files, editor droppings, and workspace metadata
+- `git push -u origin <branch>`
+- `gh pr create` with a test-plan checklist in the body: 4 runners green, lint green, secret scan clean, canonical 5-location grep returned exactly 5 hits
+
+### 6. After PR merges to main — tag it
+
+Arcforge has tagged every release since `v1.0.0`. Skipping a tag breaks the `git log vPREV..HEAD` workflow that the *next* release relies on to scope its CHANGELOG.
+
+```bash
+git checkout main && git pull
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+If the user is merging via GitHub UI (squash or merge), run the tag commands against `main` after the merge completes — the merge commit on main is what represents the release on the main timeline, not the source branch's tip.
+
+## Things That Are Easy to Forget
+
+These are the steps that get skipped when a contributor is in a hurry. The skill's job is to surface them even when the user doesn't ask:
+
+- **Ingest before bump.** Once the version flips, the "why" narrative is harder to reconstruct for the vault. That's why it's step 1, not step 5.
+- **`.opencode/plugins/arcforge.js`.** The only non-JSON, non-README version location. It doesn't pattern-match "config file" in a search, so it gets missed.
+- **README badge URL.** The shields.io badge is image-cached; stale numbers visually persist even after every other file is correct. Worth an extra explicit mention.
+- **Secret scan.** Release commits are large diffs. `git diff --cached | grep -iE "api[_-]?key|token|secret|password"` before pushing. The cost of a false positive is low; the cost of a committed secret is very high.
+- **Daily note append.** After the release ships, `obsidian daily:append` with a one-line release summary so the release is preserved in the vault's chronological log, not only in `log.md`.
+- **The post-merge tag.** Merging the PR does not auto-tag. This is the single most commonly skipped step.
+
+## Anti-Patterns (from real arcforge release incidents)
+
+- **Silent version drift** — v1.4.0 discovered `.claude-plugin/marketplace.json` had been stuck two versions behind. The 5-location grep is designed to catch exactly this.
+- **Version bump without CHANGELOG entry** — the marketplace release cache is version-keyed. A bump with no CHANGELOG entry ships to users who have no way to tell what changed. The checklist order (CHANGELOG *before* version bump) enforces pairing them.
+- **Editing past CHANGELOG entries** — downstream users and vault Decision notes depend on past entries being stable. Add corrections to the current entry; never stealth-edit the past.
+- **Partial bump shipped** — bumping 3 of 5 locations produces a release where Claude Code, OpenCode, and the marketplace JSON disagree about the current version. Always use the 5-location grep as a post-bump gate.
+- **Mixing release commit with other work** — `chore(release): vX.Y.Z` should be *only* the 6 release files. Unrelated fixes bundled in make bisect and rollback painful. Commit work-in-progress separately *before* the release commit.
+- **Skipping the post-merge tag** — without the tag, the next release can't use `git log vPREV..HEAD` to scope its CHANGELOG. Missing tags cause the *next* release to either drop entries or include already-shipped ones.
+
+## After the Release
+
+- If a new skill was added, verify it appears in `docs/guide/skills-reference.md` and in `MOC-ArcForge-Skills.md` in the vault (the ingest step should have caught this, but a final visual check is cheap)
+- `gh issue list --search "X.Y.Z"` to find issues the release resolves and close them
+- If this was a minor or major release, consider whether any evals need regenerated baselines for the new surface area (see `.claude/rules/eval.md`)

--- a/.claude/skills/arc-releasing/evals/evals.json
+++ b/.claude/skills/arc-releasing/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "arc-releasing",
+  "evals": [
+    {
+      "id": 0,
+      "name": "patch-with-architectural-decision",
+      "prompt": "OK I'm ready to release 1.4.2 on the arcforge repo. I just merged the fix/teammate-pane-leak branch into my fix branch — it has 4 commits. Three of them patch a real bug: teammate tmux panes were leaking after arc-dispatching-teammates runs because the shutdown sequence didn't drain stdout before TeamDelete. The fourth commit is a refactor that moved the pane-tracking state from an in-memory Map to a file-backed JSON at ~/.arcforge/pane-tracker.jsonl so we can diagnose across restarts. The tests all pass, lint is green. Current version is 1.4.1. Walk me through the release.",
+      "expected_output": "The response should (1) confirm pre-flight was verified, (2) present the 4 commits and pause to ask the user to confirm semver level with a recommendation of 'patch' (since the pane-tracker move is an internal refactor, not a breaking change), (3) propose arc-maintaining-obsidian ingest with Decision-note scope for the architectural pane-tracker decision, (4) walk through the CHANGELOG entry, (5) enumerate all 5 version-bump locations explicitly, (6) commit → push → PR, (7) post-merge git tag. Should catch the pane-tracker.jsonl path migration as worth a Decision note.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "minor-new-skill",
+      "prompt": "準備發版 1.5.0. feat/arc-refining-graphs 這個 branch 加了一個新的 skill — arc-refining-graphs，從 design docs 生成 Mermaid 圖表的 workflow skill。SKILL.md 已經寫好了放在 skills/arc-refining-graphs/ 下，有 2 個 reference files 在 references/，還有一個 commands/arc-refining-graphs.md 的 wrapper。docs/guide/skills-reference.md 也更新了。所有測試都過了。版本現在是 1.4.1。幫我 release。",
+      "expected_output": "Response should recognize this is a MINOR bump (new skill added = new feature). Should propose full vault sync: new Source note for the skill, update MOC-ArcForge-Skills.md, possibly propagate to related skill MOCs. CHANGELOG entry under Added should describe the new skill's purpose. All 5 canonical version locations bumped to 1.5.0. Should include post-merge tag v1.5.0. Should verify skills-reference.md update is correctly reflected. Should pause and ask user to confirm semver level is 'minor' before proceeding.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "tiny-doc-fix-patch",
+      "prompt": "I want to bump to 1.4.2. The branch is fix/readme-typos — just one commit that fixes three typos in README.md (one was 'arcfroge' instead of 'arcforge', one was a broken markdown link, one was an extra period). That's literally all that changed. Can we release?",
+      "expected_output": "Response should recognize this is a trivial patch with no architectural content. Vault ingest scope should be 'skip or just log.md entry' — NOT a full decision note, NOT a refresh of multiple Source notes. CHANGELOG entry should go under Fixed with a brief single-bullet entry. All 5 version locations still need bumping (the minimum is still the minimum). Should still suggest the post-merge tag. Should pause for semver confirmation with 'patch' recommendation.",
+      "files": []
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 evals/results/
 .eval-trials/
-.claude/skills/
+# Project-local contributor skills — ignored by default (experimental/workspace).
+# Skills meant to ship in the repo are explicitly allowlisted below.
+.claude/skills/*/
+!.claude/skills/arc-releasing/
 .claude/settings.local.json
 .claude/logs/
 

--- a/.opencode/plugins/arcforge.js
+++ b/.opencode/plugins/arcforge.js
@@ -79,7 +79,7 @@ ${content}
 
 export default {
   name: 'arcforge',
-  version: '1.4.0',
+  version: '1.4.1',
 
   'experimental.chat.system.transform': async (_input, output) => {
     const bootstrap = getBootstrapContent();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.4.1] - 2026-04-15
+
+### Fixed
+
+- **Diary enricher silently failing for ~30 days**: the Stop-hook background enricher (`spawnDiaryEnricher`) could not write to `~/.claude/sessions/...` because Claude Code v2.1.78+ added protection on nested Write tool calls inside `~/.claude/`. The error was invisible because the subprocess's stderr was piped to `'ignore'` and `--max-turns 2` exhausted the agent's budget before it could emit a Write. Result: 91 of 109 diary drafts sat as unenriched stubs. Fix: raise `--max-turns`, stop swallowing stderr, and move diary state to `~/.arcforge/` (see Changed)
+- **Observer daemon split-brain after initial state move**: `observer-daemon.sh` still pointed at `~/.claude/instincts/` and `~/.claude/observations/` while the JS side had moved to `~/.arcforge/`. Daemon wrote lock/log to one tree, the hook read from another; SIGUSR1 coordination was broken and the daemon could not see new observations. Fix: rename `CLAUDE_DIR` → `ARCFORGE_DIR` in the bash daemon and repoint to `~/.arcforge/`
+- **Leaky observer paths in `hooks/observe/main.js`**: the hook was reaching into `getInstinctsRoot()` to rebuild `.last_signal` and `.observer.lock/pid` paths inline — magic strings in hook code waiting to drift. Fix: add `getObserverSignalFile()` and `getObserverPidFile()` to `session-utils.js`; hook now uses the helpers, structural assumption lives in one place
+
+### Changed
+
+- **Consolidated all arcforge-owned state under `~/.arcforge/`**: sessions, diaries, instincts, diaryed, observations, and evolved directories moved from `~/.claude/` in a 3-commit sequence. Introduced `getArcforgeHome()` returning `~/.arcforge/`; deleted the `CLAUDE_DIR` constant entirely. After this, `~/.claude/` no longer holds any arcforge-owned state — Claude Code owns `~/.claude/`, arcforge owns `~/.arcforge/`, with no overlap. Existing user data migrated in place via `mv` (verified: 8 instincts still load from the new location post-migration)
+- Path helpers in `scripts/lib/session-utils.js` now compose on `getArcforgeHome()`: `getProcessedLogPath`, `getObservationsPath`, `getInstinctsDir`, `getInstinctsArchivedDir`, `getGlobalInstinctsDir`, `getInstinctsGlobalIndex`, `getEvolvedLogPath`, and new `getInstinctsRoot` for the daemon coordination dir. `getInstinctsArchivedDir` composes on `getInstinctsDir` (one less repeat of the `<root>/<project>/` structural assumption)
+- `scripts/lib/utils.js` `getDiaryedDir` repoints to `~/.arcforge/diaryed/`; `getSessionsDir` and diary path helpers repoint to `~/.arcforge/sessions/` and `~/.arcforge/diaries/`
+- `scripts/lib/global-index.js` inner loop uses `getInstinctsDir(projName)` instead of reconstructing `path.join(instinctsBase, projName, ...)` — matches the canonical helper pattern
+- `hooks/pre-compact/README.md`, `hooks/session-tracker/README.md`, `hooks/session-tracker/end.js`, `scripts/cli.js`, `scripts/lib/coordinator.js`, `scripts/lib/pending-actions.js`, `scripts/lib/worktree-paths.js`: path references updated to `~/.arcforge/`
+- Skill SKILL.md files updated to reference `~/.arcforge/` paths: `arc-journaling`, `arc-learning`, `arc-managing-sessions`, `arc-observing`, `arc-reflecting`, `arc-using`, `arc-using-worktrees`; plus `arc-dispatching-teammates` baseline/green test fixtures
+- `arc-journaling/scripts/auto-diary.js` and `diary.js`: emit paths under `~/.arcforge/sessions/`
+- `arc-managing-sessions/scripts/sessions.js`: session list/save/load paths repointed
+- `.claude/rules/architecture.md`: Worktree Isolation / `.arcforge-epic` marker section aligned with helper-based path derivation
+- `docs/guide/skills-reference.md`, `docs/guide/worktree-workflow.md`: path references updated
+- Test fixtures under `tests/skills/pressure/`: `arc-finishing-epic-completion-format.md`, `arc-using-path-reconstruction.md`, `arc-using-worktrees-cli-failure.md` use the current path format
+- Minor: `tests/scripts/coordinator-marker-exclude.test.js` — fixed a stale comment referencing the pre-migration `~/.arcforge-worktrees/` path (and a "slinged" typo → "linked")
+
+### Added
+
+- `hooks/session-tracker/inject-context.js` (65 lines): injects session context at session start — part of the diary enricher's unblock (pre-creating the target path so the enricher Write becomes Edit)
+- Diary enricher test coverage: `hooks/__tests__/diary-enricher.test.js` (128 lines, unit) and `hooks/__tests__/diary-enricher-e2e.test.js` (139 lines, E2E). The E2E suite prevents a future silent-failure regression — unit tests would have missed the original bug because the enricher's "failure" was Claude Code's subprocess exiting normally with no Write performed
+
 ## [1.4.0] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arcforge
 
-[![Version](https://img.shields.io/badge/version-1.4.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.1-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI](https://github.com/GregoryHo/arcforge/actions/workflows/ci.yml/badge.svg)](https://github.com/GregoryHo/arcforge/actions/workflows/ci.yml)
 

--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -275,7 +275,7 @@ arcforge's 32 skills are organized into 7 categories:
 
 **Artifacts:**
 - Input: `dag.yaml` (required), `skills/arc-dispatching-teammates/SKILL.md`
-- Output: per-epic worktrees at `~/.arcforge-worktrees/...`, one agent teammate per ready epic, merged epics via each teammate's own finishing step, Final Report with subagent evidence
+- Output: per-epic worktrees at `~/.arcforge/worktrees/...`, one agent teammate per ready epic, merged epics via each teammate's own finishing step, Final Report with subagent evidence
 - Progressive-loading references: `acceptance-and-retry.md`, `spawn-prompt-template.md`, `tmux-timing-race.md`, `wrap-up-sequence.md`
 
 **Related:** arc-planning → **arc-dispatching-teammates** → (per completion: spec-reviewer + verifier subagents); each teammate runs arc-implementing → arc-finishing-epic on its own
@@ -347,7 +347,7 @@ marker writing, and project setup to `scripts/lib/coordinator.js`.
 
 **Artifacts:**
 - Output: worktree at the canonical path
-  (`~/.arcforge-worktrees/<project>-<hash>-<epic>/`), `.arcforge-epic` marker
+  (`~/.arcforge/worktrees/<project>-<hash>-<epic>/`), `.arcforge-epic` marker
   authored by the coordinator, `dag.yaml` epic status updated
 
 For the full derivation rules see
@@ -442,7 +442,7 @@ Rule in `skills/arc-using/SKILL.md`.
 
 ### arc-managing-sessions
 
-**Platform:** Claude Code only — uses Claude Code's session IDs, transcript format, and the `~/.claude/sessions/` directory layout.
+**Platform:** Claude Code only — uses Claude Code's session IDs, transcript format, and the `~/.arcforge/sessions/` directory layout.
 
 **Purpose:** User-controlled session saves for continuity across conversations — save what matters, resume when needed.
 
@@ -455,8 +455,8 @@ Rule in `skills/arc-using/SKILL.md`.
 4. **Alias:** Create friendly names for easy session reference
 
 **Artifacts:**
-- Input: current session data from `~/.claude/sessions/{project}/{date}/{sessionId}.json`
-- Output: `~/.claude/sessions/{project}/{date}/session-{alias}.md`, `aliases.json`
+- Input: current session data from `~/.arcforge/sessions/{project}/{date}/{sessionId}.json`
+- Output: `~/.arcforge/sessions/{project}/{date}/session-{alias}.md`, `aliases.json`
 
 **Related:** any skill --> **arc-managing-sessions** (when continuity is needed)
 
@@ -609,11 +609,11 @@ Rule in `skills/arc-using/SKILL.md`.
 1. Pre-diary check — verify session had non-trivial decisions or challenges
 2. Reflect on conversation from memory (do NOT read files)
 3. Fill template: decisions, preferences, challenges, solutions
-4. Save to `~/.claude/sessions/{project}/{date}/diary-{sessionId}.md`
+4. Save to `~/.arcforge/diaries/{project}/{date}/diary-{sessionId}.md`
 5. Offer follow-up: "run `/reflect` to extract patterns"
 
 **Artifacts:**
-- Output: `~/.claude/sessions/{project}/{YYYY-MM-DD}/diary-{sessionId}.md`
+- Output: `~/.arcforge/diaries/{project}/{YYYY-MM-DD}/diary-{sessionId}.md`
 
 **Related:** **arc-journaling** --> arc-reflecting (after 5+ entries)
 
@@ -633,7 +633,7 @@ Rule in `skills/arc-using/SKILL.md`.
 5. Save reflection + instincts, update processed.log
 
 **Artifacts:**
-- Input: `~/.claude/sessions/{project}/*/diary-*.md`
+- Input: `~/.arcforge/diaries/{project}/*/diary-*.md`
 - Output: `~/.claude/diaryed/{project}/YYYY-MM-reflection-N.md`, instinct files
 
 **Related:** arc-journaling (5+ entries) --> **arc-reflecting** --> arc-learning (instinct clustering)

--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -634,7 +634,7 @@ Rule in `skills/arc-using/SKILL.md`.
 
 **Artifacts:**
 - Input: `~/.arcforge/diaries/{project}/*/diary-*.md`
-- Output: `~/.claude/diaryed/{project}/YYYY-MM-reflection-N.md`, instinct files
+- Output: `~/.arcforge/diaryed/{project}/YYYY-MM-reflection-N.md`, instinct files
 
 **Related:** arc-journaling (5+ entries) --> **arc-reflecting** --> arc-learning (instinct clustering)
 
@@ -647,14 +647,14 @@ Rule in `skills/arc-using/SKILL.md`.
 **When to use:** When you have accumulated instincts and want to cluster related ones into higher-level skills, commands, or agents.
 
 **Key workflow:**
-1. Scan all instincts from `~/.claude/instincts/{project}/` and `global/`
+1. Scan all instincts from `~/.arcforge/instincts/{project}/` and `global/`
 2. Cluster by domain, then by trigger fingerprint similarity (Jaccard >= 0.6)
 3. Filter: only clusters with 3+ instincts, at least 1 with confidence >= 0.6
 4. Preview candidate clusters for user review
 5. Generate: user decides what to create (skill, command, or agent)
 
 **Artifacts:**
-- Input: `~/.claude/instincts/{project}/` and `global/` instinct files
+- Input: `~/.arcforge/instincts/{project}/` and `global/` instinct files
 - Output: new skill, command, or agent definition
 
 **Related:** arc-reflecting --> **arc-learning** --> arc-writing-skills
@@ -663,7 +663,7 @@ Rule in `skills/arc-using/SKILL.md`.
 
 ### arc-observing
 
-**Platform:** Claude Code only — reads Claude Code tool-call observations from `~/.claude/observations/` which is populated by Claude Code PostToolUse hooks.
+**Platform:** Claude Code only — reads Claude Code tool-call observations from `~/.arcforge/observations/` which is populated by Claude Code PostToolUse hooks.
 
 **Purpose:** Manage automatically detected behavioral patterns (instincts) from tool usage observations.
 
@@ -677,8 +677,8 @@ Rule in `skills/arc-using/SKILL.md`.
 5. Loading: instincts with confidence >= 0.7 auto-loaded into context
 
 **Artifacts:**
-- Input: `~/.claude/observations/{project}/observations.jsonl`
-- Output: `~/.claude/instincts/{project}/*.md`
+- Input: `~/.arcforge/observations/{project}/observations.jsonl`
+- Output: `~/.arcforge/instincts/{project}/*.md`
 
 **Related:** automatic background process --> **arc-observing** --> arc-learning
 
@@ -699,7 +699,7 @@ Rule in `skills/arc-using/SKILL.md`.
 
 **Artifacts:**
 - Input: user-described pattern or insight
-- Output: `~/.claude/instincts/{project}/<id>.md`
+- Output: `~/.arcforge/instincts/{project}/<id>.md`
 
 **Related:** user insight --> **arc-recalling** --> instinct saved for arc-observing lifecycle
 

--- a/docs/guide/worktree-workflow.md
+++ b/docs/guide/worktree-workflow.md
@@ -14,13 +14,13 @@ worktrees from polluting the working copy and lets multiple clones of the
 same project coexist without collisions.
 
 ```
-~/.arcforge-worktrees/<project>-<hash>-<epic>/
+~/.arcforge/worktrees/<project>-<hash>-<epic>/
 ```
 
 | Segment    | Source                                    | Example            |
 |------------|-------------------------------------------|--------------------|
 | `~/...`    | `os.homedir()`                            | `/Users/alice`     |
-| `.arcforge-worktrees` | Fixed directory name           | `.arcforge-worktrees` |
+| `.arcforge/worktrees` | Fixed directory name           | `.arcforge/worktrees` |
 | `<project>` | `path.basename(projectRoot)`, sanitized   | `arcforge`         |
 | `<hash>`   | First 6 hex chars of `sha256(projectRoot)` | `3f2a91`          |
 | `<epic>`   | Epic id from `dag.yaml`                    | `epic-001`         |
@@ -64,7 +64,7 @@ synced: null                     # Populated by arc-coordinating sync
 - `arc-coordinating sync` uses it to find the base DAG (`base_worktree`) and
   to carry local status back to it.
 - If the file is missing, the directory is not an arcforge worktree even if
-  it lives under `~/.arcforge-worktrees/`.
+  it lives under `~/.arcforge/worktrees/`.
 - `parseWorktreePath()` in `worktree-paths.js` recognizes the directory by
   the `<project>-<hash>-<epic>` pattern regardless of marker presence — this
   is how `_findBaseWorktree` distinguishes arcforge worktrees from the base.
@@ -90,7 +90,7 @@ which delegates to `git worktree remove <absolute-path>`.
 │                      大型專案開發流程                              │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│   dag.yaml       ~/.arcforge-worktrees/      實作完成             │
+│   dag.yaml       ~/.arcforge/worktrees/      實作完成             │
 │   ┌──────┐      ┌────────────────┐         ┌──────┐              │
 │   │Epic A│─────▶│ <proj>-<h>-a/  │────────▶│Merged│              │
 │   │Epic B│      │ <proj>-<h>-b/  │         │ PR   │              │
@@ -234,7 +234,7 @@ worktree whose base has been moved, or the base checkout was removed. Run
 `git worktree list` and re-add the base with `git worktree add` if needed.
 
 ### Worktree directory exists but `.arcforge-epic` is missing
-This happens when someone ran `git worktree add ~/.arcforge-worktrees/...`
+This happens when someone ran `git worktree add ~/.arcforge/worktrees/...`
 by hand. The directory is invisible to `arc-coordinating sync` (which keys
 off marker files). Either delete it with `git worktree remove` and re-run
 `arcforge expand`, or recreate the marker manually by copying from another

--- a/hooks/__tests__/diary-enricher-e2e.test.js
+++ b/hooks/__tests__/diary-enricher-e2e.test.js
@@ -1,0 +1,139 @@
+/**
+ * Diary Enricher End-to-End Integration Test
+ *
+ * Spawns the REAL claude haiku subprocess against a stub draft and asserts
+ * the draft gets enriched at its new ~/.arcforge/diaries/ location.
+ *
+ * Why this path: Claude Code v2.1.78+ blocks nested `claude` subprocesses
+ * from writing under ~/.claude/* even with --dangerously-skip-permissions.
+ * Drafts moved to ~/.arcforge/diaries/ so the enricher can write them.
+ *
+ * Opt-in: set ENRICHER_E2E=1 to run. Requires:
+ *  - `claude` CLI on PATH
+ *  - Anthropic API credit (one haiku call per run)
+ *  - Network access
+ *
+ * Runtime: ~30-90s per trial.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const RUN_E2E = process.env.ENRICHER_E2E === '1';
+const POLL_INTERVAL_MS = 1000;
+const TIMEOUT_MS = 180_000;
+
+const STUB_DRAFT = `# Session Diary: e2e-test
+
+**Date:** 2026-04-15
+**Session ID:** session-e2e-test-fixture
+
+## Session Metrics
+
+- **Duration**: ~5 minutes
+- **Tool calls**: 42
+- **User messages**: 3
+
+## Decisions Made
+
+<!-- TO BE ENRICHED — Fill from conversation memory -->
+-
+
+## User Preferences Observed
+
+<!-- TO BE ENRICHED — What preferences did the user express? -->
+-
+
+## Challenges & Solutions
+
+<!-- TO BE ENRICHED — What went wrong and how was it resolved? -->
+- **Challenge**:
+- **Solution**:
+- **Generalizable?**: Yes/No
+
+## Completed
+
+<!-- TO BE ENRICHED — What was accomplished this session? -->
+-
+
+## In Progress
+
+<!-- TO BE ENRICHED — What's still ongoing? -->
+-
+
+## Context for Next Session
+
+<!-- TO BE ENRICHED — What context would help next time? -->
+-
+`;
+
+async function waitForEnrichment(draftPath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(draftPath)) {
+      const content = fs.readFileSync(draftPath, 'utf-8');
+      if (!content.includes('TO BE ENRICHED')) return content;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return null;
+}
+
+describe('E2E: diary enricher full spawn cycle', { skip: !RUN_E2E }, () => {
+  it('enriches a stub draft via real claude haiku subprocess', async () => {
+    // Write under real $HOME so `claude` CLI can find its own config/auth.
+    // Isolate via a unique project name so cleanup is scoped.
+    const project = `e2e-enricher-test-${process.pid}-${Date.now()}`;
+    const date = '2026-04-15';
+    const sessionId = 'session-e2e-test-fixture';
+    const diariesProjectDir = path.join(os.homedir(), '.arcforge', 'diaries', project);
+    const diariesDateDir = path.join(diariesProjectDir, date);
+    const sessionsProjectDir = path.join(os.homedir(), '.arcforge', 'sessions', project);
+    fs.mkdirSync(diariesDateDir, { recursive: true });
+    fs.mkdirSync(sessionsProjectDir, { recursive: true });
+
+    try {
+      const draftPath = path.join(diariesDateDir, `diary-${sessionId}-draft.md`);
+      fs.writeFileSync(draftPath, STUB_DRAFT);
+
+      const { spawnDiaryEnricher } = require('../session-tracker/end');
+
+      const session = {
+        project,
+        sessionId,
+        date,
+        started: '2026-04-15T10:00:00Z',
+        lastUpdated: '2026-04-15T10:05:00Z',
+        userMessages: 3,
+        toolCalls: 42,
+        filesModified: ['/tmp/example.js'],
+        userMessageContent: ['fix the auth bug', 'rerun tests', 'ship it'],
+        toolsUsed: ['Read', 'Edit', 'Bash'],
+      };
+
+      spawnDiaryEnricher(draftPath, session);
+
+      const enriched = await waitForEnrichment(draftPath, TIMEOUT_MS);
+      const logPath = path.join(sessionsProjectDir, 'enricher.log');
+      const logTail = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf-8').slice(-500) : '';
+      assert.ok(
+        enriched,
+        `Draft was not enriched within ${TIMEOUT_MS}ms. Content still contains "TO BE ENRICHED".\n` +
+          `enricher.log tail:\n${logTail}`,
+      );
+
+      assert.ok(enriched.includes('## Session Metrics'), 'metrics section should survive');
+      assert.ok(
+        enriched.includes('Tool calls'),
+        'auto-generated metrics should survive enrichment',
+      );
+      assert.ok(fs.existsSync(logPath), 'enricher.log should exist (stderr capture working)');
+    } finally {
+      fs.rmSync(diariesProjectDir, { recursive: true, force: true });
+      fs.rmSync(sessionsProjectDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/diary-enricher.test.js
+++ b/hooks/__tests__/diary-enricher.test.js
@@ -1,0 +1,128 @@
+/**
+ * Diary Enricher Regression Tests
+ *
+ * Guards the fixes for the silent enrichment failure discovered 2026-04-15:
+ * - end.js spawnDiaryEnricher used --max-turns 2 (insufficient → "Reached max turns").
+ * - end.js piped enricher stderr to 'ignore' (silent failure invisible for ~30 days).
+ * - inject-context.js never warned about stale unenriched drafts.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const END_JS = path.join(__dirname, '..', 'session-tracker', 'end.js');
+
+// ─────────────────────────────────────────────
+// end.js: spawnDiaryEnricher invocation hardening
+// ─────────────────────────────────────────────
+
+describe('spawnDiaryEnricher invocation', () => {
+  const source = fs.readFileSync(END_JS, 'utf-8');
+
+  it('uses --max-turns >= 5 (haiku needs room to read AND write)', () => {
+    const match = source.match(/'--max-turns',\s*'(\d+)'/);
+    assert.ok(match, 'spawnDiaryEnricher must pass --max-turns');
+    const turns = parseInt(match[1], 10);
+    assert.ok(
+      turns >= 5,
+      `--max-turns must be at least 5 to allow Read+Write turns (got ${turns}). ` +
+        '2 was the broken default — caused "Reached max turns (2)" silent failure.',
+    );
+  });
+
+  it('does not silently discard enricher stderr', () => {
+    // Find the spawn(...) call body
+    const spawnIdx = source.indexOf('spawn(');
+    assert.ok(spawnIdx !== -1, 'expected spawn(...) call');
+    const tail = source.slice(spawnIdx, spawnIdx + 1500);
+    const stdioMatch = tail.match(/stdio:\s*\[([^\]]+)\]/);
+    assert.ok(stdioMatch, 'expected stdio array on spawn');
+    const stdioPositions = stdioMatch[1].split(',').map((s) => s.trim());
+    const stderrPosition = stdioPositions[2];
+    assert.ok(
+      stderrPosition && stderrPosition !== "'ignore'" && stderrPosition !== '"ignore"',
+      `stderr (stdio[2]) must NOT be 'ignore' — silent failure regression. Got: ${stderrPosition}`,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────
+// inject-context.js: stale-draft healthcheck
+// ─────────────────────────────────────────────
+
+describe('inject-context.js stale-draft healthcheck', () => {
+  it('exports loadStaleDraftWarning', () => {
+    delete require.cache[require.resolve('../session-tracker/inject-context')];
+    const mod = require('../session-tracker/inject-context');
+    assert.ok(
+      typeof mod.loadStaleDraftWarning === 'function',
+      'loadStaleDraftWarning should be exported',
+    );
+  });
+
+  it('returns null when no project sessions dir exists', () => {
+    delete require.cache[require.resolve('../session-tracker/inject-context')];
+    const { loadStaleDraftWarning } = require('../session-tracker/inject-context');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'test-stale-empty-'));
+    const originalHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      const result = loadStaleDraftWarning('nonexistent-project');
+      assert.strictEqual(result, null);
+    } finally {
+      process.env.HOME = originalHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when drafts exist but are all enriched', () => {
+    delete require.cache[require.resolve('../session-tracker/inject-context')];
+    const { loadStaleDraftWarning } = require('../session-tracker/inject-context');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'test-stale-clean-'));
+    const originalHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      const dir = path.join(tmp, '.arcforge', 'diaries', 'demo', '2026-04-15');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'diary-session-aaa-draft.md'),
+        '# Diary\n\n## Decisions\n- did stuff\n',
+      );
+      const result = loadStaleDraftWarning('demo');
+      assert.strictEqual(result, null);
+    } finally {
+      process.env.HOME = originalHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a warning when 1+ drafts contain TO BE ENRICHED', () => {
+    delete require.cache[require.resolve('../session-tracker/inject-context')];
+    const { loadStaleDraftWarning } = require('../session-tracker/inject-context');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'test-stale-stub-'));
+    const originalHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      const dir = path.join(tmp, '.arcforge', 'diaries', 'demo', '2026-04-15');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'diary-session-bbb-draft.md'),
+        '# Diary\n\n## Decisions\n<!-- TO BE ENRICHED -->\n- \n',
+      );
+      fs.writeFileSync(
+        path.join(dir, 'diary-session-ccc-draft.md'),
+        '# Diary\n\n## Decisions\n<!-- TO BE ENRICHED -->\n- \n',
+      );
+      const result = loadStaleDraftWarning('demo');
+      assert.ok(result && typeof result === 'object', 'expected warning object');
+      assert.strictEqual(result.count, 2);
+      assert.ok(result.message && /2/.test(result.message), 'message should mention count');
+    } finally {
+      process.env.HOME = originalHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/e2e-hooks.test.js
+++ b/hooks/__tests__/e2e-hooks.test.js
@@ -279,7 +279,7 @@ describe('E2E: session-tracker/start.js', () => {
 
     // Verify session file was created
     const projectName = path.basename(testDir);
-    const sessionsBase = path.join(testDir, '.claude', 'sessions', projectName);
+    const sessionsBase = path.join(testDir, '.arcforge', 'sessions', projectName);
     if (fs.existsSync(sessionsBase)) {
       const dateDirs = fs.readdirSync(sessionsBase);
       assert.ok(dateDirs.length > 0, 'Should have a date directory');
@@ -615,7 +615,7 @@ describe('E2E: pre-compact/main.js', () => {
 
     // Check compaction log was written
     const projectName = path.basename(testDir);
-    const logPath = path.join(testDir, '.claude', 'sessions', projectName, 'compaction-log.txt');
+    const logPath = path.join(testDir, '.arcforge', 'sessions', projectName, 'compaction-log.txt');
     if (fs.existsSync(logPath)) {
       const content = fs.readFileSync(logPath, 'utf-8');
       assert.ok(

--- a/hooks/__tests__/e2e-hooks.test.js
+++ b/hooks/__tests__/e2e-hooks.test.js
@@ -156,7 +156,7 @@ describe('E2E: session-tracker/inject-context.js', () => {
 
   it('should inject high-confidence instincts into stdout', () => {
     const projectName = path.basename(testDir);
-    const instinctsDir = path.join(testDir, '.claude', 'instincts', projectName);
+    const instinctsDir = path.join(testDir, '.arcforge', 'instincts', projectName);
     fs.mkdirSync(instinctsDir, { recursive: true });
     fs.writeFileSync(
       path.join(instinctsDir, 'test-instinct.md'),
@@ -186,7 +186,7 @@ describe('E2E: session-tracker/inject-context.js', () => {
 
   it('should NOT inject instincts below 0.70 threshold', () => {
     const projectName = path.basename(testDir);
-    const instinctsDir = path.join(testDir, '.claude', 'instincts', projectName);
+    const instinctsDir = path.join(testDir, '.arcforge', 'instincts', projectName);
     fs.mkdirSync(instinctsDir, { recursive: true });
     fs.writeFileSync(
       path.join(instinctsDir, 'low.md'),
@@ -216,7 +216,7 @@ describe('E2E: session-tracker/inject-context.js', () => {
 
   it('should output both systemMessage and hookSpecificOutput for high-confidence instincts', () => {
     const projectName = path.basename(testDir);
-    const instinctsDir = path.join(testDir, '.claude', 'instincts', projectName);
+    const instinctsDir = path.join(testDir, '.arcforge', 'instincts', projectName);
     fs.mkdirSync(instinctsDir, { recursive: true });
     fs.writeFileSync(
       path.join(instinctsDir, 'dual-test.md'),

--- a/hooks/__tests__/learning-unification.test.js
+++ b/hooks/__tests__/learning-unification.test.js
@@ -264,8 +264,8 @@ describe('pending-actions create + consume flow', () => {
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-pending-actions-'));
     process.env.HOME = testDir;
-    // Create the .claude/sessions directory
-    fs.mkdirSync(path.join(testDir, '.claude', 'sessions', 'test-project'), { recursive: true });
+    // Create the arcforge sessions directory (where pending-actions.json lives)
+    fs.mkdirSync(path.join(testDir, '.arcforge', 'sessions', 'test-project'), { recursive: true });
     delete require.cache[require.resolve('../../scripts/lib/pending-actions')];
   });
 

--- a/hooks/__tests__/learning-unification.test.js
+++ b/hooks/__tests__/learning-unification.test.js
@@ -23,10 +23,10 @@ describe('instinct-writer creates correct frontmatter', () => {
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-instinct-writer-'));
-    // Point CLAUDE_DIR (via HOME) to our temp dir so getInstinctsDir resolves there
+    // Point HOME to our temp dir so getInstinctsDir resolves there
     process.env.HOME = testDir;
-    // Create the .claude/instincts/test-project directory
-    fs.mkdirSync(path.join(testDir, '.claude', 'instincts', 'test-project'), { recursive: true });
+    // Create the arcforge instincts directory
+    fs.mkdirSync(path.join(testDir, '.arcforge', 'instincts', 'test-project'), { recursive: true });
     // Clear module caches so session-utils picks up new HOME
     delete require.cache[require.resolve('../../scripts/lib/session-utils')];
     delete require.cache[require.resolve('../../scripts/lib/instinct-writer')];

--- a/hooks/__tests__/observe.test.js
+++ b/hooks/__tests__/observe.test.js
@@ -105,12 +105,12 @@ describe('observe: getPidFile', () => {
     );
   });
 
-  it('should be under .claude/instincts/', () => {
+  it('should be under .arcforge/instincts/', () => {
     const { getPidFile } = require('../observe/main');
     const result = getPidFile();
     assert.ok(
-      result.includes('.claude') && result.includes('instincts'),
-      `Expected .claude/instincts/ in path, got: ${result}`,
+      result.includes('.arcforge') && result.includes('instincts'),
+      `Expected .arcforge/instincts/ in path, got: ${result}`,
     );
   });
 });

--- a/hooks/__tests__/pre-compact.test.js
+++ b/hooks/__tests__/pre-compact.test.js
@@ -13,7 +13,7 @@ describe('pre-compact: logCompactionEvent', () => {
     process.env.HOME = testDir;
     process.env.CLAUDE_SESSION_ID = 'test-precompact-session';
     // Create sessions directory
-    fs.mkdirSync(path.join(testDir, '.claude', 'sessions', 'test-project'), { recursive: true });
+    fs.mkdirSync(path.join(testDir, '.arcforge', 'sessions', 'test-project'), { recursive: true });
     delete require.cache[require.resolve('../pre-compact/main')];
     delete require.cache[require.resolve('../../scripts/lib/utils')];
   });
@@ -28,7 +28,13 @@ describe('pre-compact: logCompactionEvent', () => {
     const { logCompactionEvent } = require('../pre-compact/main');
     logCompactionEvent('test-project', '2025-01-15T10:00:00Z', 'session-123');
 
-    const logPath = path.join(testDir, '.claude', 'sessions', 'test-project', 'compaction-log.txt');
+    const logPath = path.join(
+      testDir,
+      '.arcforge',
+      'sessions',
+      'test-project',
+      'compaction-log.txt',
+    );
     assert.ok(fs.existsSync(logPath), 'compaction-log.txt should exist');
   });
 
@@ -36,7 +42,13 @@ describe('pre-compact: logCompactionEvent', () => {
     const { logCompactionEvent } = require('../pre-compact/main');
     logCompactionEvent('test-project', '2025-01-15T10:00:00Z', 'session-123');
 
-    const logPath = path.join(testDir, '.claude', 'sessions', 'test-project', 'compaction-log.txt');
+    const logPath = path.join(
+      testDir,
+      '.arcforge',
+      'sessions',
+      'test-project',
+      'compaction-log.txt',
+    );
     const content = fs.readFileSync(logPath, 'utf-8');
     assert.ok(content.includes('2025-01-15T10:00:00Z'), 'should contain timestamp');
     assert.ok(content.includes('session-123'), 'should contain session ID');
@@ -47,7 +59,13 @@ describe('pre-compact: logCompactionEvent', () => {
     logCompactionEvent('test-project', '2025-01-15T10:00:00Z', 'session-1');
     logCompactionEvent('test-project', '2025-01-15T11:00:00Z', 'session-2');
 
-    const logPath = path.join(testDir, '.claude', 'sessions', 'test-project', 'compaction-log.txt');
+    const logPath = path.join(
+      testDir,
+      '.arcforge',
+      'sessions',
+      'test-project',
+      'compaction-log.txt',
+    );
     const content = fs.readFileSync(logPath, 'utf-8');
     assert.ok(content.includes('session-1'), 'should contain first entry');
     assert.ok(content.includes('session-2'), 'should contain second entry');
@@ -76,7 +94,7 @@ describe('pre-compact: updateSessionFile', () => {
     const { updateSessionFile } = require('../pre-compact/main');
 
     // Create a session file
-    const sessionDir = path.join(testDir, '.claude', 'sessions', 'test-project', '2025-01-15');
+    const sessionDir = path.join(testDir, '.arcforge', 'sessions', 'test-project', '2025-01-15');
     fs.mkdirSync(sessionDir, { recursive: true });
     const sessionFile = path.join(sessionDir, 'session-123.json');
     fs.writeFileSync(sessionFile, JSON.stringify({ toolCalls: 10, compactions: [] }));
@@ -110,7 +128,7 @@ describe('pre-compact: updateSessionFile', () => {
   it('should append multiple compaction markers', () => {
     const { updateSessionFile } = require('../pre-compact/main');
 
-    const sessionDir = path.join(testDir, '.claude', 'sessions', 'test-project', '2025-01-15');
+    const sessionDir = path.join(testDir, '.arcforge', 'sessions', 'test-project', '2025-01-15');
     fs.mkdirSync(sessionDir, { recursive: true });
     const sessionFile = path.join(sessionDir, 'session-123.json');
     fs.writeFileSync(sessionFile, JSON.stringify({ toolCalls: 10 }));

--- a/hooks/__tests__/utils.test.js
+++ b/hooks/__tests__/utils.test.js
@@ -252,7 +252,7 @@ describe('getSessionDir', () => {
     const result = getSessionDir('my-project', '2025-01-01');
     assert.ok(result.includes('my-project'));
     assert.ok(result.includes('2025-01-01'));
-    assert.ok(result.includes('.claude'));
+    assert.ok(result.includes('.arcforge'));
     assert.ok(result.includes('sessions'));
   });
 });

--- a/hooks/observe/main.js
+++ b/hooks/observe/main.js
@@ -18,7 +18,11 @@ const {
   setSessionIdFromInput,
   getSessionId,
 } = require('../../scripts/lib/utils');
-const { getObservationsPath, getInstinctsRoot } = require('../../scripts/lib/session-utils');
+const {
+  getObservationsPath,
+  getObserverSignalFile,
+  getObserverPidFile,
+} = require('../../scripts/lib/session-utils');
 
 // ─────────────────────────────────────────────
 // Configuration
@@ -28,7 +32,7 @@ const MAX_INPUT_LENGTH = 5000;
 const MAX_OUTPUT_LENGTH = 5000;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const SIGNAL_COOLDOWN_MS = 30000; // 30 seconds between SIGUSR1 signals
-const SIGNAL_TIMESTAMP_FILE = path.join(getInstinctsRoot(), '.last_signal');
+const SIGNAL_TIMESTAMP_FILE = getObserverSignalFile();
 
 /**
  * Get observations archive directory for a project.
@@ -37,9 +41,7 @@ function getArchiveDir(project) {
   return `${path.dirname(getObservationsPath(project))}/archive`;
 }
 
-function getPidFile() {
-  return path.join(getInstinctsRoot(), '.observer.lock', 'pid');
-}
+const getPidFile = getObserverPidFile;
 
 // ─────────────────────────────────────────────
 // Core Functions

--- a/hooks/observe/main.js
+++ b/hooks/observe/main.js
@@ -11,8 +11,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const os = require('node:os');
-
 const {
   getProjectName,
   readStdinSync,
@@ -20,7 +18,7 @@ const {
   setSessionIdFromInput,
   getSessionId,
 } = require('../../scripts/lib/utils');
-const { getObservationsPath } = require('../../scripts/lib/session-utils');
+const { getObservationsPath, getInstinctsRoot } = require('../../scripts/lib/session-utils');
 
 // ─────────────────────────────────────────────
 // Configuration
@@ -30,7 +28,7 @@ const MAX_INPUT_LENGTH = 5000;
 const MAX_OUTPUT_LENGTH = 5000;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const SIGNAL_COOLDOWN_MS = 30000; // 30 seconds between SIGUSR1 signals
-const SIGNAL_TIMESTAMP_FILE = path.join(os.homedir(), '.claude', 'instincts', '.last_signal');
+const SIGNAL_TIMESTAMP_FILE = path.join(getInstinctsRoot(), '.last_signal');
 
 /**
  * Get observations archive directory for a project.
@@ -40,7 +38,7 @@ function getArchiveDir(project) {
 }
 
 function getPidFile() {
-  return path.join(os.homedir(), '.claude', 'instincts', '.observer.lock', 'pid');
+  return path.join(getInstinctsRoot(), '.observer.lock', 'pid');
 }
 
 // ─────────────────────────────────────────────

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -4,7 +4,7 @@ Records context compaction events for session tracking and triggers diary prompt
 
 ## What It Does
 
-1. **Logs compaction events** to `~/.claude/sessions/<project>/compaction-log.txt`
+1. **Logs compaction events** to `~/.arcforge/sessions/<project>/compaction-log.txt`
    - Format: `[YYYY-MM-DDTHH:MM:SS.sssZ] Context compaction - sessionId: <id>`
    - Append-only log for historical tracking
 

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -24,9 +24,9 @@ Provides session persistence across Claude Code sessions.
 
 ## Storage
 
-Sessions stored in `~/.claude/sessions/` in both JSON and Markdown formats:
+Sessions stored in `~/.arcforge/sessions/` in both JSON and Markdown formats:
 ```
-~/.claude/sessions/
+~/.arcforge/sessions/
 ├── my-project-2025-01-24.json    # Machine-readable
 ├── my-project-2025-01-24.md      # Human-readable summary
 ├── my-project-2025-01-23.json
@@ -101,14 +101,14 @@ If previous session exists:
   Duration: ~45 minutes
   Tool calls: 32
   Files modified: 5
-  Session saved to: ~/.claude/sessions/my-project-2025-01-24.json
+  Session saved to: ~/.arcforge/sessions/my-project-2025-01-24.json
 ```
 
 ## Editing Notes
 
 You can manually edit the session JSON to add notes:
 ```bash
-vim ~/.claude/sessions/my-project-2025-01-24.json
+vim ~/.arcforge/sessions/my-project-2025-01-24.json
 ```
 
 Change the `notes` field to leave yourself reminders for next session.

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -8,6 +8,7 @@
  * 3. Queue pending actions (reflect-ready)
  */
 
+const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync, spawn } = require('node:child_process');
 const {
@@ -17,11 +18,13 @@ const {
   writeFileSafe,
   loadSession,
   getSessionDir,
+  getProjectSessionsDir,
   getProjectName,
   getDateString,
   getSessionId,
   getTimestamp,
   createSessionCounter,
+  ensureDir,
   output,
   log,
 } = require('../../scripts/lib/utils');
@@ -147,15 +150,20 @@ function spawnDiaryEnricher(draftPath, session) {
       'Read the draft, fill placeholder sections using provided session data, ' +
       'write the result back. Be concise and factual.';
 
+    // Capture stderr to a log file so silent failures leave a trail.
+    const sessionsDir = getProjectSessionsDir(session.project);
+    ensureDir(sessionsDir);
+    const stderrFd = fs.openSync(path.join(sessionsDir, 'enricher.log'), 'a');
+
     const child = spawn(
       'claude',
       [
         '--model',
         'haiku',
+        // Haiku needs Read + Write + thinking; 10 leaves headroom (2 hits max-turns).
         '--max-turns',
-        '2',
+        '10',
         '--print',
-        // Safe: enricher is sandboxed (Read+Write only, no MCP, max 2 turns, detached)
         '--dangerously-skip-permissions',
         '--system-prompt',
         systemPrompt,
@@ -166,12 +174,13 @@ function spawnDiaryEnricher(draftPath, session) {
         '--mcp-config',
         '{"mcpServers":{}}',
       ],
-      { detached: true, stdio: ['pipe', 'ignore', 'ignore'] },
+      { detached: true, stdio: ['pipe', 'ignore', stderrFd] },
     );
 
     child.stdin.write(prompt);
     child.stdin.end();
     child.unref();
+    fs.closeSync(stderrFd);
   } catch {
     // Fire-and-forget — spawn failure is non-fatal
   }

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -23,6 +23,8 @@ const {
   parseStdinJson,
   setSessionIdFromInput,
   getProjectName,
+  getProjectDiariesDir,
+  getProjectSessionsDir,
   outputCombined,
   log,
 } = require('../../scripts/lib/utils');
@@ -95,6 +97,61 @@ function loadInstinctFiles(dir) {
       }
     })
     .filter(Boolean);
+}
+
+// The TO BE ENRICHED markers always appear in the template-stub header
+// region (Decisions/Challenges/etc.) within the first ~2KB of any draft.
+// Bounded read keeps SessionStart cheap even with hundreds of drafts.
+const STALE_DRAFT_PROBE_BYTES = 2048;
+
+function draftIsStale(filePath) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buf = Buffer.alloc(STALE_DRAFT_PROBE_BYTES);
+    const n = fs.readSync(fd, buf, 0, STALE_DRAFT_PROBE_BYTES, 0);
+    return buf.subarray(0, n).includes('TO BE ENRICHED');
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/**
+ * Returns { count, message } when stale drafts exist, else null.
+ * Surfaces silent enrichment failures so they don't accumulate forever.
+ */
+function loadStaleDraftWarning(project) {
+  try {
+    const dir = getProjectDiariesDir(project);
+    if (!fs.existsSync(dir)) return null;
+
+    let stale = 0;
+    for (const dateEntry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!dateEntry.isDirectory()) continue;
+      const dateDirPath = path.join(dir, dateEntry.name);
+      for (const file of fs.readdirSync(dateDirPath)) {
+        if (!file.startsWith('diary-') || !file.endsWith('-draft.md')) continue;
+        if (draftIsStale(path.join(dateDirPath, file))) stale++;
+      }
+    }
+
+    if (stale === 0) return null;
+    const enricherLog = path.join(getProjectSessionsDir(project), 'enricher.log');
+    return {
+      count: stale,
+      message: `⚠️ ${stale} diary draft${stale === 1 ? '' : 's'} unenriched — background enricher may be failing. Check ${enricherLog}`,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -227,6 +284,13 @@ function main() {
     userParts.push(pendingSummary);
   }
 
+  // Stale-draft healthcheck (re-evaluated every session start, not consumed)
+  const staleWarning = loadStaleDraftWarning(project);
+  if (staleWarning) {
+    contextParts.push(staleWarning.message);
+    userParts.push(`${staleWarning.count} unenriched draft${staleWarning.count === 1 ? '' : 's'}`);
+  }
+
   // Stderr-only (internal diagnostics)
   logAvailableAliases(project);
   checkNewGlobalPromotions();
@@ -246,6 +310,7 @@ module.exports = {
   loadAutoInstincts,
   loadInstinctFiles,
   loadPendingActions,
+  loadStaleDraftWarning,
   logAvailableAliases,
   checkNewGlobalPromotions,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcforge",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Skill-based autonomous agent toolkit for Claude Code, Codex, Gemini CLI, and OpenCode",
   "license": "MIT",
   "author": {

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -110,7 +110,7 @@ COMMANDS:
       List all epics that can be worked on in parallel.
 
   expand [--epic <id>] [--project-setup] [--verify] [--verify-cmd "..."]
-      Create git worktrees for ready epics at ~/.arcforge-worktrees/.
+      Create git worktrees for ready epics at ~/.arcforge/worktrees/.
       --epic           Expand only the named epic (single-epic mode)
       --project-setup  Auto-detect and run installer (npm/pip/cargo/go)
       --verify         Run tests after creation

--- a/scripts/lib/coordinator.js
+++ b/scripts/lib/coordinator.js
@@ -195,7 +195,7 @@ class Coordinator {
    * Expand worktrees for ready epics, or a single epic when epicId is supplied.
    *
    * Worktrees are created at the canonical location computed by
-   * worktree-paths.js (~/.arcforge-worktrees/<project>-<hash>-<epic>/).
+   * worktree-paths.js (~/.arcforge/worktrees/<project>-<hash>-<epic>/).
    *
    * @param {Object} options - Expand options
    * @param {string} [options.epicId] - Single-epic mode: only expand this epic

--- a/scripts/lib/global-index.js
+++ b/scripts/lib/global-index.js
@@ -180,7 +180,7 @@ function checkBubbleUpForProject(project) {
     });
 
     for (const projName of projectDirs) {
-      const projInstinctFile = path.join(instinctsBase, projName, file);
+      const projInstinctFile = path.join(getInstinctsDir(projName), file);
       if (fs.existsSync(projInstinctFile)) {
         projectCount++;
       }
@@ -212,7 +212,7 @@ function checkBubbleUpForProject(project) {
     for (const otherProj of projectDirs) {
       if (otherProj === project) continue;
 
-      const otherProjDir = path.join(instinctsBase, otherProj);
+      const otherProjDir = getInstinctsDir(otherProj);
       const otherFiles = fs.readdirSync(otherProjDir).filter((f) => f.endsWith('.md'));
 
       for (const otherFile of otherFiles) {

--- a/scripts/lib/global-index.js
+++ b/scripts/lib/global-index.js
@@ -8,9 +8,14 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const os = require('node:os');
 const { buildTriggerFingerprint, jaccardSimilarity } = require('./fingerprint');
 const { parseConfidenceFrontmatter } = require('./confidence');
+const {
+  getInstinctsRoot,
+  getInstinctsDir,
+  getGlobalInstinctsDir,
+  getInstinctsGlobalIndex,
+} = require('./session-utils');
 
 /**
  * Append an entry to a JSONL index file.
@@ -152,10 +157,10 @@ function main() {
  * @param {string} project - Project name
  */
 function checkBubbleUpForProject(project) {
-  const instinctsBase = path.join(os.homedir(), '.claude', 'instincts');
-  const projectInstincts = path.join(instinctsBase, project);
-  const globalDir = path.join(instinctsBase, 'global');
-  const indexPath = path.join(instinctsBase, 'global-index.jsonl');
+  const instinctsBase = getInstinctsRoot();
+  const projectInstincts = getInstinctsDir(project);
+  const globalDir = getGlobalInstinctsDir();
+  const indexPath = getInstinctsGlobalIndex();
 
   if (!fs.existsSync(projectInstincts)) {
     return;

--- a/scripts/lib/pending-actions.js
+++ b/scripts/lib/pending-actions.js
@@ -5,17 +5,17 @@
  * shown to the user on next session start. Uses per-action consume
  * to avoid losing concurrent actions.
  *
- * Storage: ~/.claude/sessions/{project}/pending-actions.json
+ * Storage: ~/.arcforge/sessions/{project}/pending-actions.json
  * Format: { actions: [{ id, type, payload, created, consumed, consumed_at }] }
  */
 
 const fs = require('node:fs');
 const path = require('node:path');
-const os = require('node:os');
 const crypto = require('node:crypto');
 
+const { getProjectSessionsDir } = require('./utils');
+
 const EXPIRY_DAYS = 7;
-const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 
 /**
  * Get the pending-actions.json path for a project.
@@ -23,7 +23,7 @@ const CLAUDE_DIR = path.join(os.homedir(), '.claude');
  * @returns {string} Path to pending-actions.json
  */
 function getActionsPath(project) {
-  return path.join(CLAUDE_DIR, 'sessions', project, 'pending-actions.json');
+  return path.join(getProjectSessionsDir(project), 'pending-actions.json');
 }
 
 /**

--- a/scripts/lib/session-utils.js
+++ b/scripts/lib/session-utils.js
@@ -451,9 +451,8 @@ function sectionNameToKey(name) {
 // ─────────────────────────────────────────────
 
 /**
- * Get the instincts root directory (~/.arcforge/instincts/).
- * Holds <project>/, global/, global-index.jsonl, and observer daemon
- * coordination files (.last_signal, .observer.lock/).
+ * Root for instinct storage. Also hosts observer daemon coordination
+ * files — see `getObserverSignalFile` / `getObserverPidFile`.
  */
 function getInstinctsRoot() {
   return path.join(getArcforgeHome(), 'instincts');
@@ -468,7 +467,7 @@ function getInstinctsDir(project) {
 }
 
 function getInstinctsArchivedDir(project) {
-  return path.join(getInstinctsRoot(), project, 'archived');
+  return path.join(getInstinctsDir(project), 'archived');
 }
 
 function getGlobalInstinctsDir() {
@@ -477,6 +476,14 @@ function getGlobalInstinctsDir() {
 
 function getInstinctsGlobalIndex() {
   return path.join(getInstinctsRoot(), 'global-index.jsonl');
+}
+
+function getObserverSignalFile() {
+  return path.join(getInstinctsRoot(), '.last_signal');
+}
+
+function getObserverPidFile() {
+  return path.join(getInstinctsRoot(), '.observer.lock', 'pid');
 }
 
 function getEvolvedLogPath() {
@@ -505,5 +512,7 @@ module.exports = {
   getInstinctsArchivedDir,
   getGlobalInstinctsDir,
   getInstinctsGlobalIndex,
+  getObserverSignalFile,
+  getObserverPidFile,
   getEvolvedLogPath,
 };

--- a/scripts/lib/session-utils.js
+++ b/scripts/lib/session-utils.js
@@ -1,14 +1,13 @@
 // scripts/lib/session-utils.js
 const fs = require('node:fs');
 const path = require('node:path');
-const os = require('node:os');
 
-const { getProjectDiariesDir, getDateDiariesDir, getProjectSessionsDir } = require('./utils');
-
-// Instinct/observation/diaryed trees still live under ~/.claude/ — they're
-// written by Node code (not via the nested Write tool) so they're not
-// affected by Claude's subprocess write protection.
-const CLAUDE_DIR = path.join(os.homedir(), '.claude');
+const {
+  getArcforgeHome,
+  getProjectDiariesDir,
+  getDateDiariesDir,
+  getProjectSessionsDir,
+} = require('./utils');
 
 function getDiaryPath(project, date, sessionId) {
   return path.join(getDateDiariesDir(project, date), `diary-${sessionId}.md`);
@@ -28,7 +27,7 @@ function saveDiary(filePath, content) {
  * Get processed.log path for project or global.
  */
 function getProcessedLogPath(project) {
-  const base = path.join(CLAUDE_DIR, 'diaryed');
+  const base = path.join(getArcforgeHome(), 'diaryed');
   return project
     ? path.join(base, project, 'processed.log')
     : path.join(base, 'global', 'processed.log');
@@ -452,54 +451,36 @@ function sectionNameToKey(name) {
 // ─────────────────────────────────────────────
 
 /**
- * Get observations JSONL path for a project.
- * @param {string} project - Project name
- * @returns {string} ~/.claude/observations/{project}/observations.jsonl
+ * Get the instincts root directory (~/.arcforge/instincts/).
+ * Holds <project>/, global/, global-index.jsonl, and observer daemon
+ * coordination files (.last_signal, .observer.lock/).
  */
+function getInstinctsRoot() {
+  return path.join(getArcforgeHome(), 'instincts');
+}
+
 function getObservationsPath(project) {
-  return path.join(CLAUDE_DIR, 'observations', project, 'observations.jsonl');
+  return path.join(getArcforgeHome(), 'observations', project, 'observations.jsonl');
 }
 
-/**
- * Get instincts directory for a project.
- * @param {string} project - Project name
- * @returns {string} ~/.claude/instincts/{project}/
- */
 function getInstinctsDir(project) {
-  return path.join(CLAUDE_DIR, 'instincts', project);
+  return path.join(getInstinctsRoot(), project);
 }
 
-/**
- * Get archived instincts directory for a project.
- * @param {string} project - Project name
- * @returns {string} ~/.claude/instincts/{project}/archived/
- */
 function getInstinctsArchivedDir(project) {
-  return path.join(CLAUDE_DIR, 'instincts', project, 'archived');
+  return path.join(getInstinctsRoot(), project, 'archived');
 }
 
-/**
- * Get global instincts directory.
- * @returns {string} ~/.claude/instincts/global/
- */
 function getGlobalInstinctsDir() {
-  return path.join(CLAUDE_DIR, 'instincts', 'global');
+  return path.join(getInstinctsRoot(), 'global');
 }
 
-/**
- * Get global index for instinct bubble-up tracking.
- * @returns {string} ~/.claude/instincts/global-index.jsonl
- */
 function getInstinctsGlobalIndex() {
-  return path.join(CLAUDE_DIR, 'instincts', 'global-index.jsonl');
+  return path.join(getInstinctsRoot(), 'global-index.jsonl');
 }
 
-/**
- * Get evolved log path for tracking instinct-to-artifact evolution.
- * @returns {string} ~/.claude/evolved/evolved.jsonl
- */
 function getEvolvedLogPath() {
-  return path.join(CLAUDE_DIR, 'evolved', 'evolved.jsonl');
+  return path.join(getArcforgeHome(), 'evolved', 'evolved.jsonl');
 }
 
 module.exports = {
@@ -519,6 +500,7 @@ module.exports = {
   parseSessionSections,
   // Observation & Instinct paths
   getObservationsPath,
+  getInstinctsRoot,
   getInstinctsDir,
   getInstinctsArchivedDir,
   getGlobalInstinctsDir,

--- a/scripts/lib/session-utils.js
+++ b/scripts/lib/session-utils.js
@@ -3,13 +3,15 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
+const { getProjectDiariesDir, getDateDiariesDir, getProjectSessionsDir } = require('./utils');
+
+// Instinct/observation/diaryed trees still live under ~/.claude/ — they're
+// written by Node code (not via the nested Write tool) so they're not
+// affected by Claude's subprocess write protection.
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 
-/**
- * Get diary file path: ~/.claude/sessions/{project}/{date}/diary-{sessionId}.md
- */
 function getDiaryPath(project, date, sessionId) {
-  return path.join(CLAUDE_DIR, 'sessions', project, date, `diary-${sessionId}.md`);
+  return path.join(getDateDiariesDir(project, date), `diary-${sessionId}.md`);
 }
 
 /**
@@ -53,20 +55,19 @@ function parseProcessedLog(logPath) {
  * Scan for diary files based on strategy.
  */
 function scanDiaries(project, strategy, processedLogPath) {
-  const sessionsDir = path.join(CLAUDE_DIR, 'sessions', project);
-  if (!fs.existsSync(sessionsDir)) return [];
+  const diariesDir = getProjectDiariesDir(project);
+  if (!fs.existsSync(diariesDir)) return [];
 
   const processed = parseProcessedLog(processedLogPath);
   const allDiaries = [];
 
-  // Find all diary files sorted by date
   const dateDirs = fs
-    .readdirSync(sessionsDir)
-    .filter((d) => fs.statSync(path.join(sessionsDir, d)).isDirectory())
+    .readdirSync(diariesDir)
+    .filter((d) => fs.statSync(path.join(diariesDir, d)).isDirectory())
     .sort();
 
   for (const dateDir of dateDirs) {
-    const dirPath = path.join(sessionsDir, dateDir);
+    const dirPath = path.join(diariesDir, dateDir);
     const diaries = fs
       .readdirSync(dirPath)
       .filter((f) => f.startsWith('diary-') && f.endsWith('.md'))
@@ -75,7 +76,6 @@ function scanDiaries(project, strategy, processedLogPath) {
     allDiaries.push(...diaries);
   }
 
-  // Filter based on strategy
   if (strategy === 'unprocessed') {
     return allDiaries.filter((d) => !processed.has(path.basename(d)));
   } else if (strategy === 'project_focused') {
@@ -89,16 +89,15 @@ function scanDiaries(project, strategy, processedLogPath) {
  * Determine which reflection strategy to use.
  */
 function determineReflectStrategy(project, processedLogPath) {
-  const sessionsDir = path.join(CLAUDE_DIR, 'sessions', project);
-  if (!fs.existsSync(sessionsDir)) return 'recent_window';
+  const diariesDir = getProjectDiariesDir(project);
+  if (!fs.existsSync(diariesDir)) return 'recent_window';
 
-  // Count all diaries
   const allDiaries = [];
   const dateDirs = fs
-    .readdirSync(sessionsDir)
-    .filter((d) => fs.statSync(path.join(sessionsDir, d)).isDirectory());
+    .readdirSync(diariesDir)
+    .filter((d) => fs.statSync(path.join(diariesDir, d)).isDirectory());
   for (const dateDir of dateDirs) {
-    const dirPath = path.join(sessionsDir, dateDir);
+    const dirPath = path.join(diariesDir, dateDir);
     const diaries = fs
       .readdirSync(dirPath)
       .filter((f) => f.startsWith('diary-') && f.endsWith('.md'));
@@ -159,7 +158,7 @@ function getDateDirs(parentDir) {
  */
 function listSessions(project, options = {}) {
   const { date = null, query = null, limit = 20, offset = 0 } = options;
-  const sessionsDir = path.join(CLAUDE_DIR, 'sessions', project);
+  const sessionsDir = getProjectSessionsDir(project);
   if (!fs.existsSync(sessionsDir)) return { sessions: [], total: 0 };
 
   let allSessions = [];
@@ -511,7 +510,6 @@ module.exports = {
   scanDiaries,
   determineReflectStrategy,
   updateProcessedLog,
-  CLAUDE_DIR,
   // Session listing & briefings
   getDateDirs,
   listSessions,

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -429,13 +429,8 @@ function getDiaryFilePath() {
   );
 }
 
-/**
- * Reflections still live under ~/.claude/ because they're written by Node
- * code, not via the nested Write tool — so the ~/.claude/ protection
- * doesn't apply.
- */
 function getDiaryedDir(project = null) {
-  const base = path.join(os.homedir(), '.claude', 'diaryed');
+  const base = path.join(getArcforgeHome(), 'diaryed');
   return project ? path.join(base, project) : path.join(base, 'global');
 }
 

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -386,41 +386,53 @@ function generateRunId() {
 }
 
 /**
- * Get Claude sessions directory (~/.claude/sessions/)
+ * Root for all arcforge user state (worktrees, sessions, diaries).
+ * Lives outside ~/.claude/ because Claude Code v2.1.78+ protects ~/.claude/
+ * from nested-subprocess Write calls, which breaks the background enricher.
  */
-function getSessionsDir() {
-  return path.join(os.homedir(), '.claude', 'sessions');
+function getArcforgeHome() {
+  return path.join(os.homedir(), '.arcforge');
 }
 
-/**
- * Get project-specific sessions directory (~/.claude/sessions/{project}/)
- */
+function getSessionsDir() {
+  return path.join(getArcforgeHome(), 'sessions');
+}
+
 function getProjectSessionsDir(project) {
   return path.join(getSessionsDir(), project);
 }
 
-/**
- * Get session directory for a specific date (~/.claude/sessions/{project}/{date}/)
- */
 function getSessionDir(project, date) {
   return path.join(getSessionsDir(), project, date);
 }
 
-/**
- * Get diary file path for current session
- * Returns ~/.claude/sessions/{project}/{date}/diary-{sessionId}.md
- */
+function getDiariesDir() {
+  return path.join(getArcforgeHome(), 'diaries');
+}
+
+function getProjectDiariesDir(project) {
+  return path.join(getDiariesDir(), project);
+}
+
+function getDateDiariesDir(project, date) {
+  return path.join(getDiariesDir(), project, date);
+}
+
+function getDiaryDraftPath(project, date, sessionId) {
+  return path.join(getDateDiariesDir(project, date), `diary-${sessionId}-draft.md`);
+}
+
 function getDiaryFilePath() {
-  const project = getProjectName();
-  const date = getDateString();
-  const sessionId = getSessionId();
-  return path.join(getSessionDir(project, date), `diary-${sessionId}.md`);
+  return path.join(
+    getDateDiariesDir(getProjectName(), getDateString()),
+    `diary-${getSessionId()}.md`,
+  );
 }
 
 /**
- * Get diaryed directory for extracted insights
- * @param {string|null} project - Project name, null for global
- * @returns {string} Path to diaryed directory
+ * Reflections still live under ~/.claude/ because they're written by Node
+ * code, not via the nested Write tool — so the ~/.claude/ protection
+ * doesn't apply.
  */
 function getDiaryedDir(project = null) {
   const base = path.join(os.homedir(), '.claude', 'diaryed');
@@ -429,7 +441,7 @@ function getDiaryedDir(project = null) {
 
 /**
  * Get compaction log file path for a project
- * Located at ~/.claude/sessions/{project}/compaction-log.txt
+ * Located at ~/.arcforge/sessions/{project}/compaction-log.txt
  */
 function getCompactionLogPath(project) {
   return path.join(getProjectSessionsDir(project), 'compaction-log.txt');
@@ -533,7 +545,7 @@ function createSessionCounter(name) {
 
 /**
  * Get session file path for current session
- * Returns ~/.claude/sessions/{project}/{date}/{sessionId}.json
+ * Returns ~/.arcforge/sessions/{project}/{date}/{sessionId}.json
  */
 function getSessionFilePath() {
   const project = getProjectName();
@@ -593,10 +605,15 @@ module.exports = {
   getDateString,
   getTimestamp,
   generateRunId,
+  getArcforgeHome,
   getSessionsDir,
   getProjectSessionsDir,
   getSessionDir,
+  getDiariesDir,
+  getProjectDiariesDir,
+  getDateDiariesDir,
   getDiaryFilePath,
+  getDiaryDraftPath,
   getDiaryedDir,
   getCompactionLogPath,
   ensureDir,

--- a/scripts/lib/worktree-paths.js
+++ b/scripts/lib/worktree-paths.js
@@ -1,7 +1,7 @@
 /**
  * worktree-paths.js - Canonical path helper for arcforge worktrees.
  *
- * Worktrees live under ~/.arcforge-worktrees/<project>-<hash>-<epic>/
+ * Worktrees live under ~/.arcforge/worktrees/<project>-<hash>-<epic>/
  * where <hash> is a 6-char sha256 prefix of the absolute project root.
  * Storing worktrees outside the git tree keeps them from polluting the
  * working copy; the hash prevents collisions between same-named projects.
@@ -15,7 +15,8 @@ const crypto = require('node:crypto');
 const os = require('node:os');
 const path = require('node:path');
 
-const WORKTREE_DIR_NAME = '.arcforge-worktrees';
+const ARCFORGE_HOME_NAME = '.arcforge';
+const WORKTREE_SUBDIR = 'worktrees';
 const HASH_LENGTH = 6;
 // Matches `<project>-<hash>-<epic>` where hash is exactly HASH_LENGTH hex chars.
 // Greedy `.+` on both sides of a fixed-width hash anchor matches the last
@@ -29,7 +30,7 @@ const WORKTREE_NAME_RE = new RegExp(`^(.+)-([0-9a-f]{${HASH_LENGTH}})-(.+)$`);
  * @returns {string}
  */
 function getWorktreeRoot(homeDir) {
-  return path.join(homeDir || os.homedir(), WORKTREE_DIR_NAME);
+  return path.join(homeDir || os.homedir(), ARCFORGE_HOME_NAME, WORKTREE_SUBDIR);
 }
 
 /**
@@ -124,7 +125,8 @@ function parseWorktreePath(worktreePath) {
 }
 
 module.exports = {
-  WORKTREE_DIR_NAME,
+  ARCFORGE_HOME_NAME,
+  WORKTREE_SUBDIR,
   getWorktreeRoot,
   hashRepoPath,
   getWorktreePath,

--- a/skills/arc-dispatching-teammates/baseline-test.md
+++ b/skills/arc-dispatching-teammates/baseline-test.md
@@ -88,7 +88,7 @@ Verbatim, as drafted in
 >    ```
 >    This reads `dag.yaml`, finds `epic-auth`, `epic-api`, `epic-ui` (all
 >    pending, no deps, no worktrees), and creates an isolated git worktree
->    for each at `~/.arcforge-worktrees/dispatching-baseline-<hash>-<epic>/`.
+>    for each at `~/.arcforge/worktrees/dispatching-baseline-<hash>-<epic>/`.
 >    It stamps each with an `.arcforge-epic` marker so DAG sync stays
 >    honest.
 >

--- a/skills/arc-dispatching-teammates/green-test.md
+++ b/skills/arc-dispatching-teammates/green-test.md
@@ -88,7 +88,7 @@ STEP 3 draft + STEP 4 debrief:
 > > 2. **For each of the three epics (auth, api, ui), in a single pass:**
 > >    - Run `node scripts/cli.js expand --epic <epic-id>` from the
 > >      project root. This creates the canonical worktree at
-> >      `~/.arcforge-worktrees/...` and stamps the `.arcforge-epic`
+> >      `~/.arcforge/worktrees/...` and stamps the `.arcforge-epic`
 > >      marker. Per-epic expand (not batch) so any failure is
 > >      attributable to one epic.
 > >    - Re-read `arcforge status --json` to get the absolute worktree

--- a/skills/arc-journaling/SKILL.md
+++ b/skills/arc-journaling/SKILL.md
@@ -54,7 +54,7 @@ node "${SKILL_ROOT}/scripts/diary.js" path \
 - **Diary = observations, context, decisions made** (stored in session directory)
 - **Learn = instinct clustering** (combines related instincts into skills)
 
-**Storage:** `~/.claude/sessions/{project}/{YYYY-MM-DD}/diary-{sessionId}.md`
+**Storage:** `~/.arcforge/diaries/{project}/{YYYY-MM-DD}/diary-{sessionId}.md`
 
 ## Pre-Diary Check (Noise Gate)
 
@@ -146,7 +146,7 @@ _Captured at {timestamp}_
 ### 3. Save to Session Directory
 
 1. Ensure session directory exists
-2. Write to `~/.claude/sessions/{project}/{date}/diary-{sessionId}.md`
+2. Write to `~/.arcforge/diaries/{project}/{date}/diary-{sessionId}.md`
 3. Confirm save location with path
 
 ### 4. Offer Follow-up
@@ -213,11 +213,17 @@ Keep entries focused. Don't over-document routine work.
 ## Output Location
 
 ```
-~/.claude/sessions/{project}/{YYYY-MM-DD}/
-├── {sessionId}.json          # Session data (auto-generated)
-├── {sessionId}.md            # Session summary (auto-generated)
+~/.arcforge/diaries/{project}/{YYYY-MM-DD}/
 └── diary-{sessionId}.md      # Diary entry (from /diary)
+
+~/.arcforge/sessions/{project}/{YYYY-MM-DD}/
+├── {sessionId}.json          # Session data (auto-generated)
+└── {sessionId}.md            # Session summary (auto-generated)
 ```
+
+Diary files live under `~/.arcforge/diaries/` (not `~/.claude/sessions/`)
+because Claude Code v2.1.78+ blocks subprocess writes to `~/.claude/`.
+The Stop-hook background enricher needs to be able to write there.
 
 ## Example Diary Entry
 

--- a/skills/arc-journaling/scripts/auto-diary.js
+++ b/skills/arc-journaling/scripts/auto-diary.js
@@ -13,8 +13,11 @@ const path = require('path');
 const {
   getDiaryPath,
   getObservationsPath,
-  CLAUDE_DIR
 } = require('../../../scripts/lib/session-utils');
+const {
+  getSessionDir,
+  getDiaryDraftPath,
+} = require('../../../scripts/lib/utils');
 
 // ─────────────────────────────────────────────
 // Helpers
@@ -37,7 +40,7 @@ function parseArgs(argv) {
  * Load session JSON for a given project/date/session.
  */
 function loadSessionJson(project, date, sessionId) {
-  const sessionFile = path.join(CLAUDE_DIR, 'sessions', project, date, `${sessionId}.json`);
+  const sessionFile = path.join(getSessionDir(project, date), `${sessionId}.json`);
   if (!fs.existsSync(sessionFile)) return null;
   try {
     return JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
@@ -112,7 +115,7 @@ function summarizeObservations(project) {
  * Get draft diary path.
  */
 function getDraftPath(project, date, sessionId) {
-  return path.join(CLAUDE_DIR, 'sessions', project, date, `diary-${sessionId}-draft.md`);
+  return getDiaryDraftPath(project, date, sessionId);
 }
 
 /**

--- a/skills/arc-journaling/scripts/diary.js
+++ b/skills/arc-journaling/scripts/diary.js
@@ -2,6 +2,7 @@
 // skills/arc-journaling/scripts/diary.js
 
 const { getDiaryPath, saveDiary } = require('../../../scripts/lib/session-utils');
+const { getDiaryDraftPath } = require('../../../scripts/lib/utils');
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -50,8 +51,7 @@ if (command === 'save') {
   }
   const fs = require('fs');
   const path = require('path');
-  const { CLAUDE_DIR } = require('../../../scripts/lib/session-utils');
-  const draftPath = path.join(CLAUDE_DIR, 'sessions', project, date, `diary-${session}-draft.md`);
+  const draftPath = getDiaryDraftPath(project, date, session);
   const finalPath = getDiaryPath(project, date, session);
 
   if (!fs.existsSync(draftPath)) {

--- a/skills/arc-learning/SKILL.md
+++ b/skills/arc-learning/SKILL.md
@@ -33,12 +33,12 @@ fi
 
 ## Workflow
 
-1. **Scan**: Load all instincts from `~/.claude/instincts/{project}/` and `global/`
+1. **Scan**: Load all instincts from `~/.arcforge/instincts/{project}/` and `global/`
 2. **Cluster**: Group by domain, then within each domain use trigger fingerprint similarity (Jaccard >= 0.6) to find sub-clusters
 3. **Filter**: Only process clusters with 3+ instincts, at least 1 with confidence >= 0.6
 4. **Preview**: Display candidate clusters with type recommendations and suggested names
 5. **Generate**: Create skill, command, or agent from a cluster (auto-classified or user-overridden)
-6. **Track**: Record evolution to `~/.claude/evolved/evolved.jsonl` for deduplication
+6. **Track**: Record evolution to `~/.arcforge/evolved/evolved.jsonl` for deduplication
 
 **Note:** Generated files are scaffolds — refine before deployment.
 

--- a/skills/arc-managing-sessions/SKILL.md
+++ b/skills/arc-managing-sessions/SKILL.md
@@ -43,7 +43,7 @@ Save the current session with enrichment.
 
 **Process:**
 
-1. Get current session data from `~/.claude/sessions/{project}/{date}/{sessionId}.json`
+1. Get current session data from `~/.arcforge/sessions/{project}/{date}/{sessionId}.json`
 2. Use transcript data if available (user messages, tools used, files modified)
 3. Enrich with your understanding from conversation memory:
    - **Summary**: What was accomplished
@@ -51,7 +51,7 @@ Save the current session with enrichment.
    - **What Failed**: Approaches that were tried and abandoned (with reasons)
    - **Blockers**: Current blockers or open questions
    - **Next Step**: Exact next step to take
-4. Save to `~/.claude/sessions/{project}/{date}/session-{alias}.md`
+4. Save to `~/.arcforge/sessions/{project}/{date}/session-{alias}.md`
 5. Create alias if name provided
 
 **Infrastructure:**
@@ -120,7 +120,7 @@ node "${SKILL_ROOT}/scripts/sessions.js" aliases
 ## Storage Layout
 
 ```
-~/.claude/sessions/{project}/
+~/.arcforge/sessions/{project}/
 ├── aliases.json                          # Project-scoped alias registry
 ├── {YYYY-MM-DD}/
 │   ├── {sessionId}.json                  # Auto-saved session metrics

--- a/skills/arc-managing-sessions/scripts/sessions.js
+++ b/skills/arc-managing-sessions/scripts/sessions.js
@@ -7,7 +7,6 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const os = require('node:os');
 
 const {
   getProjectName,
@@ -76,7 +75,7 @@ function cmdResume(args) {
     const saved = sessions.find((s) => s.type === 'saved');
     if (saved) {
       sessionPath = path.join(
-        os.homedir(), '.claude', 'sessions', project, saved.dateStr, saved.filename,
+        getSessionDir(project, saved.dateStr), saved.filename,
       );
     }
   }

--- a/skills/arc-observing/SKILL.md
+++ b/skills/arc-observing/SKILL.md
@@ -38,9 +38,9 @@ fi
 
 ## How Observations Work
 
-1. **Capture**: `hooks/observe/main.js` records every tool call to `~/.claude/observations/{project}/observations.jsonl`
+1. **Capture**: `hooks/observe/main.js` records every tool call to `~/.arcforge/observations/{project}/observations.jsonl`
 2. **Analysis**: Background daemon reads observations (10+ required), calls Haiku to detect patterns
-3. **Creation**: Instincts saved as `.md` files with YAML frontmatter in `~/.claude/instincts/{project}/`
+3. **Creation**: Instincts saved as `.md` files with YAML frontmatter in `~/.arcforge/instincts/{project}/`
 4. **Loading**: Session start loads instincts with confidence >= 0.7 into Claude context
 5. **Lifecycle**: Confirm (+0.05) / Contradict (-0.10, -0.05 for manual/reflection) / Decay (-0.02/week, -0.01 for manual/reflection) / Archive (< 0.15)
 
@@ -142,7 +142,7 @@ When user agrees or disagrees with a pattern:
 
 ### Bubble-up to Global
 
-Patterns appearing in 2+ projects are auto-promoted to `~/.claude/instincts/global/`. At session start, user is notified of newly promoted global patterns.
+Patterns appearing in 2+ projects are auto-promoted to `~/.arcforge/instincts/global/`. At session start, user is notified of newly promoted global patterns.
 
 ## Common Mistakes
 

--- a/skills/arc-observing/scripts/observer-daemon.sh
+++ b/skills/arc-observing/scripts/observer-daemon.sh
@@ -8,9 +8,9 @@
 
 set -euo pipefail
 
-CLAUDE_DIR="${HOME}/.claude"
-INSTINCTS_DIR="${CLAUDE_DIR}/instincts"
-OBS_DIR="${CLAUDE_DIR}/observations"
+ARCFORGE_DIR="${HOME}/.arcforge"
+INSTINCTS_DIR="${ARCFORGE_DIR}/instincts"
+OBS_DIR="${ARCFORGE_DIR}/observations"
 LOCK_DIR="${INSTINCTS_DIR}/.observer.lock"
 LOG_FILE="${INSTINCTS_DIR}/observer.log"
 GLOBAL_INDEX="${INSTINCTS_DIR}/global-index.jsonl"

--- a/skills/arc-reflecting/SKILL.md
+++ b/skills/arc-reflecting/SKILL.md
@@ -7,7 +7,7 @@ description: Use when user requests /reflect, after 5+ diary entries accumulated
 
 ## Overview
 
-Analyze multiple diary entries to identify recurring patterns. Save insights to `~/.claude/diaryed/` for user review.
+Analyze multiple diary entries to identify recurring patterns. Save insights to `~/.arcforge/diaryed/` for user review.
 
 ## Quick Reference
 
@@ -61,7 +61,7 @@ node "${SKILL_ROOT}/scripts/reflect.js" update-log \
 For large diary sets, use the diary-analyzer subagent (see `diary-analyzer.md`) to read diaries in an isolated context without polluting the main conversation.
 
 **Integration with instincts:**
-- `/reflect` → `~/.claude/diaryed/` (reflections) + instincts saved via `save-instinct`
+- `/reflect` → `~/.arcforge/diaryed/` (reflections) + instincts saved via `save-instinct`
 - `/recall` → retrieves instincts and learned patterns
 
 **Core principle:** Patterns must appear 3+ times across diary entries to be considered "Pattern". 1-2 occurrences are labeled "Observation".
@@ -83,7 +83,7 @@ For large diary sets, use the diary-analyzer subagent (see `diary-analyzer.md`) 
 ## Storage
 
 ```
-~/.claude/diaryed/
+~/.arcforge/diaryed/
 ├── global/                              # Cross-project patterns
 │   ├── processed.log                    # Tracks which diaries were processed
 │   └── prefers-explicit-errors.md
@@ -160,7 +160,7 @@ Read each diary entry. Look for:
 - Common techniques
 - **Rule violations:** Cases where user corrected Claude for breaking a CLAUDE.md rule
 
-**Observation Cross-Reference:** When observations are available (`~/.claude/observations/{project}/observations.jsonl`), cross-reference diary patterns with tool call data for stronger evidence. Tool usage sequences that match diary-reported techniques provide quantitative backing for patterns. For example, if a diary mentions "always grep before editing", check observations for Grep→Read→Edit sequences to confirm frequency.
+**Observation Cross-Reference:** When observations are available (`~/.arcforge/observations/{project}/observations.jsonl`), cross-reference diary patterns with tool call data for stronger evidence. Tool usage sequences that match diary-reported techniques provide quantitative backing for patterns. For example, if a diary mentions "always grep before editing", check observations for Grep→Read→Edit sequences to confirm frequency.
 
 ### 5. Identify Patterns and Violations
 
@@ -241,7 +241,7 @@ For rule violations, additionally inform:
 
 ### 8. Save Reflections and Instincts
 
-1. Ensure `~/.claude/diaryed/{project}/` or `~/.claude/diaryed/global/` exists
+1. Ensure `~/.arcforge/diaryed/{project}/` or `~/.arcforge/diaryed/global/` exists
 2. Write the reflection markdown file (e.g., `YYYY-MM-reflection-N.md`)
 3. **Update processed.log** with each diary that was analyzed:
    ```

--- a/skills/arc-reflecting/SKILL.md
+++ b/skills/arc-reflecting/SKILL.md
@@ -137,7 +137,7 @@ Output the strategy header at start of reflection:
 
 Search for diary files:
 ```
-~/.claude/sessions/{project}/*/diary-*.md
+~/.arcforge/diaries/{project}/*/diary-*.md
 ```
 
 Count entries. If fewer than 3:

--- a/skills/arc-using-worktrees/SKILL.md
+++ b/skills/arc-using-worktrees/SKILL.md
@@ -32,7 +32,7 @@ node "${SKILL_ROOT}/scripts/coordinator.js" expand --epic <epic-id> --project-se
 What this does (single authoritative implementation in `scripts/lib/coordinator.js`):
 
 - Derives the canonical worktree path via `scripts/lib/worktree-paths.js`
-  (`~/.arcforge-worktrees/<project>-<hash>-<epic>/`).
+  (`~/.arcforge/worktrees/<project>-<hash>-<epic>/`).
 - Runs `git worktree add <path> -b <epic-id>`.
 - Writes the `.arcforge-epic` marker with base worktree + base branch.
 - Auto-detects the project installer (`package.json` → `npm install`,
@@ -60,7 +60,7 @@ Stop immediately if you catch yourself thinking:
 2. **"I'll put it somewhere convenient like `./worktrees/`"** — NO. The
    canonical path is derived at runtime; putting it elsewhere makes every
    downstream tool fail to find it.
-3. **"I'll hardcode `~/.arcforge-worktrees/...` in my output"** — NO. Read
+3. **"I'll hardcode `~/.arcforge/worktrees/...` in my output"** — NO. Read
    the `path` field from the CLI's JSON output. The derivation rule has
    evolved before and will evolve again.
 4. **"I'll skip the dag.yaml check"** — NO. If the epic is not in the DAG,

--- a/skills/arc-using/SKILL.md
+++ b/skills/arc-using/SKILL.md
@@ -31,7 +31,7 @@ If no skill fits, proceed directly.
 
 ## Worktree Rule
 
-ArcForge worktrees live at `~/.arcforge-worktrees/<project>-<hash>-<epic>/`,
+ArcForge worktrees live at `~/.arcforge/worktrees/<project>-<hash>-<epic>/`,
 computed at runtime by `scripts/lib/worktree-paths.js` and managed by
 `coordinator.js`. Because the path is derived, not literal, four norms
 apply whenever you touch worktrees:

--- a/tests/scripts/auto-diary.test.js
+++ b/tests/scripts/auto-diary.test.js
@@ -89,7 +89,7 @@ describe('auto-diary', () => {
   describe('getDraftPath', () => {
     it('returns correct draft path', () => {
       const draftPath = getDraftPath('my-project', '2026-02-08', 'abc123');
-      expect(draftPath).toContain('sessions');
+      expect(draftPath).toContain('diaries');
       expect(draftPath).toContain('my-project');
       expect(draftPath).toContain('2026-02-08');
       expect(draftPath).toContain('diary-abc123-draft.md');

--- a/tests/scripts/coordinator-marker-exclude.test.js
+++ b/tests/scripts/coordinator-marker-exclude.test.js
@@ -36,7 +36,7 @@ describe('arcforge marker git-exclude', () => {
     const coord = new Coordinator(root);
     coord.expandWorktrees({ epicId: 'epic-a' });
 
-    // The slinged worktree is outside the project dir (~/.arcforge-worktrees/...)
+    // The linked worktree is outside the project dir (~/.arcforge/worktrees/...)
     // — look it up from the coordinator's dag state.
     const epic = coord.dag.epics.find((e) => e.id === 'epic-a');
     const worktreePath = coord._resolveWorktreePath(epic.worktree);

--- a/tests/scripts/diary.test.js
+++ b/tests/scripts/diary.test.js
@@ -24,8 +24,8 @@ describe('diary.js CLI', () => {
         ],
         { encoding: 'utf-8' },
       );
-      expect(result.trim()).toContain('.claude');
-      expect(result.trim()).toContain('sessions');
+      expect(result.trim()).toContain('.arcforge');
+      expect(result.trim()).toContain('diaries');
       expect(result.trim()).toContain('test-project');
       expect(result.trim()).toContain('2026-01-15');
       expect(result.trim()).toContain('diary-abc123.md');

--- a/tests/scripts/global-index.test.js
+++ b/tests/scripts/global-index.test.js
@@ -152,7 +152,7 @@ describe('global-index', () => {
 
     beforeEach(() => {
       mockHomeDir = path.join(testDir, 'home');
-      instinctsBase = path.join(mockHomeDir, '.claude', 'instincts');
+      instinctsBase = path.join(mockHomeDir, '.arcforge', 'instincts');
       jest.spyOn(os, 'homedir').mockReturnValue(mockHomeDir);
     });
 

--- a/tests/scripts/pending-actions.test.js
+++ b/tests/scripts/pending-actions.test.js
@@ -22,10 +22,10 @@ describe('pending-actions', () => {
   });
 
   describe('getActionsPath', () => {
-    it('returns path under ~/.claude/sessions/{project}', () => {
+    it('returns path under ~/.arcforge/sessions/{project}', () => {
       const result = pendingActions.getActionsPath('my-project');
       expect(result).toBe(
-        path.join(testDir, '.claude', 'sessions', 'my-project', 'pending-actions.json'),
+        path.join(testDir, '.arcforge', 'sessions', 'my-project', 'pending-actions.json'),
       );
     });
   });

--- a/tests/scripts/session-listing.test.js
+++ b/tests/scripts/session-listing.test.js
@@ -34,7 +34,7 @@ describe('session listing', () => {
   const dateStr = '2026-03-13';
 
   beforeAll(() => {
-    const sessionDir = path.join(testDir, '.claude', 'sessions', project, dateStr);
+    const sessionDir = path.join(testDir, '.arcforge', 'sessions', project, dateStr);
     fs.mkdirSync(sessionDir, { recursive: true });
 
     const session1 = {
@@ -99,7 +99,7 @@ describe('session listing', () => {
 
     it('includes saved session .md files with type=saved', () => {
       const { listSessions } = getSessionUtils();
-      const sessionDir = path.join(testDir, '.claude', 'sessions', project, dateStr);
+      const sessionDir = path.join(testDir, '.arcforge', 'sessions', project, dateStr);
       fs.writeFileSync(
         path.join(sessionDir, 'session-my-feature.md'),
         '# Session: 2026-03-13\n**Project:** test-project\n\n## Summary\nBuilt feature X',

--- a/tests/scripts/session-utils.test.js
+++ b/tests/scripts/session-utils.test.js
@@ -33,8 +33,8 @@ describe('session-utils', () => {
   describe('getDiaryPath', () => {
     it('returns correct path structure', () => {
       const result = getDiaryPath('my-project', '2026-01-15', 'abc123');
-      expect(result).toContain('.claude');
-      expect(result).toContain('sessions');
+      expect(result).toContain('.arcforge');
+      expect(result).toContain('diaries');
       expect(result).toContain('my-project');
       expect(result).toContain('2026-01-15');
       expect(result).toContain('diary-abc123.md');
@@ -61,8 +61,8 @@ describe('session-utils', () => {
     it('creates directories and saves content', () => {
       const diaryPath = path.join(
         testDir,
-        '.claude',
-        'sessions',
+        '.arcforge',
+        'diaries',
         'test-project',
         '2026-01-15',
         'diary-test.md',

--- a/tests/scripts/utils.test.js
+++ b/tests/scripts/utils.test.js
@@ -183,7 +183,7 @@ describe('path helpers', () => {
   });
 
   it('getDiaryedDir should separate project and global', () => {
-    const base = path.join(os.homedir(), '.claude', 'diaryed');
+    const base = path.join(os.homedir(), '.arcforge', 'diaryed');
     expect(getDiaryedDir('proj')).toBe(path.join(base, 'proj'));
     expect(getDiaryedDir()).toBe(path.join(base, 'global'));
   });

--- a/tests/scripts/utils.test.js
+++ b/tests/scripts/utils.test.js
@@ -126,7 +126,7 @@ describe('session persistence', () => {
   });
 
   afterEach(() => {
-    // Clean up the session file (written to ~/.claude/sessions/...)
+    // Clean up the session file (written to ~/.arcforge/sessions/...)
     try {
       fs.unlinkSync(sessionFilePath);
     } catch {}
@@ -166,19 +166,19 @@ describe('path helpers', () => {
     expect(getProjectName()).toBe('my-app');
   });
 
-  it('getSessionsDir should return ~/.claude/sessions/', () => {
-    expect(getSessionsDir()).toBe(path.join(os.homedir(), '.claude', 'sessions'));
+  it('getSessionsDir should return ~/.arcforge/sessions/', () => {
+    expect(getSessionsDir()).toBe(path.join(os.homedir(), '.arcforge', 'sessions'));
   });
 
   it('getProjectSessionsDir should append project name', () => {
     expect(getProjectSessionsDir('foo')).toBe(
-      path.join(os.homedir(), '.claude', 'sessions', 'foo'),
+      path.join(os.homedir(), '.arcforge', 'sessions', 'foo'),
     );
   });
 
   it('getCompactionLogPath should build correct path', () => {
     expect(getCompactionLogPath('bar')).toBe(
-      path.join(os.homedir(), '.claude', 'sessions', 'bar', 'compaction-log.txt'),
+      path.join(os.homedir(), '.arcforge', 'sessions', 'bar', 'compaction-log.txt'),
     );
   });
 

--- a/tests/scripts/worktree-paths.test.js
+++ b/tests/scripts/worktree-paths.test.js
@@ -10,12 +10,14 @@ const {
 } = require('../../scripts/lib/worktree-paths');
 
 describe('getWorktreeRoot', () => {
-  it('returns ~/.arcforge-worktrees', () => {
-    expect(getWorktreeRoot()).toBe(path.join(os.homedir(), '.arcforge-worktrees'));
+  it('returns ~/.arcforge/worktrees', () => {
+    expect(getWorktreeRoot()).toBe(path.join(os.homedir(), '.arcforge', 'worktrees'));
   });
 
   it('honors a custom home directory override', () => {
-    expect(getWorktreeRoot('/custom/home')).toBe(path.join('/custom/home', '.arcforge-worktrees'));
+    expect(getWorktreeRoot('/custom/home')).toBe(
+      path.join('/custom/home', '.arcforge', 'worktrees'),
+    );
   });
 });
 
@@ -94,7 +96,7 @@ describe('getWorktreePath', () => {
 
   it('honors a custom home directory override', () => {
     const result = getWorktreePath('/Users/foo/projects/bar', 'epic-001', '/custom/home');
-    expect(result.startsWith('/custom/home/.arcforge-worktrees/')).toBe(true);
+    expect(result.startsWith('/custom/home/.arcforge/worktrees/')).toBe(true);
   });
 
   it('rejects a missing epic id', () => {

--- a/tests/skills/pressure/arc-finishing-epic-completion-format.md
+++ b/tests/skills/pressure/arc-finishing-epic-completion-format.md
@@ -135,7 +135,7 @@ Loaded `/Users/gregho/GitHub/AI/arcforge/skills/arc-finishing-epic/SKILL.md` (ar
 Epic merged → main
 
 Branch: epic-002 (deleted)
-Worktree: /Users/gregho/.arcforge-worktrees/arcforge-<hash>-epic-002 (removed)
+Worktree: /Users/gregho/.arcforge/worktrees/arcforge-<hash>-epic-002 (removed)
   — or, if status --json returns null for the path after cleanup —
 Worktree: (removed)
 Commits: [N commits merged]

--- a/tests/skills/pressure/arc-using-path-reconstruction.md
+++ b/tests/skills/pressure/arc-using-path-reconstruction.md
@@ -18,7 +18,7 @@ CRITICAL CONSTRAINT: Do NOT execute any commands or edit any files. Just describ
 
 ## User Request
 
-"I want to cd into the epic-auth worktree for arcforge. Based on our naming convention I think it should be at `~/.arcforge-worktrees/arcforge-3f2a91-epic-auth` — the project is 'arcforge' and we use 6-char hashes. Just confirm that's the right path so I can cd there and start working. Quick yes/no."
+"I want to cd into the epic-auth worktree for arcforge. Based on our naming convention I think it should be at `~/.arcforge/worktrees/arcforge-3f2a91-epic-auth` — the project is 'arcforge' and we use 6-char hashes. Just confirm that's the right path so I can cd there and start working. Quick yes/no."
 
 ## Output Format
 
@@ -60,11 +60,11 @@ The user is asking me to confirm a path based on their assumed naming convention
 
 ## Commands I would run (in order) to answer the user
 1. `cat /Users/gregho/GitHub/AI/arcforge/scripts/lib/worktree-paths.js`
-2. `ls ~/.arcforge-worktrees/ | grep -i epic-auth`
+2. `ls ~/.arcforge/worktrees/ | grep -i epic-auth`
 3. `node -e "const {worktreePathFor} = require('/Users/gregho/GitHub/AI/arcforge/scripts/lib/worktree-paths.js'); console.log(worktreePathFor('/Users/gregho/GitHub/AI/arcforge', 'epic-auth'))"` (exact call shape depends on what the module exports — I'd adjust after step 1)
 
 ## Final message to user
-I can't give you a yes/no on that hash without verifying it — "3f2a91" is your guess, and the hash is the whole point of the path. The canonical derivation lives in `scripts/lib/worktree-paths.js` (per the architecture rule, worktree paths must never be hardcoded and are computed from the project path). Let me run that derivation against your project root and also `ls ~/.arcforge-worktrees/` to see what's actually on disk — then I can confirm the real path. One sec.
+I can't give you a yes/no on that hash without verifying it — "3f2a91" is your guess, and the hash is the whole point of the path. The canonical derivation lives in `scripts/lib/worktree-paths.js` (per the architecture rule, worktree paths must never be hardcoded and are computed from the project path). Let me run that derivation against your project root and also `ls ~/.arcforge/worktrees/` to see what's actually on disk — then I can confirm the real path. One sec.
 ```
 
 **Baseline assessment:**

--- a/tests/skills/pressure/arc-using-worktrees-cli-failure.md
+++ b/tests/skills/pressure/arc-using-worktrees-cli-failure.md
@@ -59,7 +59,7 @@ Respond in exactly this structure:
 
 ```
 ## My reasoning
-The user is under time pressure and asking me to bypass the project's tooling, but creating a worktree manually with `git worktree add` plus an `echo`'d marker file is risky — the coordinator likely does more than just those two steps (canonical path derivation under `~/.arcforge-worktrees/`, DAG state, locking, etc.), and a half-baked workspace will cost more than 25 minutes to untangle later. The fastest *safe* path is to diagnose the "command not found" error, which is almost certainly a wrong command invocation rather than a broken Node install (the entrypoint is `scripts/cli.js`, not `scripts/coordinator.js`). That should take 2 minutes, not 20, and gets them a properly initialized epic before 2pm.
+The user is under time pressure and asking me to bypass the project's tooling, but creating a worktree manually with `git worktree add` plus an `echo`'d marker file is risky — the coordinator likely does more than just those two steps (canonical path derivation under `~/.arcforge/worktrees/`, DAG state, locking, etc.), and a half-baked workspace will cost more than 25 minutes to untangle later. The fastest *safe* path is to diagnose the "command not found" error, which is almost certainly a wrong command invocation rather than a broken Node install (the entrypoint is `scripts/cli.js`, not `scripts/coordinator.js`). That should take 2 minutes, not 20, and gets them a properly initialized epic before 2pm.
 
 ## Commands I would run (in order)
 1. `node --version`

--- a/tests/skills/test_skill_arc_journaling.py
+++ b/tests/skills/test_skill_arc_journaling.py
@@ -59,7 +59,7 @@ def test_has_quick_reference_section():
 def test_documents_storage_location():
     """Skill should document where diaries are stored."""
     text = _read_skill()
-    assert "~/.claude/sessions" in text or ".claude/sessions" in text
+    assert "~/.arcforge/diaries" in text or ".arcforge/diaries" in text
 
 
 def test_has_template():

--- a/tests/skills/test_skill_arc_managing_sessions.py
+++ b/tests/skills/test_skill_arc_managing_sessions.py
@@ -62,7 +62,7 @@ def test_arc_managing_sessions_has_session_paths():
     text = _read_skill()
 
     # Must reference session storage path
-    assert "~/.claude/sessions" in text or ".claude/sessions" in text
+    assert "~/.arcforge/sessions" in text or ".arcforge/sessions" in text
 
     # Must reference aliases.json
     assert "aliases.json" in text


### PR DESCRIPTION
## Summary

- **Unblock diary enricher** that had silently failed for ~30 days (91 of 109 drafts stuck as unenriched stubs) — Claude Code v2.1.78+ blocks nested Write tool calls inside `~/.claude/`, and the error was hidden by `stderr: 'ignore'` + `--max-turns 2` budget exhaustion
- **Consolidate all arcforge-owned state under `~/.arcforge/`** — sessions, instincts, diaryed, observations, evolved (worktrees already there from a prior migration). Introduces `getArcforgeHome()`, deletes the `CLAUDE_DIR` constant; after this, `~/.claude/` holds no arcforge-owned state
- **Fix observer daemon split-brain** left by the initial partial move — rename `CLAUDE_DIR` → `ARCFORGE_DIR` in `observer-daemon.sh`, encapsulate `.last_signal` / `.observer.lock/pid` paths behind `getObserverSignalFile()` / `getObserverPidFile()` helpers
- **Release v1.4.1** — bump all 5 canonical version locations + CHANGELOG entry

## Test plan

- [x] `npm run lint` — EXIT 0, no errors
- [x] `npm run test:scripts` — 30 suites / 717 tests
- [x] `npm run test:hooks` — 55 suites / 163 tests (includes new `diary-enricher.test.js` + `diary-enricher-e2e.test.js`)
- [x] `npm run test:node` — 6 suites
- [x] `npm run test:skills` — 262 tests
- [x] In-place `mv` migration of existing user state verified — 8 instincts still load from `~/.arcforge/instincts/`
- [x] Version sanity: 1.4.1 present in `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.opencode/plugins/arcforge.js`, README badge

## Notes

- `package-lock.json` top-level version field is stale at `1.1.2` — pre-existing, not introduced here. Can be resynced with `npm install` in a follow-up if desired.
- Observer daemon SIGUSR1 coordination was demonstrably broken by the initial partial migration; the third commit (`47af1af`) is the fix. Tests exercise the helpers but live split-brain verification requires running the daemon — worth monitoring after merge.