### PR TITLE
feat(docs): redesign hero schematic — correct SDD + add session lifecycle

### DIFF
--- a/website/page/hero.js
+++ b/website/page/hero.js
@@ -369,16 +369,16 @@ function HeroSchematic({
     d: "M0 20 H 500",
     stroke: t.ink,
     strokeWidth: "0.8"
-  })), ['brainstorm', 'refine', 'plan'].map((s, i) => /*#__PURE__*/React.createElement("g", {
+  })), ['brainstorm', 'refine', 'plan', 'coordinate'].map((s, i) => /*#__PURE__*/React.createElement("g", {
     key: s,
-    transform: `translate(${i * 170 + 40},35)`
+    transform: `translate(${i * 130 + 30},35)`
   }, /*#__PURE__*/React.createElement("g", {
     filter: "url(#sk-hero)"
   }, /*#__PURE__*/React.createElement("rect", {
-    x: "-55",
-    y: "-14",
-    width: "110",
-    height: "28",
+    x: "-48",
+    y: "-13",
+    width: "96",
+    height: "26",
     fill: t.bg,
     stroke: t.brass,
     strokeWidth: "1.2",
@@ -387,65 +387,120 @@ function HeroSchematic({
     y: "4",
     textAnchor: "middle",
     fill: t.ink,
-    fontSize: "11"
+    fontSize: "10"
   }, "arc-", s))), /*#__PURE__*/React.createElement("g", {
     filter: "url(#sk-hero)"
-  }, /*#__PURE__*/React.createElement("path", {
-    d: "M95 35 L125 35 M265 35 L295 35",
-    stroke: t.ember,
-    strokeWidth: "1.4",
-    fill: "none"
-  }), /*#__PURE__*/React.createElement("polygon", {
-    points: "121,31 129,35 121,39",
-    fill: t.ember
-  }), /*#__PURE__*/React.createElement("polygon", {
-    points: "291,31 299,35 291,39",
-    fill: t.ember
-  })), /*#__PURE__*/React.createElement("text", {
+  }, [0, 1, 2].map(i => {
+    const x1 = i * 130 + 30 + 48;
+    const x2 = (i + 1) * 130 + 30 - 48;
+    return /*#__PURE__*/React.createElement("g", {
+      key: i
+    }, /*#__PURE__*/React.createElement("path", {
+      d: `M${x1 + 2} 35 L${x2 - 4} 35`,
+      stroke: t.ember,
+      strokeWidth: "1.4",
+      fill: "none"
+    }), /*#__PURE__*/React.createElement("polygon", {
+      points: `${x2 - 8},31 ${x2},35 ${x2 - 8},39`,
+      fill: t.ember
+    }));
+  }))), /*#__PURE__*/React.createElement("g", {
+    transform: "translate(60,490)",
+    fontFamily: "JetBrains Mono,monospace"
+  }, /*#__PURE__*/React.createElement("text", {
     x: "0",
-    y: "90",
+    y: "0",
     fill: t.dim,
     fontSize: "10",
     letterSpacing: "2"
-  }, "SDD \xB7 DOWNSTREAM"), /*#__PURE__*/React.createElement("g", {
+  }, "SESSION \xB7 LIFECYCLE"), /*#__PURE__*/React.createElement("text", {
+    x: "256",
+    y: "0",
+    fill: t.brass,
+    fontSize: "10",
+    fontStyle: "italic",
+    fontFamily: "Fraunces,serif"
+  }, "hooks fire at every gate"), /*#__PURE__*/React.createElement("g", {
     filter: "url(#sk-hero)"
   }, /*#__PURE__*/React.createElement("path", {
-    d: "M0 110 H 500",
+    d: "M0 20 H 500",
     stroke: t.ink,
     strokeWidth: "0.8"
-  })), ['implement', 'loop', 'dispatch'].map((s, i) => /*#__PURE__*/React.createElement("g", {
-    key: s,
-    transform: `translate(${i * 170 + 40},125)`
+  })), [{
+    name: 'SessionStart',
+    sub: 'inject-skills'
+  }, {
+    name: 'UserPrompt',
+    sub: 'arc-using routes'
+  }, {
+    name: 'Pre/Post Tool',
+    sub: 'observe · quality'
+  }, {
+    name: 'Stop',
+    sub: 'journal · compact'
+  }].map((o, i) => /*#__PURE__*/React.createElement("g", {
+    key: o.name,
+    transform: `translate(${i * 130 + 30},45)`
   }, /*#__PURE__*/React.createElement("g", {
     filter: "url(#sk-hero)"
   }, /*#__PURE__*/React.createElement("rect", {
-    x: "-55",
-    y: "-14",
-    width: "110",
-    height: "28",
+    x: "-56",
+    y: "-16",
+    width: "112",
+    height: "32",
     fill: t.bg,
     stroke: t.ember,
     strokeWidth: "1.2",
     rx: "3"
   })), /*#__PURE__*/React.createElement("text", {
-    y: "4",
+    y: "-3",
     textAnchor: "middle",
     fill: t.ink,
-    fontSize: "11"
-  }, "arc-", s))), /*#__PURE__*/React.createElement("g", {
+    fontSize: "10",
+    fontWeight: "600"
+  }, o.name), /*#__PURE__*/React.createElement("text", {
+    y: "10",
+    textAnchor: "middle",
+    fill: t.dim,
+    fontSize: "8",
+    fontStyle: "italic",
+    fontFamily: "Fraunces,serif"
+  }, o.sub))), /*#__PURE__*/React.createElement("g", {
+    filter: "url(#sk-hero)"
+  }, [0, 1, 2].map(i => {
+    const x1 = i * 130 + 30 + 56;
+    const x2 = (i + 1) * 130 + 30 - 56;
+    return /*#__PURE__*/React.createElement("g", {
+      key: i
+    }, /*#__PURE__*/React.createElement("path", {
+      d: `M${x1 + 2} 45 L${x2 - 4} 45`,
+      stroke: t.ember,
+      strokeWidth: "1.4",
+      fill: "none"
+    }), /*#__PURE__*/React.createElement("polygon", {
+      points: `${x2 - 8},41 ${x2},45 ${x2 - 8},49`,
+      fill: t.ember
+    }));
+  })), /*#__PURE__*/React.createElement("g", {
     filter: "url(#sk-hero)"
   }, /*#__PURE__*/React.createElement("path", {
-    d: "M95 125 L125 125 M265 125 L295 125",
-    stroke: t.ember,
-    strokeWidth: "1.4",
-    fill: "none"
+    d: "M290 61 Q 225 85 160 61",
+    stroke: t.brass,
+    strokeWidth: "1.2",
+    fill: "none",
+    strokeDasharray: "3 3"
   }), /*#__PURE__*/React.createElement("polygon", {
-    points: "121,121 129,125 121,129",
-    fill: t.ember
-  }), /*#__PURE__*/React.createElement("polygon", {
-    points: "291,121 299,125 291,129",
-    fill: t.ember
-  }))), /*#__PURE__*/React.createElement("g", {
+    points: "164,57 156,61 164,65",
+    fill: t.brass
+  })), /*#__PURE__*/React.createElement("text", {
+    x: "225",
+    y: "90",
+    textAnchor: "middle",
+    fill: t.brass,
+    fontSize: "10",
+    fontStyle: "italic",
+    fontFamily: "Fraunces,serif"
+  }, "loops per prompt")), /*#__PURE__*/React.createElement("g", {
     fontFamily: "'Caveat',cursive",
     fontSize: "17",
     fill: t.brass

--- a/website/page/hero.jsx
+++ b/website/page/hero.jsx
@@ -124,43 +124,73 @@ function HeroSchematic({theme:t}) {
         })}
       </g>
 
-      {/* SDD flow below */}
+      {/* SDD upstream — 4 stations, correctly linear */}
       <g transform="translate(60,400)" fontFamily="JetBrains Mono,monospace">
         <text x="0" y="0" fill={t.dim} fontSize="10" letterSpacing="2">SDD · UPSTREAM</text>
         <g filter="url(#sk-hero)">
           <path d="M0 20 H 500" stroke={t.ink} strokeWidth="0.8"/>
         </g>
-        {['brainstorm','refine','plan'].map((s,i)=>(
-          <g key={s} transform={`translate(${i*170+40},35)`}>
+        {['brainstorm','refine','plan','coordinate'].map((s,i)=>(
+          <g key={s} transform={`translate(${i*130+30},35)`}>
             <g filter="url(#sk-hero)">
-              <rect x="-55" y="-14" width="110" height="28" fill={t.bg} stroke={t.brass} strokeWidth="1.2" rx="3"/>
+              <rect x="-48" y="-13" width="96" height="26" fill={t.bg} stroke={t.brass} strokeWidth="1.2" rx="3"/>
             </g>
-            <text y="4" textAnchor="middle" fill={t.ink} fontSize="11">arc-{s}</text>
+            <text y="4" textAnchor="middle" fill={t.ink} fontSize="10">arc-{s}</text>
           </g>
         ))}
         <g filter="url(#sk-hero)">
-          <path d="M95 35 L125 35 M265 35 L295 35" stroke={t.ember} strokeWidth="1.4" fill="none"/>
-          <polygon points="121,31 129,35 121,39" fill={t.ember}/>
-          <polygon points="291,31 299,35 291,39" fill={t.ember}/>
+          {[0,1,2].map(i=>{
+            const x1 = i*130 + 30 + 48;
+            const x2 = (i+1)*130 + 30 - 48;
+            return (
+              <g key={i}>
+                <path d={`M${x1+2} 35 L${x2-4} 35`} stroke={t.ember} strokeWidth="1.4" fill="none"/>
+                <polygon points={`${x2-8},31 ${x2},35 ${x2-8},39`} fill={t.ember}/>
+              </g>
+            );
+          })}
         </g>
+      </g>
 
-        <text x="0" y="90" fill={t.dim} fontSize="10" letterSpacing="2">SDD · DOWNSTREAM</text>
+      {/* Session lifecycle — how hooks fire across a session (distinct from SDD, complements the top-half agent/hook/skills-ring story) */}
+      <g transform="translate(60,490)" fontFamily="JetBrains Mono,monospace">
+        <text x="0" y="0" fill={t.dim} fontSize="10" letterSpacing="2">SESSION · LIFECYCLE</text>
+        <text x="256" y="0" fill={t.brass} fontSize="10" fontStyle="italic" fontFamily="Fraunces,serif">hooks fire at every gate</text>
         <g filter="url(#sk-hero)">
-          <path d="M0 110 H 500" stroke={t.ink} strokeWidth="0.8"/>
+          <path d="M0 20 H 500" stroke={t.ink} strokeWidth="0.8"/>
         </g>
-        {['implement','loop','dispatch'].map((s,i)=>(
-          <g key={s} transform={`translate(${i*170+40},125)`}>
+        {[
+          {name:'SessionStart',   sub:'inject-skills'},
+          {name:'UserPrompt',     sub:'arc-using routes'},
+          {name:'Pre/Post Tool',  sub:'observe · quality'},
+          {name:'Stop',           sub:'journal · compact'},
+        ].map((o,i)=>(
+          <g key={o.name} transform={`translate(${i*130+30},45)`}>
             <g filter="url(#sk-hero)">
-              <rect x="-55" y="-14" width="110" height="28" fill={t.bg} stroke={t.ember} strokeWidth="1.2" rx="3"/>
+              <rect x="-56" y="-16" width="112" height="32" fill={t.bg} stroke={t.ember} strokeWidth="1.2" rx="3"/>
             </g>
-            <text y="4" textAnchor="middle" fill={t.ink} fontSize="11">arc-{s}</text>
+            <text y="-3" textAnchor="middle" fill={t.ink} fontSize="10" fontWeight="600">{o.name}</text>
+            <text y="10" textAnchor="middle" fill={t.dim} fontSize="8" fontStyle="italic" fontFamily="Fraunces,serif">{o.sub}</text>
           </g>
         ))}
         <g filter="url(#sk-hero)">
-          <path d="M95 125 L125 125 M265 125 L295 125" stroke={t.ember} strokeWidth="1.4" fill="none"/>
-          <polygon points="121,121 129,125 121,129" fill={t.ember}/>
-          <polygon points="291,121 299,125 291,129" fill={t.ember}/>
+          {[0,1,2].map(i=>{
+            const x1 = i*130 + 30 + 56;
+            const x2 = (i+1)*130 + 30 - 56;
+            return (
+              <g key={i}>
+                <path d={`M${x1+2} 45 L${x2-4} 45`} stroke={t.ember} strokeWidth="1.4" fill="none"/>
+                <polygon points={`${x2-8},41 ${x2},45 ${x2-8},49`} fill={t.ember}/>
+              </g>
+            );
+          })}
         </g>
+        {/* inner loop: Pre/PostTool → UserPrompt — tool cycles repeat per prompt */}
+        <g filter="url(#sk-hero)">
+          <path d="M290 61 Q 225 85 160 61" stroke={t.brass} strokeWidth="1.2" fill="none" strokeDasharray="3 3"/>
+          <polygon points="164,57 156,61 164,65" fill={t.brass}/>
+        </g>
+        <text x="225" y="90" textAnchor="middle" fill={t.brass} fontSize="10" fontStyle="italic" fontFamily="Fraunces,serif">loops per prompt</text>
       </g>
 
       {/* annotation */}


### PR DESCRIPTION
## Summary
Fixes two correctness bugs in the hero's mini-schematic (Section 001) and rewrites its bottom-half content so it no longer duplicates Section 002.

## Bugs fixed

**B1 · Downstream band drawn as a serial pipeline.** `arc-implement → arc-loop → arc-dispatch` with arrows between them mis-described the actual model — the four downstream modes (`arc-agent-driven`, `arc-implementing`, `arc-dispatching-teammates`, `arc-looping`) are a **chooser routed by scope × attendance**, not a pipeline. This was the same correctness bug that Section 002 already corrected in an earlier cycle; the fix hadn't propagated to the hero.

**B2 · Skills list incomplete.** Upstream showed 3 of 4 stations (missing `arc-coordinate`). Downstream showed 3 of 4 modes (missing `arc-agent-driven`) — and was the wrong shape anyway.

## What changed

### Upstream (fix A — keep shape, correct content)
Now shows all four stations linearly (`arc-brainstorm → arc-refine → arc-plan → arc-coordinate`). Linear arrows stay because upstream *is* sequential. Box width 110→96px to fit 4 stations inside the 500px band.

### Downstream → replaced by Session Lifecycle (rewrite B1)
The downstream band was cutting the same cake as Section 002's detailed chooser. Replaced with a new **SESSION · LIFECYCLE** band explaining *when* hooks fire across a session:

```
SessionStart  →  UserPrompt  →  Pre/Post Tool  →  Stop
(inject-skills) (arc-using    (observe ·        (journal ·
                 routes)       quality)          compact)
                      ↖___________↙
                   loops per prompt
```

A dashed inner-loop arrow back from `Pre/Post Tool` to `UserPrompt` shows the tool-call cycle per prompt. This complements the hero's top-half (agent → inject-skills → skills ring) by answering "*when* do those skills get injected?" instead of repeating Section 002.

## Design rationale
- Hero's first-impression budget is ~2s of user attention → showing a chooser diagram with 4 labelled mode-cards at that scale would be too dense.
- Section 002 is where the chooser visual belongs (with room for each mode's axis labels and notes).
- Hero schematic now explains **the mechanism** (hooks × lifecycle) rather than **the methodology** (SDD pipeline). Section 002 does methodology properly.

## Test plan
- [ ] Desktop: both bands render within the 620×640 viewBox, no overflow
- [ ] Mobile (~390px): schematic scales down via SVG viewBox, still legible
- [ ] Labels don't overlap: longest box label "Pre/Post Tool" (13 chars × ~6.5px mono) fits 112px box
- [ ] Inner-loop dashed arrow renders and the "loops per prompt" annotation reads clearly
- [ ] Cloudflare preview deploys cleanly