### PR TITLE
feat(learning): Slice B — daemon drift fix (Migration step 1)

### DIFF
--- a/hooks/__tests__/observe.test.js
+++ b/hooks/__tests__/observe.test.js
@@ -618,3 +618,258 @@ describe('observe: statistical auto-trigger is retired', () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────
+// Slice B — C1 + C2: shouldObserve path filtering
+// ─────────────────────────────────────────────
+
+describe('observe: shouldObserve — eval-trial path rejection (C1)', () => {
+  const originalEnv = { ...process.env };
+  let testHome;
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'test-observe-c1-'));
+    delete require.cache[require.resolve('../observe/main')];
+    delete require.cache[require.resolve('../../scripts/lib/utils')];
+    delete require.cache[require.resolve('../../scripts/lib/session-utils')];
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+
+    // Enable learning globally so path filtering is the only gate
+    const learning = require('../../scripts/lib/learning');
+    learning.setLearningEnabled({ scope: 'global', enabled: true, homeDir: testHome });
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('rejects a projectRoot containing /.eval-trials/', () => {
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'projects', '.eval-trials', 'run-1'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(result, false, 'should return false for .eval-trials/ path');
+  });
+
+  it('rejects a projectRoot matching trial-dir suffix -tN+-[A-Za-z0-9]{6}', () => {
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'myapp-t123-abc456'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(result, false, 'should return false for trial-dir suffix path');
+  });
+
+  it('rejects various valid trial-dir suffix patterns', () => {
+    const { shouldObserve } = require('../observe/main');
+    const trialPaths = [
+      path.join(testHome, 'proj-t1-aB2cD3'),
+      path.join(testHome, 'myrepo-t99-ZZZZZZ'),
+      path.join(testHome, 'arcforge-t0-a1B2c3'),
+    ];
+    for (const projectRoot of trialPaths) {
+      const result = shouldObserve({ projectRoot, homeDir: testHome });
+      assert.strictEqual(result, false, `should reject trial path: ${projectRoot}`);
+    }
+  });
+
+  it('allows a normal project path when learning is globally enabled', () => {
+    const { shouldObserve } = require('../observe/main');
+    const normalRoot = path.join(testHome, 'my-normal-project');
+    const result = shouldObserve({ projectRoot: normalRoot, homeDir: testHome });
+    assert.strictEqual(
+      result,
+      true,
+      'should return true for normal path with global learning enabled',
+    );
+  });
+
+  it('does not reject a path that has "eval-trials" without the /.eval-trials/ pattern', () => {
+    const { shouldObserve } = require('../observe/main');
+    // A path named "eval-trials-project" at the basename level (no slash+dot)
+    const normalRoot = path.join(testHome, 'eval-trials-project');
+    const result = shouldObserve({ projectRoot: normalRoot, homeDir: testHome });
+    assert.strictEqual(
+      result,
+      true,
+      'eval-trials-project without /.eval-trials/ should be allowed',
+    );
+  });
+});
+
+describe('observe: shouldObserve — ARCFORGE_OBSERVE_SKIP_PATHS env var (C2)', () => {
+  const originalEnv = { ...process.env };
+  let testHome;
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'test-observe-c2-'));
+    delete require.cache[require.resolve('../observe/main')];
+    delete require.cache[require.resolve('../../scripts/lib/utils')];
+    delete require.cache[require.resolve('../../scripts/lib/session-utils')];
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+
+    // Enable learning globally so skip-path env var is the only gate
+    const learning = require('../../scripts/lib/learning');
+    learning.setLearningEnabled({ scope: 'global', enabled: true, homeDir: testHome });
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('rejects a projectRoot that contains a substring from ARCFORGE_OBSERVE_SKIP_PATHS', () => {
+    const skipDir = path.join(testHome, 'skip-me');
+    process.env.ARCFORGE_OBSERVE_SKIP_PATHS = `${skipDir},/other/skip`;
+    delete require.cache[require.resolve('../observe/main')];
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(skipDir, 'my-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(
+      result,
+      false,
+      'should return false when projectRoot matches ARCFORGE_OBSERVE_SKIP_PATHS substring',
+    );
+  });
+
+  it('rejects the second entry in a comma-separated list', () => {
+    const skipDir = path.join(testHome, 'other-skip');
+    process.env.ARCFORGE_OBSERVE_SKIP_PATHS = `${path.join(testHome, 'first')},${skipDir}`;
+    delete require.cache[require.resolve('../observe/main')];
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(skipDir, 'project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(result, false, 'should reject the second skip-path entry');
+  });
+
+  it('allows a path not in ARCFORGE_OBSERVE_SKIP_PATHS when learning is enabled', () => {
+    process.env.ARCFORGE_OBSERVE_SKIP_PATHS = path.join(testHome, 'skip-me');
+    delete require.cache[require.resolve('../observe/main')];
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'safe-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(result, true, 'should allow a path not in the skip list');
+  });
+
+  it('honors an empty ARCFORGE_OBSERVE_SKIP_PATHS (no-op)', () => {
+    process.env.ARCFORGE_OBSERVE_SKIP_PATHS = '';
+    delete require.cache[require.resolve('../observe/main')];
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'project'),
+      homeDir: testHome,
+    });
+    // With empty skip list and global learning enabled, should return true
+    assert.strictEqual(result, true, 'empty skip list should not block observation');
+  });
+});
+
+// ─────────────────────────────────────────────
+// Slice B — C6: Daemon lazy-start
+// ─────────────────────────────────────────────
+
+describe('observe: daemon lazy-start (C6)', () => {
+  const originalEnv = { ...process.env };
+  let testDir;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-observe-lazystart-'));
+    process.env.HOME = testDir;
+    process.env.CLAUDE_PROJECT_DIR = path.join(testDir, 'project');
+    // CI safety: never actually spawn a real daemon during tests.
+    process.env.ARCFORGE_OBSERVE_NO_SPAWN = '1';
+    fs.mkdirSync(process.env.CLAUDE_PROJECT_DIR, { recursive: true });
+    delete require.cache[require.resolve('../observe/main')];
+    delete require.cache[require.resolve('../../scripts/lib/utils')];
+    delete require.cache[require.resolve('../../scripts/lib/session-utils')];
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('exports LAZY_START_THRESHOLD constant defaulting to 50', () => {
+    const mod = require('../observe/main');
+    assert.strictEqual(mod.LAZY_START_THRESHOLD, 50, 'default LAZY_START_THRESHOLD must be 50');
+  });
+
+  it('exports spawnDaemonIfNeeded function', () => {
+    const mod = require('../observe/main');
+    assert.strictEqual(
+      typeof mod.spawnDaemonIfNeeded,
+      'function',
+      'spawnDaemonIfNeeded must be exported',
+    );
+  });
+
+  it('honors ARCFORGE_LAZY_START_THRESHOLD env override', () => {
+    process.env.ARCFORGE_LAZY_START_THRESHOLD = '5';
+    delete require.cache[require.resolve('../observe/main')];
+    const mod = require('../observe/main');
+    assert.strictEqual(mod.LAZY_START_THRESHOLD, 5, 'env override must apply');
+  });
+
+  it('returns "below-threshold" when observation count is below threshold', () => {
+    const { spawnDaemonIfNeeded } = require('../observe/main');
+    const { getObservationsPath } = require('../../scripts/lib/session-utils');
+    const obsPath = getObservationsPath('test-project');
+    fs.mkdirSync(path.dirname(obsPath), { recursive: true });
+    const lines = Array.from({ length: 10 }, (_, i) => JSON.stringify({ i })).join('\n') + '\n';
+    fs.writeFileSync(obsPath, lines, 'utf-8');
+
+    assert.strictEqual(spawnDaemonIfNeeded(obsPath), 'below-threshold');
+  });
+
+  it('returns "pid-exists" when PID file is present (daemon already running)', () => {
+    const { spawnDaemonIfNeeded } = require('../observe/main');
+    const { getObservationsPath, getObserverPidFile } = require('../../scripts/lib/session-utils');
+    const obsPath = getObservationsPath('test-project');
+    fs.mkdirSync(path.dirname(obsPath), { recursive: true });
+    const lines = Array.from({ length: 60 }, (_, i) => JSON.stringify({ i })).join('\n') + '\n';
+    fs.writeFileSync(obsPath, lines, 'utf-8');
+
+    const pidFile = getObserverPidFile();
+    fs.mkdirSync(path.dirname(pidFile), { recursive: true });
+    fs.writeFileSync(pidFile, String(process.pid), 'utf-8');
+
+    assert.strictEqual(spawnDaemonIfNeeded(obsPath), 'pid-exists');
+    assert.ok(fs.existsSync(pidFile), 'PID file should still exist');
+  });
+
+  it('returns "no-file" when observations file does not exist', () => {
+    const { spawnDaemonIfNeeded } = require('../observe/main');
+    const { getObservationsPath } = require('../../scripts/lib/session-utils');
+    const obsPath = getObservationsPath('test-project');
+    assert.strictEqual(spawnDaemonIfNeeded(obsPath), 'no-file');
+  });
+
+  it('returns "no-spawn-env" when threshold met but ARCFORGE_OBSERVE_NO_SPAWN=1', () => {
+    const { spawnDaemonIfNeeded, LAZY_START_THRESHOLD } = require('../observe/main');
+    const { getObservationsPath } = require('../../scripts/lib/session-utils');
+    const obsPath = getObservationsPath('test-project');
+    fs.mkdirSync(path.dirname(obsPath), { recursive: true });
+    const lines =
+      Array.from({ length: LAZY_START_THRESHOLD }, (_, i) => JSON.stringify({ i })).join('\n') +
+      '\n';
+    fs.writeFileSync(obsPath, lines, 'utf-8');
+
+    assert.strictEqual(spawnDaemonIfNeeded(obsPath), 'no-spawn-env');
+  });
+});

--- a/hooks/observe/main.js
+++ b/hooks/observe/main.js
@@ -10,6 +10,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawn } = require('node:child_process');
 
 const {
   getProjectName,
@@ -34,6 +35,8 @@ const MAX_OUTPUT_LENGTH = 5000;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const SIGNAL_COOLDOWN_MS = 30000; // 30 seconds between SIGUSR1 signals
 const SIGNAL_TIMESTAMP_FILE = getObserverSignalFile();
+const LAZY_START_THRESHOLD = Number(process.env.ARCFORGE_LAZY_START_THRESHOLD) || 50;
+const SKIP_SPAWN = process.env.ARCFORGE_OBSERVE_NO_SPAWN === '1';
 
 /**
  * Get observations archive directory for a project.
@@ -44,11 +47,31 @@ function getArchiveDir(project) {
 
 const getPidFile = getObserverPidFile;
 
+// Eval harness isolation — observations from eval trial dirs are not real user activity.
+const EVAL_TRIAL_SEGMENT_RE = /\/\.eval-trials\//;
+const EVAL_TRIAL_SUFFIX_RE = /-t\d+-[A-Za-z0-9]{6}$/;
+
+// User-configured skip list — parsed once at module load (hook is a fresh process per event).
+const USER_SKIP_ENTRIES = (process.env.ARCFORGE_OBSERVE_SKIP_PATHS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+function isSkippedPath(projectRoot) {
+  if (EVAL_TRIAL_SEGMENT_RE.test(projectRoot)) return true;
+  if (EVAL_TRIAL_SUFFIX_RE.test(projectRoot)) return true;
+  for (const entry of USER_SKIP_ENTRIES) {
+    if (projectRoot.includes(entry)) return true;
+  }
+  return false;
+}
+
 function shouldObserve({
   projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd(),
   homeDir,
 } = {}) {
   try {
+    if (isSkippedPath(projectRoot)) return false;
     return (
       isLearningEnabled({ scope: 'project', projectRoot, homeDir }) ||
       isLearningEnabled({ scope: 'global', projectRoot, homeDir })
@@ -292,6 +315,38 @@ function signalDaemon() {
   }
 }
 
+/**
+ * Spawn the observer daemon if observations >= LAZY_START_THRESHOLD and daemon not running.
+ * Non-blocking, silent catch — never throws. Returns a status string for testability:
+ *   'pid-exists' | 'no-file' | 'below-threshold' | 'no-spawn-env' | 'spawned' | 'error'
+ */
+function spawnDaemonIfNeeded(obsPath) {
+  try {
+    const pidFile = getPidFile();
+    if (fs.existsSync(pidFile)) return 'pid-exists';
+    if (!fs.existsSync(obsPath)) return 'no-file';
+
+    const content = fs.readFileSync(obsPath, 'utf-8');
+    const lineCount = content.split('\n').filter((l) => l.trim()).length;
+    if (lineCount < LAZY_START_THRESHOLD) return 'below-threshold';
+
+    if (SKIP_SPAWN) return 'no-spawn-env';
+
+    const daemonScript = path.resolve(
+      __dirname,
+      '../../skills/arc-observing/scripts/observer-daemon.sh',
+    );
+    const child = spawn('bash', [daemonScript, 'start'], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    return 'spawned';
+  } catch {
+    return 'error';
+  }
+}
+
 // ─────────────────────────────────────────────
 // Main
 // ─────────────────────────────────────────────
@@ -369,6 +424,9 @@ function main() {
     // Append observation
     fs.appendFileSync(obsPath, `${JSON.stringify(observation)}\n`, 'utf-8');
 
+    // Lazy-start daemon when enough observations have accumulated.
+    spawnDaemonIfNeeded(obsPath);
+
     // Wake the LLM-curation daemon; statistical auto-trigger retired (Slice A).
     signalDaemon();
   } catch {
@@ -397,6 +455,8 @@ module.exports = {
   getArchiveDir,
   getPidFile,
   shouldObserve,
+  spawnDaemonIfNeeded,
   MAX_INPUT_LENGTH,
   MAX_OUTPUT_LENGTH,
+  LAZY_START_THRESHOLD,
 };

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
   ],
   "scripts": {
     "dev": "claude --plugin-dir .",
-    "test": "npm run test:scripts && npm run test:hooks && npm run test:node && npm run test:skills",
+    "test": "npm run test:scripts && npm run test:hooks && npm run test:node && npm run test:skills && npm run test:observer-daemon",
     "test:scripts": "jest",
     "test:hooks": "cd hooks && npm test",
     "test:node": "node tests/node/run-tests.js",
     "test:skills": "python3 -m pytest tests/skills/ -v",
+    "test:observer-daemon": "bash skills/arc-observing/tests/run-tests.sh",
     "test:diary": "node skills/arc-journaling/scripts/diary.js",
     "test:reflect": "node skills/arc-reflecting/scripts/reflect.js",
     "lint": "biome check .",

--- a/skills/arc-observing/scripts/observer-daemon.sh
+++ b/skills/arc-observing/scripts/observer-daemon.sh
@@ -21,9 +21,14 @@ MIN_OBSERVATIONS=10    # Minimum obs before analysis
 IDLE_TIMEOUT=1800      # 30 minutes no new obs → auto-stop
 MAX_AGE=7200           # 2 hours maximum lifetime
 ANALYSIS_COOLDOWN=60   # Minimum 60 seconds between analyses
+# Watchdog timeout for claude CLI invocation (override via env var for tests)
+OBSERVER_DAEMON_WATCHDOG_SECS="${OBSERVER_DAEMON_WATCHDOG_SECS:-120}"
 
 # Path to observer prompt (relative to this script)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# SCRIPT_DIR can be pre-set via env var when sourced for testing
+if [ -z "${SCRIPT_DIR:-}" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 OBSERVER_PROMPT="${SCRIPT_DIR}/observer-prompt.md"
 OBSERVER_SYSTEM_PROMPT="${SCRIPT_DIR}/observer-system-prompt.md"
 
@@ -166,31 +171,57 @@ Each file: {id}.md with YAML frontmatter + markdown body.
 "
 
   # Call Haiku for analysis — clean session with zero MCP overhead
+  # Wrapped in a watchdog: kill claude if it exceeds OBSERVER_DAEMON_WATCHDOG_SECS.
   local claude_output
   local analysis_success=false
   local retry_count=0
   local max_retries=1
 
+  # Deterministic per-function tmp file so the daemon-level EXIT trap can
+  # clean it even if SIGTERM hits mid-analysis. Guarded by the ANALYZING
+  # lock so only one analyze_project runs at a time.
+  local tmp_out="${INSTINCTS_DIR}/.analyzing.output.tmp"
+  trap 'rm -f "$tmp_out"' RETURN
+
   while [ "$retry_count" -le "$max_retries" ] && [ "$analysis_success" = false ]; do
     if command -v claude &>/dev/null; then
-      # Capture stdout and stderr separately
       local exit_code=0
-      claude_output=$(echo "$prompt" | claude --model haiku \
-        --max-turns 3 \
+      local claude_pid=""
+      local watchdog_pid=""
+
+      (echo "$prompt" | claude --model haiku \
+        --max-turns 15 \
         --print \
         --system-prompt "$(cat "$OBSERVER_SYSTEM_PROMPT")" \
         --tools "Write,Read,Bash,Grep,Glob" \
         --disable-slash-commands \
         --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
-        2>&1) || exit_code=$?
+        > "$tmp_out" 2>&1) &
+      claude_pid=$!
+
+      # Watchdog: kill claude_pid after OBSERVER_DAEMON_WATCHDOG_SECS seconds
+      (sleep "$OBSERVER_DAEMON_WATCHDOG_SECS" && \
+        if kill -0 "$claude_pid" 2>/dev/null; then \
+          log_msg "WATCHDOG: claude exceeded ${OBSERVER_DAEMON_WATCHDOG_SECS}s — killing (PID ${claude_pid})"; \
+          kill "$claude_pid" 2>/dev/null || true; \
+        fi) &
+      watchdog_pid=$!
+
+      wait "$claude_pid" 2>/dev/null && exit_code=0 || exit_code=$?
+      # Cancel watchdog if claude finished normally
+      kill "$watchdog_pid" 2>/dev/null || true
+      wait "$watchdog_pid" 2>/dev/null || true
+
+      claude_output=$(cat "$tmp_out" 2>/dev/null || true)
 
       if [ "$exit_code" -eq 0 ]; then
         analysis_success=true
         log_msg "Claude analysis completed successfully"
       else
         log_msg "ERROR: claude analysis failed (exit code: ${exit_code})"
-        if [ "$retry_count" -lt "$max_retries" ]; then
-          retry_count=$((retry_count + 1))
+        # Always advance retry_count so the while condition eventually becomes false
+        retry_count=$((retry_count + 1))
+        if [ "$retry_count" -le "$max_retries" ]; then
           log_msg "Retrying analysis (attempt ${retry_count}/${max_retries})..."
           sleep 2
         fi
@@ -251,7 +282,25 @@ archive_observations() {
 }
 
 analyze_all_projects() {
+  local analyzing_lock="${INSTINCTS_DIR}/.analyzing.lock"
+  # Staleness: a SIGKILL/OOM can leave .analyzing.lock behind because EXIT
+  # trap doesn't fire. Treat locks older than 30 minutes as stale and reclaim.
+  local stale_lock_minutes=30
+
+  if [ -f "$analyzing_lock" ]; then
+    if find "$analyzing_lock" -mmin +"$stale_lock_minutes" -print 2>/dev/null | grep -q .; then
+      log_msg "ANALYZING: stale .analyzing.lock (>${stale_lock_minutes}m old) — reclaiming"
+      rm -f "$analyzing_lock"
+    else
+      log_msg "ANALYZING: analysis already in progress (.analyzing.lock exists) — skipping this round"
+      return
+    fi
+  fi
+
+  touch "$analyzing_lock" 2>/dev/null || true
+
   if [ ! -d "$OBS_DIR" ]; then
+    rm -f "$analyzing_lock"
     return
   fi
 
@@ -261,6 +310,8 @@ analyze_all_projects() {
     project=$(basename "$project_dir")
     analyze_project "$project"
   done
+
+  rm -f "$analyzing_lock"
 }
 
 # ─────────────────────────────────────────────
@@ -279,9 +330,9 @@ daemon_loop() {
   # Track observation state to detect actual new data
   local obs_state_file="${OBS_DIR}/.obs_state"
 
-  # Cleanup lock on exit
-  trap 'log_msg "Daemon stopping (EXIT)"; remove_lock' EXIT
-  trap 'log_msg "Daemon stopping (signal)"; remove_lock; exit 0' TERM INT
+  # Cleanup lock + transient analyzer files on exit; also remove ANALYZING lock to prevent stale lock after crash
+  trap 'log_msg "Daemon stopping (EXIT)"; rm -f "${INSTINCTS_DIR}/.analyzing.lock" "${INSTINCTS_DIR}/.analyzing.output.tmp"; remove_lock' EXIT
+  trap 'log_msg "Daemon stopping (signal)"; rm -f "${INSTINCTS_DIR}/.analyzing.lock" "${INSTINCTS_DIR}/.analyzing.output.tmp"; remove_lock; exit 0' TERM INT
 
   # SIGUSR1 handler with cooldown
   handle_sigusr1() {
@@ -421,12 +472,15 @@ cmd_status() {
 # Main
 # ─────────────────────────────────────────────
 
-case "${1:-status}" in
-  start)  cmd_start ;;
-  stop)   cmd_stop ;;
-  status) cmd_status ;;
-  *)
-    echo "Usage: $0 {start|stop|status}"
-    exit 1
-    ;;
-esac
+# Guard: skip command dispatch when sourced (allows tests to import functions)
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+  case "${1:-status}" in
+    start)  cmd_start ;;
+    stop)   cmd_stop ;;
+    status) cmd_status ;;
+    *)
+      echo "Usage: $0 {start|stop|status}"
+      exit 1
+      ;;
+  esac
+fi

--- a/skills/arc-observing/tests/run-tests.sh
+++ b/skills/arc-observing/tests/run-tests.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Bash tests for observer-daemon.sh behavior (Slice B)
+# Minimal POSIX shell test framework — no external deps.
+#
+# Usage: bash skills/arc-observing/tests/run-tests.sh
+# Requires: bash 4+ (macOS ships bash 3.2 but uses zsh by default — this
+# script is invoked as 'bash run-tests.sh' so homebrew bash is not required)
+
+set -uo pipefail
+
+DAEMON_SCRIPT="$(cd "$(dirname "$0")/../scripts" && pwd)/observer-daemon.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ─────────────────────────────────────────────
+# Test Framework
+# ─────────────────────────────────────────────
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description"
+    echo "        expected: $expected"
+    echo "        actual:   $actual"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$description")
+  fi
+}
+
+assert_match() {
+  local description="$1"
+  local pattern="$2"
+  local actual="$3"
+  if echo "$actual" | grep -qEi "$pattern"; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description"
+    echo "        pattern:  $pattern"
+    echo "        actual:   $actual"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$description")
+  fi
+}
+
+assert_not_match() {
+  local description="$1"
+  local pattern="$2"
+  local actual="$3"
+  if ! echo "$actual" | grep -qEi "$pattern"; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description"
+    echo "        pattern should NOT match: $pattern"
+    echo "        actual: $actual"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$description")
+  fi
+}
+
+# ─────────────────────────────────────────────
+# C5: --max-turns value is 15
+# ─────────────────────────────────────────────
+
+echo ""
+echo "=== C5: --max-turns value ==="
+
+MAX_TURNS_LINE=$(grep -- '--max-turns' "$DAEMON_SCRIPT" | head -1 || true)
+assert_match \
+  'daemon script contains --max-turns 15' \
+  '\-\-max-turns 15' \
+  "$MAX_TURNS_LINE"
+
+assert_not_match \
+  'daemon script does not contain old --max-turns 3' \
+  '\-\-max-turns 3[^0-9]' \
+  "$MAX_TURNS_LINE"
+
+# ─────────────────────────────────────────────
+# C3: ANALYZING re-entrancy guard
+# ─────────────────────────────────────────────
+# Strategy: source the daemon with HOME pointing to a temp dir so all paths
+# (INSTINCTS_DIR, LOG_FILE) resolve under that temp dir. The BASH_SOURCE guard
+# at the bottom of the daemon ensures the case block is skipped when sourced.
+
+echo ""
+echo "=== C3: ANALYZING re-entrancy guard ==="
+
+TMPDIR_C3=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_C3"' EXIT
+TEST_HOME_C3="${TMPDIR_C3}/home"
+mkdir -p "$TEST_HOME_C3"
+
+# Test 1: pre-create .analyzing.lock → analyze_all_projects must skip and log
+C3_LOCKED_LOG=$(
+  HOME="$TEST_HOME_C3"
+  SCRIPT_DIR="$(dirname "$DAEMON_SCRIPT")"
+  OBSERVER_PROMPT="${SCRIPT_DIR}/observer-prompt.md"
+  OBSERVER_SYSTEM_PROMPT="${SCRIPT_DIR}/observer-system-prompt.md"
+  set +e
+  # shellcheck source=/dev/null
+  source "$DAEMON_SCRIPT" 2>/dev/null
+  mkdir -p "$INSTINCTS_DIR"
+  touch "${INSTINCTS_DIR}/.analyzing.lock"
+  analyze_all_projects 2>/dev/null
+  cat "$LOG_FILE" 2>/dev/null || true
+) 2>/dev/null
+
+assert_match \
+  'C3: logs skip message when .analyzing.lock exists' \
+  'ANALYZING.*in.progress|ANALYZING.*skip|analysis.*in.progress|re.entrancy|already.analyz' \
+  "$C3_LOCKED_LOG"
+
+# Test 2: no lock → analysis runs normally, lock removed after completion
+TEST_HOME_C3B="${TMPDIR_C3}/home2"
+mkdir -p "$TEST_HOME_C3B"
+C3_CLEAN_RESULT=$(
+  HOME="$TEST_HOME_C3B"
+  SCRIPT_DIR="$(dirname "$DAEMON_SCRIPT")"
+  OBSERVER_PROMPT="${SCRIPT_DIR}/observer-prompt.md"
+  OBSERVER_SYSTEM_PROMPT="${SCRIPT_DIR}/observer-system-prompt.md"
+  set +e
+  # shellcheck source=/dev/null
+  source "$DAEMON_SCRIPT" 2>/dev/null
+  mkdir -p "$INSTINCTS_DIR"
+  analyze_all_projects 2>/dev/null
+  [ -f "${INSTINCTS_DIR}/.analyzing.lock" ] && echo 'LOCK_EXISTS' || echo 'LOCK_GONE'
+) 2>/dev/null
+
+assert_eq \
+  'C3: lock file removed after analysis completes (no stale lock)' \
+  'LOCK_GONE' \
+  "$C3_CLEAN_RESULT"
+
+# Test 3: no skip message in clean run
+TEST_HOME_C3C="${TMPDIR_C3}/home3"
+mkdir -p "$TEST_HOME_C3C"
+C3_CLEAN_LOG=$(
+  HOME="$TEST_HOME_C3C"
+  SCRIPT_DIR="$(dirname "$DAEMON_SCRIPT")"
+  OBSERVER_PROMPT="${SCRIPT_DIR}/observer-prompt.md"
+  OBSERVER_SYSTEM_PROMPT="${SCRIPT_DIR}/observer-system-prompt.md"
+  set +e
+  # shellcheck source=/dev/null
+  source "$DAEMON_SCRIPT" 2>/dev/null
+  mkdir -p "$INSTINCTS_DIR"
+  analyze_all_projects 2>/dev/null
+  cat "$LOG_FILE" 2>/dev/null || true
+) 2>/dev/null
+
+assert_not_match \
+  'C3: no skip message in clean run (lock was not pre-created)' \
+  'ANALYZING.*in.progress|ANALYZING.*skip' \
+  "$C3_CLEAN_LOG"
+
+# ─────────────────────────────────────────────
+# C4: Watchdog around claude invocation
+# ─────────────────────────────────────────────
+# Strategy: create a stub 'claude' that sleeps longer than the test watchdog,
+# inject it into PATH, set OBSERVER_DAEMON_WATCHDOG_SECS=3, and call analyze_project.
+# Verify: (a) timeout log message appears, (b) elapsed time < stub sleep duration.
+
+echo ""
+echo "=== C4: Watchdog around claude invocation ==="
+
+TMPDIR_C4=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_C3" "$TMPDIR_C4"' EXIT
+TEST_HOME_C4="${TMPDIR_C4}/home"
+STUB_BIN="${TMPDIR_C4}/bin"
+mkdir -p "$TEST_HOME_C4" "$STUB_BIN"
+
+# Stub 'claude' that sleeps 10 seconds (longer than 3s test watchdog)
+cat > "${STUB_BIN}/claude" << 'STUB_EOF'
+#!/usr/bin/env bash
+sleep 10
+STUB_EOF
+chmod +x "${STUB_BIN}/claude"
+
+# Create a project with enough observations to pass the MIN_OBSERVATIONS gate
+PROJ_DIR="${TEST_HOME_C4}/.arcforge/observations/test-proj"
+mkdir -p "$PROJ_DIR"
+for i in $(seq 1 15); do
+  echo '{"event":"tool_start","tool":"Read"}' >> "${PROJ_DIR}/observations.jsonl"
+done
+
+START_TS=$(date +%s)
+C4_LOG=$(
+  HOME="$TEST_HOME_C4"
+  PATH="${STUB_BIN}:${PATH}"
+  OBSERVER_DAEMON_WATCHDOG_SECS=3
+  SCRIPT_DIR="$(dirname "$DAEMON_SCRIPT")"
+  OBSERVER_PROMPT="${SCRIPT_DIR}/observer-prompt.md"
+  OBSERVER_SYSTEM_PROMPT="${SCRIPT_DIR}/observer-system-prompt.md"
+  set +e
+  # shellcheck source=/dev/null
+  source "$DAEMON_SCRIPT" 2>/dev/null
+  mkdir -p "$INSTINCTS_DIR"
+  analyze_project 'test-proj' 2>/dev/null || true
+  cat "$LOG_FILE" 2>/dev/null || true
+) 2>/dev/null
+END_TS=$(date +%s)
+ELAPSED=$((END_TS - START_TS))
+
+assert_match \
+  'C4: logs timeout/kill message when claude exceeds watchdog' \
+  'WATCHDOG|timeout|timed.out|killed' \
+  "$C4_LOG"
+
+# Should complete in ~3-7s (3s watchdog + overhead), not 10s (stub sleep)
+if [ "$ELAPSED" -lt 10 ]; then
+  echo "  PASS: C4: process killed before stub sleep (${ELAPSED}s elapsed, expected < 10s)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: C4: watchdog did not kill process in time (${ELAPSED}s elapsed, expected < 10s)"
+  FAIL=$((FAIL + 1))
+  ERRORS+=('C4: process killed before stub sleep (elapsed check)')
+fi
+
+# ─────────────────────────────────────────────
+# Results
+# ─────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo ""
+
+if [ "${#ERRORS[@]}" -gt 0 ]; then
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Second implementation slice of the learning curator pivot. Patches four high-risk ECC daemon drift items + adds lazy-start so daemon health is verifiable before Slice E rewires the output. **No observation shape changes, no candidate queue work** — that's C and D.

Reference: implementation plan Section 4 (Slice B) + Section 7 goal template.

## Acceptance criteria (verified)

| # | Drift | What |
|---|---|---|
| 1 | #1 | `shouldObserve()` skips `/.eval-trials/` segment + `-t\d+-[A-Za-z0-9]{6}$` suffix |
| 2 | #1 | `ARCFORGE_OBSERVE_SKIP_PATHS` env var (comma-separated substring) |
| 3 | #5 | `.analyzing.lock` ANALYZING re-entrancy guard with 30-min staleness reclaim |
| 4 | #11 | 120s watchdog around `claude --model haiku` (env `OBSERVER_DAEMON_WATCHDOG_SECS`) |
| 5 | #15 | `--max-turns 3` → `15` |
| 6 | #14 | Daemon lazy-start when ≥ 50 observations and no PID file (env-overridable) |
| 7 | — | `npm test` (4 runners + new observer-daemon bash runner) + `npm run lint` pass |

## Process gate

- **Implementer** ran TDD per drift item, produced tests + code in one pass
- **spec-reviewer** verified against acceptance criteria — VERDICT ACCEPT (one false-positive C8 about untracked orchestrator HTML, not in this PR)
- **simplify** (3 parallel reviewers: reuse, quality, efficiency) — 7 of 13 findings applied, 6 deferred as over-engineering or scope creep
- All decisions logged in `docs/plans/2026-05-20-learning-curator-decisions.html` (orchestrator artifact, not in this PR)

## Files

| Path | Δ | Note |
|---|---:|---|
| `hooks/observe/main.js` | +60 | `isSkippedPath`, `EVAL_TRIAL_*` regexes, cached `USER_SKIP_ENTRIES`, `spawnDaemonIfNeeded` returning status string |
| `hooks/__tests__/observe.test.js` | +255 | C1/C2/C6 test sections with precise return-value assertions |
| `skills/arc-observing/scripts/observer-daemon.sh` | +92 | watchdog, ANALYZING guard with staleness, `--max-turns 15`, sourceable for tests |
| `skills/arc-observing/tests/run-tests.sh` | new | C3/C4/C5 bash tests with `assert_eq`/`assert_contains` helpers |
| `package.json` | +3 | `test:observer-daemon` script + chained into root test runner |

## Drive-by fix (logged)

`analyze_project()` had a pre-existing infinite-retry-loop bug — `retry_count` was only incremented inside `if [ retry_count -lt max_retries ]`, so the loop spun forever on persistent claude failure. Fixed because the C4 watchdog test hangs otherwise. Behavior change: caps total attempts at `max_retries + 1` (= 2) as originally intended; success path unchanged.

## Simplify pass — applied

1. `spawnDaemonIfNeeded` returns status string (`'pid-exists' | 'no-file' | 'below-threshold' | 'no-spawn-env' | 'spawned' | 'error'`) so tests assert precisely instead of `doesNotThrow`
2. `LAZY_START_THRESHOLD` + `SKIP_SPAWN` env-overridable (CI safety + parity with watchdog env)
3. `USER_SKIP_ENTRIES` parsed once at module load
4. `.analyzing.lock` reclaims after 30 min mtime (SIGKILL/OOM recovery)
5. Daemon tmp file deterministic + cleaned by daemon EXIT/TERM/INT traps and per-function RETURN trap
6. C6 tests use `ARCFORGE_OBSERVE_NO_SPAWN=1` to prevent CI from leaking real daemon processes
7. Tightened JSDoc on `isSkippedPath` (drop WHAT-narration, keep WHY)

## Simplify pass — deferred (over-engineering or scope creep)

- Extract `spawnDetached` helper — single live caller
- Extract `makeObserveTestEnv` — touches pre-existing test pattern
- Co-locate eval-trial regex in `scripts/lib/eval.js` — cross-module refactor outside slice
- Hot-path file-read optimization — bounded to ≤ 50 events during bootstrap window
- SIGKILL escalation in watchdog — claude well-behaved on SIGTERM
- substring → prefix match in skip list — substring was the spec'd semantics

## Test plan

- [x] `npm test` — 4 runners pass (557 + 205 hooks + 7 observer-daemon)
- [x] `npm run lint` — clean (2 non-blocking template-literal style infos)
- [x] C1 skip filter test asserts both regex patterns + 4 path scenarios
- [x] C2 env var test asserts honored + empty + multi-entry
- [x] C3 re-entrancy test creates lock manually, asserts skip message + clean-run no-skip
- [x] C4 watchdog test uses stub claude that sleeps 10s with watchdog at 3s — process killed before stub completes
- [x] C5 grep-assertion on `--max-turns 15`
- [x] C6 lazy-start asserts each branch via return status string + env override + NO_SPAWN safety