### PR TITLE
docs(learning): reconcile layer 0-8 schema contracts

### DIFF
--- a/docs/plans/2026-05-09-learning-curator-schema-contracts.md
+++ b/docs/plans/2026-05-09-learning-curator-schema-contracts.md
@@ -83,6 +83,37 @@ This file is the schema contract index and governance document. It is not the so
 7. Runtime influence is forbidden before explicit Layer 8 activation. Pending, approved, and materialized artifacts must not alter Claude runtime behavior.
 8. Debug artifacts are local-only, retention-bound, excluded from default production readers, and never primary evidence for future learning runs.
 
+## Persistence root organization
+
+The learning subsystem persists state under two roots with deliberately different retention contracts:
+
+- `~/.arcforge/observations/` holds **raw evidence**. Files here (`<project>/observations.jsonl`) are subject to retention/purge/quarantine policies and may be deleted without violating any product invariant. Observation data is local-only and is not a candidate or product-truth artifact.
+- `~/.arcforge/learning/` holds **curator artifacts** that constitute Layer 3-8 product truth — curator batch manifests, curator run manifests, the candidate queue, rejection audits, materialization records, activation records, dashboard audit logs, and optional debug artifacts. These follow append-only / event-log / atomic-overwrite semantics and have stricter retention than raw observations.
+
+Implementers must respect this split: an observation in `~/.arcforge/observations/` may be retired aggressively; a candidate event in `~/.arcforge/learning/candidates/queue.jsonl` is product state and must not be silently dropped. The split is not an organizational accident — it expresses different retention contracts and different relationships to runtime influence.
+
+## Artifact terminology (Manifest / Record / Event)
+
+Three artifact patterns appear across layers and must be named consistently:
+
+- **Manifest** — pre-handoff metadata describing the *input* a layer received. Examples: Layer 3 `CuratorBatchManifest` (what evidence went into the batch), Layer 4 `CuratorRunManifest` (what batch + policy went into the LLM run).
+- **Record** — post-side-effect proof a layer wrote. Examples: Layer 7 `MaterializationRecord` (what draft files were written), Layer 8 `ActivationRecord` (what active surface was changed).
+- **Event** — append-only lifecycle line in Layer 5's `queue.jsonl`. Captures `candidate.created`, `candidate.transitioned`, `candidate.updated`, `candidate.related`.
+
+The three concepts are genuinely different (input metadata, output proof, lifecycle log line). Use the right noun for the right artifact. Do not call a Layer 7 materialization output a "manifest", and do not call a Layer 5 lifecycle event a "record".
+
+## Daemon role
+
+The bash daemon (`skills/arc-observing/scripts/observer-daemon.sh`) is a Layer 3+4 orchestrator and a Layer 5 consumer. It is not a schema authority at any layer.
+
+Specifically, the daemon:
+
+- triggers Layer 3 batch assembly (Node CLI call);
+- triggers Layer 4 prompt assembly + LLM curator invocation (bash spawns `claude -p`, wrapped in a watchdog);
+- hands the LLM proposal payload to Layer 5 (Node CLI call) for validation, sanitization, dedupe, and queue append.
+
+The daemon does not own validation logic, schema definitions, sanitizer rules, or lifecycle state. Those live in shared Node modules (`scripts/lib/sanitize-observation.js`, `scripts/lib/learning-curator/*.js`) that other entrypoints — `/recall`, `/reflect`, dashboard `[Evolve]` — also call. See the implementation plan's "Daemon Redesign Depth" section for the full division of responsibility.
+
 ## Reference file layout
 
 ```text

--- a/docs/plans/references/learning-curator-schema/layer-2-sanitization-derived-semantic-view.md
+++ b/docs/plans/references/learning-curator-schema/layer-2-sanitization-derived-semantic-view.md
@@ -350,7 +350,7 @@ Derived semantic view is not primary persisted observation data. It is a read-ti
 type DerivedSemanticView = {
   tool: string;
 
-  operation?:
+  operation_kind?:
     | "shell"
     | "read"
     | "write"
@@ -405,7 +405,7 @@ Examples:
 ```json
 {
   "tool": "Bash",
-  "operation": "shell",
+  "operation_kind": "shell",
   "command_kind": "test"
 }
 ```
@@ -413,7 +413,7 @@ Examples:
 ```json
 {
   "tool": "Read",
-  "operation": "read",
+  "operation_kind": "read",
   "path_class": "docs",
   "file_kind": "md"
 }

--- a/docs/plans/references/learning-curator-schema/layer-4-llm-curator-analysis.md
+++ b/docs/plans/references/learning-curator-schema/layer-4-llm-curator-analysis.md
@@ -106,6 +106,9 @@ type CuratorPromptPolicy = {
   no_file_writes: true;
   no_activation_claims: true;
 
+  sanitizer_module: "scripts/lib/sanitize-observation.js";
+  sanitizer_policy_version: string;
+
   output_format: "json";
 };
 ```
@@ -128,6 +131,8 @@ The prompt must instruct the LLM:
 - do not assign candidate IDs, lifecycle status, final confidence, or final evidence quality;
 - for the first 3.1 daemon-curator policy, output `instinct` proposals only;
 - if evidence is weak, output `needs_more_evidence` or no proposal.
+
+The Curator Prompt Builder must run the bounded batch through `scripts/lib/sanitize-observation.js` (the canonical sanitizer) before passing it to the LLM. The `sanitizer_policy_version` recorded in the prompt policy must match the `rule_version` Layer 5 stamps on accepted candidates. Layer 4 and Layer 5 must agree on the same sanitizer module to close the secret-scan gap by construction.
 
 ## Primary output — CandidateProposalPayload
 
@@ -202,7 +207,7 @@ type CandidateProposalDraft = {
   trigger?: string;
 
   body?: string;
-  body_source?: "llm_draft";
+  body_source?: "llm_curator";
 
   evidence_refs: CandidateProposalEvidenceRef[];
 
@@ -219,6 +224,8 @@ type CandidateProposalDraft = {
 ```
 
 Use `name`, not `title`, to avoid avoidable drift between Layer 4 proposals and later canonical candidate records.
+
+`body_source` is `"llm_curator"` at the source (Layer 4 *is* the LLM curator). It must not be `"llm_draft"`, `"draft"`, or any other label that would require Layer 5 to normalize. The enum value Layer 4 emits is the same enum value Layer 5 accepts, eliminating mid-pipeline rename drift.
 
 For the first 3.1 daemon-curator policy, `proposed_scope.kind` is `"project"`. Global candidate proposals come from explicit first-slice dashboard promotion/review flows through Layer 6 → Layer 5, not from the default production Layer 4 daemon-curator path.
 

--- a/docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md
+++ b/docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md
@@ -232,6 +232,7 @@ type CandidateRejectionReason = {
     | "missing_required_field"
     | "field_too_long"
     | "evidence_ref_missing"
+    | "evidence_ref_omitted_upstream"
     | "evidence_type_mismatch"
     | "too_few_evidence_refs"
     | "too_many_evidence_refs"
@@ -250,6 +251,21 @@ type CandidateRejectionReason = {
 ```
 
 `detail` must be sanitized and bounded. It must not contain raw prompt text, raw response text, raw evidence bodies, transcript bodies, hook payloads, file contents, or secrets.
+
+### Upstream evidence-status mapping
+
+Layer 2 / Layer 3 produce `evidence_status ∈ { "present", "omitted_no_input", "omitted_unsupported_tool", "omitted_safety" }` on each evidence item. When Layer 5 validates a proposal's `evidence_refs`, it dereferences each cited `evidence_id` to its source batch item and reads that item's `evidence_status`. The mapping below converts upstream status into Layer 5 rejection outcomes:
+
+| Upstream `evidence_status` | Layer 5 outcome |
+|---|---|
+| `present` | The evidence is citable. Proceed with normal validation. |
+| `omitted_no_input` | Reject with `evidence_ref_omitted_upstream` (`detail` indicates "no input upstream"). |
+| `omitted_unsupported_tool` | Reject with `evidence_ref_omitted_upstream` (`detail` indicates "tool not in allowlist"). |
+| `omitted_safety` | Reject with `evidence_ref_omitted_upstream` (`detail` indicates "upstream omitted for safety"). |
+
+`evidence_ref_omitted_upstream` is distinct from `evidence_ref_missing` (which means the cited `evidence_id` does not exist in the batch at all). The new code closes the gap where a proposal could cite an evidence item that Layer 2/3 already omitted, which a non-mapped Layer 5 would otherwise silently accept.
+
+A proposal whose **every** cited evidence ref resolves to `evidence_status ≠ "present"` must be rejected. A proposal with mixed status may still be valid if the remaining `present` refs satisfy `min_evidence_refs_per_proposal`.
 
 ```ts
 type RejectionSafetyMetadata = {
@@ -412,19 +428,19 @@ type CandidateScope =
     }
   | {
       kind: "global";
-      promoted_from_candidate_id: string;
-      promoted_from_project_id: string;
     };
 ```
 
 Daemon / Layer 4 proposals must create project-scoped candidates only. Global candidates are first-slice product behavior, but they are created only by an explicit Layer 6 dashboard `[Promote]` action through the `dashboard_promote` source adapter.
 
+**Cross-layer invariant — promotion source linkage lives in relationships, not in scope.** `CandidateScope` describes the candidate's *current* scope (project or global). Lineage from a source candidate is a relationship and must be stored only on `CandidateRelationships`. Do not re-introduce `promoted_from_candidate_id` or `promoted_from_project_id` on `CandidateScope`.
+
 Promotion creates a new canonical candidate record with:
 
-- `scope.kind: "global"`;
+- `scope.kind: "global"` (no extra scope fields — lineage lives elsewhere);
 - `source.source_type: "dashboard_promote"`;
-- `source.promote.source_candidate_id` and `source.promote.source_project_id`;
-- `relationships.promoted_from_candidate_id` on the global candidate;
+- `source.promote.source_candidate_id` and `source.promote.source_project_id` (audit provenance of the creation event);
+- `relationships.promoted_from_candidate_id` on the global candidate (single source of truth for the linkage);
 - `relationships.promoted_to_candidate_id` recorded on the source project candidate through a `candidate.related` event.
 
 Promotion does not activate behavior, does not materialize files, and does not mutate the original candidate body except for deterministic scope/relationship metadata required by the global candidate record.
@@ -497,6 +513,10 @@ project_obs_count >= 1000  → high
 project_obs_count < 100  → low
 ```
 
+**3.1 v1 rule consumes `project_obs_count` only.** All other `basis` fields (cited_evidence_count, cited_evidence_by_type, has_user_correction, has_manual_recall, has_reflect_pattern, has_error_repair_sequence) are **future-extension fields**. They may be populated by the calculator for audit/debug, but the v1 quality formula must not read them. Layer 3 transcript summary support is deferred; until Layer 3 emits transcript summaries, the calculator may leave `cited_evidence_by_type.session_summary` as 0 without affecting quality.
+
+This pin closes the back-door dependency where Layer 5 quality could silently change behavior based on whether Layer 3 transcript summaries existed. Future formula upgrades are additive and must be versioned via `rule_version`.
+
 Layer 5 also stores the rule basis:
 
 ```ts
@@ -504,7 +524,10 @@ type EvidenceQualityMetadata = {
   rule_version: string;
 
   basis: {
+    // Consumed by v1 formula:
     project_obs_count: number;
+
+    // Recorded for audit / future formula versions only — NOT consumed by v1:
     cited_evidence_count: number;
 
     cited_evidence_by_type: {
@@ -677,6 +700,29 @@ return validation error
 ```
 
 Layer 5 may record successful `materialized`, `activated`, `deactivated`, and `superseded` transitions reported by later layers, but it must not perform those side effects itself.
+
+### Action × Status legality matrix (canonical)
+
+Layer 6 dashboard actions and CLI lifecycle actions must consult this matrix. Layer 5 is the canonical authority — any action handler at any layer must reject requests that violate it. `✓` = action is legal from this status; `✗` = action must be rejected with `policy_violation`.
+
+```text
+status \ action       │ dismiss │ approve │ materialize │ activate │ promote │ evolve
+─────────────────────────────────────────────────────────────────────────────────────
+pending_review        │   ✓     │   ✓     │     ✗       │    ✗     │   ✓     │   ✓
+needs_more_evidence   │   ✓     │   ✗     │     ✗       │    ✗     │   ✗     │   ✗
+approved              │   ✗     │   ✗     │     ✓       │    ✗     │   ✓     │   ✓
+materialized          │   ✗     │   ✗     │     ✗       │    ✓     │   ✗     │   ✗
+activated             │   ✗     │   ✗     │     ✗       │    ✗     │   ✗     │   ✗
+deactivated           │   ✗     │   ✗     │     ✓       │    ✓     │   ✗     │   ✗
+dismissed             │   ✗     │   ✗     │     ✗       │    ✗     │   ✗     │   ✗
+superseded            │   ✗     │   ✗     │     ✗       │    ✗     │   ✗     │   ✗
+```
+
+Notes:
+
+- `promote` and `evolve` are candidate-producing actions, not status transitions on the source candidate. They create a new candidate (global-scoped for `promote`; evolved skill candidate for `evolve`) and add a relationship event on the source. The source candidate's lifecycle status does not change.
+- `materialize` and `activate` require the prior state to be `approved` and `materialized` respectively. The deactivated → materialized / activated path allows re-materializing or re-activating a previously deactivated artifact.
+- `dismiss` is reversible only via re-creating a new candidate; once `dismissed` it is terminal.
 
 ## Relationships
 
@@ -890,6 +936,7 @@ Layer 5 records what safety checks were applied to accepted candidates.
 type CandidateSafetyMetadata = {
   validator_version: string;
   sanitizer_policy_version: string;
+  sanitizer_module: "scripts/lib/sanitize-observation.js";
 
   raw_prompt_included: false;
   raw_response_included: false;
@@ -914,6 +961,16 @@ type CandidateSafetyMetadata = {
 ```
 
 Layer 5 accepted records must not include raw unsafe material. Tests and evals should assert these flags and inspect persisted candidate records.
+
+### Shared sanitizer contract
+
+`secret_scan.rule_version` and `sanitizer_policy_version` reference the canonical sanitizer module at `scripts/lib/sanitize-observation.js`. This module is shared between Layer 4 (curator prompt assembly — sanitizes the bounded batch before LLM invocation) and Layer 5 (validator — sanitizes proposal `body` and every cited evidence field before queue append). Both layers must:
+
+1. Import from the same module — no parallel regex implementations in bash, jq, or inline JavaScript.
+2. Record the same `rule_version` string in their respective manifests / safety metadata.
+3. Fail closed if the module is unavailable.
+
+This eliminates the gap where Layer 4 and Layer 5 could enforce different secret-scan rules by construction.
 
 ## Dashboard exposure of rejections
 

--- a/docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md
+++ b/docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md
@@ -435,6 +435,8 @@ Daemon / Layer 4 proposals must create project-scoped candidates only. Global ca
 
 **Cross-layer invariant — promotion source linkage lives in relationships, not in scope.** `CandidateScope` describes the candidate's *current* scope (project or global). Lineage from a source candidate is a relationship and must be stored only on `CandidateRelationships`. Do not re-introduce `promoted_from_candidate_id` or `promoted_from_project_id` on `CandidateScope`.
 
+**Where this invariant is enforced.** The implicit follow-on rule — "a candidate with `scope.kind === 'global'` and `source.source_type === 'dashboard_promote'` must have `relationships.promoted_from_candidate_id` set" — is **enforced by adapter unit tests, not by a Layer 5 validator rule**. The reason is that this rule lives inside the same trust domain (Node adapter code under our control); the only realistic violation is a programmer bug in a new or modified adapter, which a test on the adapter catches directly. Layer 5 validator rules are reserved for cross-trust-boundary checks (e.g. LLM proposals from Layer 4, future import/repair adapters). Do not add this invariant as a Layer 5 reject code.
+
 Promotion creates a new canonical candidate record with:
 
 - `scope.kind: "global"` (no extra scope fields — lineage lives elsewhere);

--- a/docs/plans/references/learning-curator-schema/layer-6-dashboard-review-control-plane.md
+++ b/docs/plans/references/learning-curator-schema/layer-6-dashboard-review-control-plane.md
@@ -289,6 +289,8 @@ type DashboardSafetyAcknowledgement = {
 
 Action requests are durable audit inputs, not proof that the action succeeded. The target layer must validate current state again before side effects.
 
+**Action × Status legality** — the legality of each `action` value against the current `expected_current_status` (and the candidate's actual status at handling time) is defined canonically in Layer 5's "Action × Status legality matrix (canonical)" section. Layer 6 must reject requests that violate the matrix locally (to give immediate feedback) and Layer 5 must reject them again at handling time. Do not duplicate the matrix in Layer 6 — link to and consult the Layer 5 canonical source.
+
 ## Action routing contract
 
 Layer 6 routes actions by responsibility:

--- a/docs/plans/references/learning-curator-schema/layer-8-activation-runtime-influence-surface.md
+++ b/docs/plans/references/learning-curator-schema/layer-8-activation-runtime-influence-surface.md
@@ -141,9 +141,15 @@ type ActivationPolicy = {
 
   claude_md_auto_apply_allowed: false;
 
-  overwrite_existing_active_artifact:
-    | "forbidden"
-    | "supersede_with_backup";
+  // Per-target-kind overwrite policy. Each target kind that may be activated
+  // must have an explicit policy. Missing keys are treated as "forbidden".
+  overwrite_existing_active_artifact: {
+    instinct?: "forbidden" | "supersede_with_backup";
+    skill?: "forbidden" | "supersede_with_backup";
+    command?: "forbidden" | "supersede_with_backup";
+    agent?: "forbidden" | "supersede_with_backup";
+    manual_claude_md_patch?: "forbidden" | "supersede_with_backup";
+  };
 
   deactivation_mode:
     | "disable_manifest"
@@ -479,6 +485,11 @@ The first 3.1 implementation slice uses these defaults unless a later reviewed p
 2. `command` and `agent` activation are **reserved** until skill activation is implemented, reviewed, and proven safe. `claude_md_addition` remains manual-only and is never auto-applied.
 3. Activated instincts are consumed by dashboard/history/evolve surfaces only in the first slice. They must not be auto-loaded into Claude context at SessionStart and must not become direct runtime instructions.
 4. Deactivation uses `move_to_disabled_archive` with a backup record. The first dashboard UX exposes deactivate status and backup metadata; full rollback/supersede UX is deferred.
+5. **Overwrite policy defaults**:
+   - `instinct`: `"supersede_with_backup"` — re-activating an instinct after manual edit must preserve the prior body as a backup record, not hard-fail. The instinct path includes a candidate-derived `<id>`, so collisions are intended re-activations.
+   - `skill`: `"forbidden"` — `skills/<name>/SKILL.md` may be user-edited; overwriting must hard-fail to protect manual changes. (Moot in the first slice, where skill activation is reserved; the policy is pinned for forward compatibility.)
+   - `manual_claude_md_patch`: `"forbidden"` — `CLAUDE.md` is never auto-applied, so this is also moot but pinned explicitly to prevent future relaxation by default.
+   - `command`, `agent`: `"forbidden"` (reserved for first slice).
 
 ## Deferred decisions
 


### PR DESCRIPTION
## Summary

Documentation-only PR that resolves 11 cross-layer inconsistencies in the learning curator schema ahead of the implementation slices. No code paths change.

The full rationale lives in the implementation plan (`/Users/gregho/.claude/plans/read-documents-below-docs-plans-2026-05-spicy-conway.md`, Section 1). This PR turns that section into the actual schema edits.

## What changed

| # | Layer | Change |
|---|---|---|
| 1.1 | layer-2 | Rename `DerivedSemanticView.operation` → `operation_kind` (matches `SafeEvidencePatch` and other layers) |
| 1.2 | layer-4 | Emit `body_source: "llm_curator"` directly (was `"llm_draft"`) — kills the silent layer-4→5 rename |
| 1.3 | layer-5 | Drop `promoted_from_candidate_id` from `CandidateScope.global`; promotion lineage lives only on `CandidateRelationships` |
| 1.4 | layer-5 | New rejection code `evidence_ref_omitted_upstream` + mapping table from layer-2/3 `evidence_status` |
| 1.5 | layer-5 / layer-6 | Add canonical Action × Status legality matrix in layer-5; layer-6 links to it |
| 1.6 | schema index | Document the `~/.arcforge/observations/` vs `~/.arcforge/learning/` retention split |
| 1.7 | schema index | Define Manifest / Record / Event terminology |
| 1.8 | schema index | Daemon Role note: Layer 3+4 orchestrator, Layer 5 consumer; not a schema authority |
| 1.9 | layer-4 / layer-5 | Pin `scripts/lib/sanitize-observation.js` as canonical sanitizer for both layers, with shared `rule_version` |
| 1.10 | layer-8 | Per-artifact-type overwrite defaults: instinct=`supersede_with_backup`, skill/command/agent/manual_claude_md_patch=`forbidden` |
| 1.11 | layer-5 | Pin `evidence_quality` v1 formula to `project_obs_count` only; other basis fields are future-extension |

## Files

- `docs/plans/2026-05-09-learning-curator-schema-contracts.md` (+31)
- `docs/plans/references/learning-curator-schema/layer-2-sanitization-derived-semantic-view.md` (+3 / -3)
- `docs/plans/references/learning-curator-schema/layer-4-llm-curator-analysis.md` (+6 / -3)
- `docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md` (+66 / -1)
- `docs/plans/references/learning-curator-schema/layer-6-dashboard-review-control-plane.md` (+2)
- `docs/plans/references/learning-curator-schema/layer-8-activation-runtime-influence-surface.md` (+15 / -2)

Total: 6 files, +120 / -12.

## Test plan

- [x] `npm run lint` (biome) — clean, 116 files checked, no fixes applied.
- [x] No code paths touched; `npm test` not required for docs-only PR but can be run as smoke if desired.
- [ ] Reviewer: walk through each of the 11 items and confirm the recommended change matches intent. Push back on any item that should be reconsidered before Slice A starts.

## Next

Once this merges, Slice A (stop-the-bleeding) is the next deliverable per the implementation plan.