### PR TITLE
docs: drop pre-release migration sections and extend release audit

### DIFF
--- a/.claude/skills/arc-releasing/SKILL.md
+++ b/.claude/skills/arc-releasing/SKILL.md
@@ -79,6 +79,20 @@ grep -rn "<old-version>" skills/ docs/guide/
 
 Also check for renamed helpers, removed CLI flags, or deprecated config keys that the SKILL.md / rules / guides still mention.
 
+**Install docs and platform READMEs get missed every release** because they sit off the main code path — "what did this release touch" diffs usually light up `scripts/`, `skills/`, `docs/guide/`, not `.codex/` / `.gemini/` / `.opencode/` / `docs/README.*.md`. Audit all six every release:
+
+| File | Why it matters |
+|---|---|
+| `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md` | Fetched and executed by the quick-install one-liner — broken commands ship silently to every new user |
+| `docs/README.codex.md`, `docs/README.gemini.md`, `docs/README.opencode.md` | Human-facing platform guides |
+
+Things to verify, with reasoning:
+
+- **No hardcoded skill/symlink counts.** Values like "24 symlinks" drift every time a skill ships. Replace with invariants ("one symlink per skill") — a description that stays true across all releases needs no maintenance.
+- **No stale path references.** If this release moved anything (state dirs, worktree paths, config locations), greps from the examples above apply here too.
+- **Sibling parity, with judgment.** When Gemini/Codex/OpenCode docs diverge, ask whether the asymmetry is intentional before "fixing" it. Windows shell variants (cmd/PowerShell/Git Bash) being uneven is usually real drift; a missing Tool Mapping table in the Codex doc is intentional (Codex's tool vocabulary isn't publicly documented). Don't blindly force parity — verify *why* they differ first.
+- **Pre-v1.0.0: no "Migrating from old paths" sections.** Before the first public release, migration sections describe fictional users — there is no prior published version they could be migrating from. Keep only the latest setup until after v1.0.0 ships.
+
 **Never rewrite past `CHANGELOG.md` entries.** They are history, and downstream users, the vault's Decision notes, and `git log vPREV..vCURRENT` workflows all depend on them being stable. If a past entry turns out wrong, add a correction inside the *new* release's entry. Stealth edits break provenance.
 
 Out-of-scope for this audit (do not modify):
@@ -156,6 +170,7 @@ These are the steps that get skipped when a contributor is in a hurry. The skill
 - **Ingest before bump.** Once the version flips, the "why" narrative is harder to reconstruct for the vault. That's why it's step 1, not step 5.
 - **`.opencode/plugins/arcforge.js`.** The only non-JSON, non-README version location. It doesn't pattern-match "config file" in a search, so it gets missed.
 - **README badge URL.** The shields.io badge is image-cached; stale numbers visually persist even after every other file is correct. Worth an extra explicit mention.
+- **The six install-surface files.** `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md` plus the three `docs/README.{codex,gemini,opencode}.md` files are sibling-flat and don't light up in normal "what did this release touch" diffs. Step 2 covers the audit details.
 - **Secret scan.** Release commits are large diffs. `git diff --cached | grep -iE "api[_-]?key|token|secret|password"` before pushing. The cost of a false positive is low; the cost of a committed secret is very high.
 - **Daily note append.** After the release ships, `obsidian daily:append` with a one-line release summary so the release is preserved in the vault's chronological log, not only in `log.md`.
 - **The post-merge tag.** Merging the PR does not auto-tag. This is the single most commonly skipped step.

--- a/.claude/skills/arc-releasing/evals/evals.json
+++ b/.claude/skills/arc-releasing/evals/evals.json
@@ -21,6 +21,13 @@
       "prompt": "I want to bump to 1.4.2. The branch is fix/readme-typos — just one commit that fixes three typos in README.md (one was 'arcfroge' instead of 'arcforge', one was a broken markdown link, one was an extra period). That's literally all that changed. Can we release?",
       "expected_output": "Response should recognize this is a trivial patch with no architectural content. Vault ingest scope should be 'skip or just log.md entry' — NOT a full decision note, NOT a refresh of multiple Source notes. CHANGELOG entry should go under Fixed with a brief single-bullet entry. All 5 version locations still need bumping (the minimum is still the minimum). Should still suggest the post-merge tag. Should pause for semver confirmation with 'patch' recommendation.",
       "files": []
+    },
+    {
+      "id": 3,
+      "name": "install-docs-have-drift",
+      "prompt": "我要 release v1.4.2. Branch fix/session-memory-consolidation — 3 commits 修 session memory 跟 global auto-memory 的 coexistence bug。測試全綠, lint 綠。版本從 1.4.1 bump。開始 release workflow。注意: arcforge 還沒正式 release (pre-v1.0.0 phase 的規則一樣適用 — 不該有 Migrating from old paths 段落)。Repo 目前 shipped skill count 是 33。repo 的實際狀態: .gemini/INSTALL.md 還寫 'You should see 24 symlinks' (stale);.codex/INSTALL.md 有一段完整的 'Migrating from ~/.codex/arcforge' section (pre-release 不該保留);docs/README.codex.md 的 Windows 小節只有 PowerShell,sibling (Gemini/OpenCode) 都有 cmd/PowerShell/Git Bash 三種。",
+      "expected_output": "Step 2 audit should explicitly enumerate and check all six install-surface files (.codex/INSTALL.md, .gemini/INSTALL.md, .opencode/INSTALL.md, docs/README.codex.md, docs/README.gemini.md, docs/README.opencode.md). Should (a) flag the '24 symlinks' in .gemini/INSTALL.md as hardcoded drift and recommend replacing with an invariant phrasing like 'one symlink per skill' rather than bumping the number to 33, (b) flag the Migrating section in .codex/INSTALL.md as inappropriate pre-v1.0.0 because there is no prior public version users could be migrating from, (c) note the Windows shell asymmetry in docs/README.codex.md but apply judgment about whether this is intentional drift or a real gap — should not blindly force parity. Agent should refuse to proceed past Step 2 until the drift is addressed, not treat it as cosmetic. Should still walk through the rest of the release workflow (CHANGELOG, 5-file bump, commit/push/PR, post-merge tag) after the drift is fixed.",
+      "files": []
     }
   ]
 }

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -25,35 +25,6 @@ Enable agentic skills in Codex via native skill discovery. One clone, one symlin
 
 4. **Restart Codex** to discover the skills.
 
-## Migrating from old paths
-
-If you previously cloned to `~/.codex/arcforge`:
-
-1. Remove the old symlink (if any):
-   ```bash
-   rm -f ~/.agents/skills/arcforge
-   ```
-
-2. Move the clone to the new location:
-   ```bash
-   mv ~/.codex/arcforge ~/.agents/arcforge
-   ```
-
-3. Pull latest changes:
-   ```bash
-   cd ~/.agents/arcforge && git pull
-   ```
-
-4. Create the new symlink:
-   ```bash
-   mkdir -p ~/.agents/skills
-   ln -s ~/.agents/arcforge/skills ~/.agents/skills/arcforge
-   ```
-
-5. Remove the old bootstrap block from `~/.codex/AGENTS.md` (if present).
-
-6. Restart Codex.
-
 ## Verify
 
 ```bash

--- a/.gemini/INSTALL.md
+++ b/.gemini/INSTALL.md
@@ -25,44 +25,13 @@ Enable agentic skills in Gemini CLI via native skill discovery.
 
 Gemini expects skill folders directly under `~/.gemini/skills/`, so each skill gets its own symlink.
 
-## Migrating from old paths
-
-If you previously cloned to `~/.gemini/arcforge`:
-
-1. Remove old symlinks (if any):
-   ```bash
-   rm -f ~/.gemini/skills/arcforge
-   ```
-
-2. Move the clone to the new location:
-   ```bash
-   mv ~/.gemini/arcforge ~/.agents/arcforge
-   ```
-
-3. Pull latest changes:
-   ```bash
-   cd ~/.agents/arcforge && git pull
-   ```
-
-4. Create per-skill symlinks:
-   ```bash
-   mkdir -p ~/.gemini/skills
-   for skill in ~/.agents/arcforge/skills/arc-*/; do
-     ln -sf "$skill" ~/.gemini/skills/
-   done
-   ```
-
-5. Remove the old bootstrap block from `~/.gemini/GEMINI.md` (if present).
-
-6. Restart Gemini CLI.
-
 ## Verify
 
 ```bash
 ls ~/.gemini/skills/arc-*
 ```
 
-You should see 24 symlinks, each pointing to a skill directory in `~/.agents/arcforge/skills/`.
+You should see one symlink per skill, each pointing to a directory in `~/.agents/arcforge/skills/`.
 
 ## Updating
 

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -28,37 +28,6 @@ Enable agentic skills in OpenCode via native skill discovery and system transfor
 
 4. **Restart OpenCode** to discover skills and load the plugin.
 
-## Migrating from old paths
-
-If you previously cloned to `~/.config/opencode/arcforge`:
-
-1. Remove old symlinks (if any):
-   ```bash
-   rm -f ~/.config/opencode/skills/arcforge
-   rm -f ~/.config/opencode/plugins/arcforge.js
-   ```
-
-2. Move the clone to the new location:
-   ```bash
-   mv ~/.config/opencode/arcforge ~/.agents/arcforge
-   ```
-
-3. Pull latest changes:
-   ```bash
-   cd ~/.agents/arcforge && git pull
-   ```
-
-4. Create the new symlinks:
-   ```bash
-   mkdir -p ~/.config/opencode/skills
-   ln -s ~/.agents/arcforge/skills ~/.config/opencode/skills/arcforge
-
-   mkdir -p ~/.config/opencode/plugins
-   ln -s ~/.agents/arcforge/.opencode/plugins/arcforge.js ~/.config/opencode/plugins/arcforge.js
-   ```
-
-5. Restart OpenCode.
-
 ## Verify
 
 ```bash

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -42,9 +42,18 @@ Codex scans `~/.agents/skills/` for skill directories at startup. Each directory
 
 The symlink `~/.agents/skills/arcforge` points into the cloned repo's `skills/` directory, making all arcforge skills visible to Codex without copying files. The `description` field in each skill's SKILL.md frontmatter tells Codex when to auto-activate the skill (e.g., `"Use when exploring ideas before implementation"`).
 
+> **Note:** The `~/.agents/arcforge` clone is shared with Gemini CLI. If you already installed arcforge for Gemini, skip step 1 and reuse the existing clone.
+
 ## Usage
 
 Skills are discovered automatically after installation. Use them as you would any native Codex skill.
+
+## Skill Priority
+
+1. **Personal skills** (`~/.agents/skills/my-skill/`) — your own skills
+2. **Agentic skills** (`~/.agents/skills/arcforge/`) — symlinked from the arcforge repo
+
+Higher-priority skills override lower ones with the same name.
 
 ### Personal Skills
 
@@ -94,9 +103,19 @@ unlink ~/.agents/skills/arcforge
 rm -rf ~/.agents/arcforge   # optional: remove the repo
 ```
 
-## Windows (PowerShell)
+> **Note:** If Gemini CLI also uses this clone, removing `~/.agents/arcforge` will affect Gemini too.
 
-### Installation
+## Windows
+
+### cmd
+
+```cmd
+git clone https://github.com/GregoryHo/arcforge.git "%USERPROFILE%\.agents\arcforge"
+mkdir "%USERPROFILE%\.agents\skills"
+mklink /J "%USERPROFILE%\.agents\skills\arcforge" "%USERPROFILE%\.agents\arcforge\skills"
+```
+
+### PowerShell
 
 ```powershell
 git clone https://github.com/GregoryHo/arcforge.git "$env:USERPROFILE\.agents\arcforge"
@@ -104,7 +123,15 @@ New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills"
 cmd /c mklink /J "$env:USERPROFILE\.agents\skills\arcforge" "$env:USERPROFILE\.agents\arcforge\skills"
 ```
 
-### Uninstalling
+### Git Bash
+
+```bash
+git clone https://github.com/GregoryHo/arcforge.git ~/.agents/arcforge
+mkdir -p ~/.agents/skills
+ln -s ~/.agents/arcforge/skills ~/.agents/skills/arcforge
+```
+
+### Uninstalling (PowerShell)
 
 ```powershell
 cmd /c rmdir "$env:USERPROFILE\.agents\skills\arcforge"

--- a/docs/README.gemini.md
+++ b/docs/README.gemini.md
@@ -127,6 +127,6 @@ done
 
 ### Skills not found
 
-1. Verify symlinks: `ls -la ~/.gemini/skills/arc-*` (should show 24 symlinks)
+1. Verify symlinks: `ls -la ~/.gemini/skills/arc-*` (should show one symlink per skill)
 2. Verify a skill resolves: `ls ~/.gemini/skills/arc-using/SKILL.md`
 3. Restart Gemini CLI to trigger skill discovery


### PR DESCRIPTION
## Summary

- Remove "Migrating from old paths" sections from `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`, and `docs/README.codex.md`. Pre-v1.0.0 toolkit has no prior published version — these sections described fictional users and added install-doc weight without serving a real audience.
- Replace hardcoded "24 symlinks" count in `.gemini/INSTALL.md` and `docs/README.gemini.md` with an invariant phrasing ("one symlink per skill") that stays correct as the shipped skill count changes across releases.
- Sync `docs/README.codex.md` to match its Gemini/OpenCode siblings: add Skill Priority section, cross-platform shared-clone note, Windows `cmd`/`Git Bash` variants (was PowerShell-only), and shared-clone uninstall caveat.
- Extend `arc-releasing` Step 2 with an explicit six-file install-surface audit. New guidance includes reasoning-bearing rules: no hardcoded skill counts, sibling parity with judgment (not blind), and pre-v1.0.0 migration-section prohibition. Added `Things That Are Easy to Forget` pointer for bump-in-a-hurry mode.
- Added eval `id: 3` (`install-docs-have-drift`) to the skill's eval set — probes whether the release workflow catches these drift classes (stale count / inappropriate migration / asymmetric Windows shells) before shipping.

Net: +54 / −96 lines. The pre-release artifacts removed outweigh the audit additions.

## Test plan

- [x] JSON validates: `python3 -c "import json; json.load(open('.claude/skills/arc-releasing/evals/evals.json'))"` — 4 evals, ids 0-3
- [x] Grep confirms no "Migrating" or "24 symlinks" residue in the six install-surface files
- [x] `arc-releasing` SKILL.md word count 2059 (Meta tier, acceptable for a release-workflow meta-skill)
- [ ] Vibe-check the new Step 2 audit content reads cleanly alongside existing Step 2 structure
- [ ] Verify `docs/README.codex.md` Windows section renders correctly on GitHub (three sub-sections: cmd / PowerShell / Git Bash)