### PR TITLE
feat(learning): Slice C — safe evidence collection + shared sanitizer (Migration step 2)

### DIFF
--- a/hooks/__tests__/observe.test.js
+++ b/hooks/__tests__/observe.test.js
@@ -4,53 +4,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
-describe('observe: truncate', () => {
-  const originalEnv = { ...process.env };
-
-  beforeEach(() => {
-    process.env.CLAUDE_SESSION_ID = 'test-observe-session';
-    delete require.cache[require.resolve('../observe/main')];
-    delete require.cache[require.resolve('../../scripts/lib/utils')];
-    delete require.cache[require.resolve('../../scripts/lib/session-utils')];
-  });
-
-  afterEach(() => {
-    for (const key of Object.keys(process.env)) delete process.env[key];
-    Object.assign(process.env, originalEnv);
-  });
-
-  it('should return original string when under maxLen', () => {
-    const { truncate } = require('../observe/main');
-    assert.strictEqual(truncate('hello', 10), 'hello');
-  });
-
-  it('should return original string when exactly maxLen', () => {
-    const { truncate } = require('../observe/main');
-    assert.strictEqual(truncate('12345', 5), '12345');
-  });
-
-  it('should truncate and add indicator when over maxLen', () => {
-    const { truncate } = require('../observe/main');
-    const result = truncate('hello world', 5);
-    assert.strictEqual(result, 'hello...[truncated]');
-  });
-
-  it('should return empty string for null input', () => {
-    const { truncate } = require('../observe/main');
-    assert.strictEqual(truncate(null, 10), '');
-  });
-
-  it('should return empty string for undefined input', () => {
-    const { truncate } = require('../observe/main');
-    assert.strictEqual(truncate(undefined, 10), '');
-  });
-
-  it('should return empty string for empty string input', () => {
-    const { truncate } = require('../observe/main');
-    assert.strictEqual(truncate('', 10), '');
-  });
-});
-
 describe('observe: getArchiveDir', () => {
   const originalEnv = { ...process.env };
   let testDir;
@@ -150,26 +103,6 @@ describe('observe: extractSkillName', () => {
   });
 });
 
-describe('observe: buildObservedToolInput', () => {
-  beforeEach(() => {
-    delete require.cache[require.resolve('../observe/main')];
-  });
-
-  it('drops Skill args while retaining the skill name', () => {
-    const { buildObservedToolInput } = require('../observe/main');
-    assert.deepStrictEqual(
-      buildObservedToolInput('Skill', { skill: 'arc-debugging', args: 'private task details' }),
-      { skill: 'arc-debugging' },
-    );
-  });
-
-  it('keeps non-Skill tool input unchanged for existing learning signal extraction', () => {
-    const { buildObservedToolInput } = require('../observe/main');
-    const input = { command: 'npm test' };
-    assert.strictEqual(buildObservedToolInput('Bash', input), input);
-  });
-});
-
 describe('observe: classifyOutcome', () => {
   beforeEach(() => {
     delete require.cache[require.resolve('../observe/main')];
@@ -224,10 +157,12 @@ describe('observe: responseByteSize', () => {
 describe('observe: privacy boundaries', () => {
   beforeEach(() => {
     delete require.cache[require.resolve('../observe/main')];
+    delete require.cache[require.resolve('../../scripts/lib/sanitize-observation')];
   });
 
   it('redacts secret-like fields from sanitized payloads', () => {
-    const { sanitizeObservationPayload } = require('../observe/main');
+    // sanitizeObservationPayload now lives in scripts/lib/sanitize-observation
+    const { sanitizeObservationPayload } = require('../../scripts/lib/sanitize-observation');
     const out = sanitizeObservationPayload(
       'curl -H "Authorization: Bearer sk-12345" --data api_key="abc123"',
       5000,
@@ -239,7 +174,8 @@ describe('observe: privacy boundaries', () => {
   });
 
   it('caps sanitized payload length at the configured maximum', () => {
-    const { sanitizeObservationPayload, MAX_OUTPUT_LENGTH } = require('../observe/main');
+    const { sanitizeObservationPayload } = require('../../scripts/lib/sanitize-observation');
+    const { MAX_OUTPUT_LENGTH } = require('../observe/main');
     const huge = 'A'.repeat(MAX_OUTPUT_LENGTH * 4);
     const out = sanitizeObservationPayload(huge, MAX_OUTPUT_LENGTH);
     assert.ok(
@@ -302,7 +238,10 @@ describe('observe: event shape on PreToolUse', () => {
     assert.strictEqual(entry.event, 'tool_start');
     assert.strictEqual(entry.skill, 'arc-debugging');
     assert.ok(!('input' in entry), 'pre-event must not persist raw tool input');
-    assert.strictEqual(entry.semantic.skill_name, 'arc-debugging');
+    // Slice C: no semantic field; SafeEvidencePatch fields instead
+    assert.ok(!('semantic' in entry), 'semantic field must not be persisted (Decision 4)');
+    assert.strictEqual(entry.evidence_status, 'present');
+    assert.strictEqual(entry.operation_kind, 'skill');
     assert.ok(!JSON.stringify(entry).includes('private task details'));
     assert.ok(!JSON.stringify(entry).includes('sk-12345'));
   });
@@ -426,66 +365,16 @@ describe('observe: event shape on PostToolUse', () => {
   });
 });
 
-describe('observe: semantic summaries', () => {
-  beforeEach(() => {
-    delete require.cache[require.resolve('../observe/main')];
-  });
+// Note: summarizeToolInput tests moved to tests/scripts/learning-observation-view.test.js
+// (Slice C — Decision 4: semantic view is read-time only, lives in scripts/lib/)
 
-  it('classifies known bash command kinds without storing the command line', () => {
-    const { summarizeToolInput } = require('../observe/main');
-    assert.deepStrictEqual(summarizeToolInput('Bash', { command: 'npm test' }), {
-      tool: 'Bash',
-      payload_saved: false,
-      operation: 'shell',
-      command_kind: 'test',
-    });
-    assert.strictEqual(summarizeToolInput('Bash', { command: 'git status' }).command_kind, 'git');
-    assert.strictEqual(
-      summarizeToolInput('Bash', { command: 'npm run lint' }).command_kind,
-      'lint',
-    );
-  });
-
-  it('classifies file-targeted tools by path class without storing file path', () => {
-    const { summarizeToolInput } = require('../observe/main');
-    const summary = summarizeToolInput('Edit', { file_path: 'tests/scripts/foo.test.js' });
-    assert.strictEqual(summary.path_class, 'test');
-    assert.strictEqual(summary.file_kind, 'js');
-    assert.strictEqual(summary.payload_saved, false);
-    assert.ok(!('file_path' in summary), 'file path must not be persisted in summary');
-  });
-
-  it('maps unknown file suffixes to a bounded enum', () => {
-    const { summarizeToolInput } = require('../observe/main');
-    const summary = summarizeToolInput('Read', {
-      file_path: 'notes/customer-acme.secretprojectcodename',
-    });
-    assert.strictEqual(summary.file_kind, 'other');
-    assert.ok(!JSON.stringify(summary).includes('secretprojectcodename'));
-  });
-
-  it('records skill name in summary when tool is Skill', () => {
-    const { summarizeToolInput } = require('../observe/main');
-    const summary = summarizeToolInput('Skill', { skill: 'arc-debugging', args: 'private' });
-    assert.strictEqual(summary.skill_name, 'arc-debugging');
-    assert.ok(!('args' in summary), 'skill args must not be persisted in summary');
-  });
-
-  it('falls back to the unknown classifications when unfamiliar tool is supplied', () => {
-    const { summarizeToolInput } = require('../observe/main');
-    const summary = summarizeToolInput('SomeNewTool', { x: 1 });
-    assert.strictEqual(summary.operation, 'other');
-    assert.strictEqual(summary.payload_saved, false);
-  });
-});
-
-describe('observe: pre-event persists semantic summary', () => {
+describe('observe: pre-event persists SafeEvidencePatch (Slice C)', () => {
   const originalEnv = { ...process.env };
   let testDir;
   let projectRoot;
 
   beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-observe-semantic-'));
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-observe-evidence-'));
     projectRoot = path.join(testDir, 'project');
     fs.mkdirSync(projectRoot, { recursive: true });
     process.env.HOME = path.join(testDir, 'home');
@@ -502,7 +391,7 @@ describe('observe: pre-event persists semantic summary', () => {
     Object.assign(process.env, originalEnv);
   });
 
-  it('writes a bounded semantic field on tool_start observations', () => {
+  it('writes SafeEvidencePatch on Bash tool_start (no semantic, no raw input)', () => {
     const learning = require('../../scripts/lib/learning');
     const sessionUtils = require('../../scripts/lib/session-utils');
     const { spawnSync } = require('node:child_process');
@@ -510,7 +399,7 @@ describe('observe: pre-event persists semantic summary', () => {
     learning.setLearningEnabled({ scope: 'project', enabled: true, projectRoot });
 
     const hookInput = {
-      session_id: 'sem-session',
+      session_id: 'evidence-bash-session',
       hook_event_name: 'PreToolUse',
       cwd: projectRoot,
       tool_name: 'Bash',
@@ -527,13 +416,79 @@ describe('observe: pre-event persists semantic summary', () => {
     const obsPath = sessionUtils.getObservationsPath(path.basename(projectRoot));
     const lines = fs.readFileSync(obsPath, 'utf8').trim().split('\n');
     const entry = JSON.parse(lines[lines.length - 1]);
-    assert.ok(entry.semantic, 'semantic summary must be present on pre events');
-    assert.strictEqual(entry.semantic.tool, 'Bash');
-    assert.strictEqual(entry.semantic.command_kind, 'test');
-    assert.strictEqual(entry.semantic.payload_saved, false);
-    assert.ok(!('input' in entry), 'pre-event must not persist raw tool input');
-    assert.ok(!JSON.stringify(entry).includes('npm test'));
-    assert.ok(!JSON.stringify(entry).includes('run tests'));
+    // Decision 4: no semantic field
+    assert.ok(!('semantic' in entry), 'semantic field must not be persisted (Decision 4)');
+    // SafeEvidencePatch fields
+    assert.strictEqual(entry.evidence_status, 'present');
+    assert.strictEqual(entry.operation_kind, 'shell');
+    // sanitized input is present (Bash tool)
+    assert.ok('input' in entry, 'Bash tool_start must have sanitized input');
+    assert.ok(!JSON.stringify(entry).includes('run tests'), 'description must not be persisted');
+  });
+
+  it('writes SafeEvidencePatch on Read tool_start (path field, no contents)', () => {
+    const learning = require('../../scripts/lib/learning');
+    const sessionUtils = require('../../scripts/lib/session-utils');
+    const { spawnSync } = require('node:child_process');
+
+    learning.setLearningEnabled({ scope: 'project', enabled: true, projectRoot });
+
+    const hookInput = {
+      session_id: 'evidence-read-session',
+      hook_event_name: 'PreToolUse',
+      cwd: projectRoot,
+      tool_name: 'Read',
+      tool_input: { file_path: 'README.md', contents: 'secret content' },
+    };
+    const scriptPath = path.join(__dirname, '..', 'observe', 'main.js');
+    const result = spawnSync('node', [scriptPath, 'pre'], {
+      input: JSON.stringify(hookInput),
+      env: { ...process.env, HOME: process.env.HOME, CLAUDE_PROJECT_DIR: projectRoot },
+      encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+    const obsPath = sessionUtils.getObservationsPath(path.basename(projectRoot));
+    const lines = fs.readFileSync(obsPath, 'utf8').trim().split('\n');
+    const entry = JSON.parse(lines[lines.length - 1]);
+    assert.ok(!('semantic' in entry), 'semantic field must not be persisted');
+    assert.strictEqual(entry.evidence_status, 'present');
+    assert.strictEqual(entry.operation_kind, 'read');
+    assert.ok('path' in entry, 'Read must persist sanitized path');
+    assert.ok(!('input' in entry), 'Read must not have input field');
+    assert.ok(
+      !JSON.stringify(entry).includes('secret content'),
+      'file contents must not be persisted',
+    );
+  });
+
+  it('omits_unsupported_tool for unknown tool classes', () => {
+    const learning = require('../../scripts/lib/learning');
+    const sessionUtils = require('../../scripts/lib/session-utils');
+    const { spawnSync } = require('node:child_process');
+
+    learning.setLearningEnabled({ scope: 'project', enabled: true, projectRoot });
+
+    const hookInput = {
+      session_id: 'evidence-unknown-session',
+      hook_event_name: 'PreToolUse',
+      cwd: projectRoot,
+      tool_name: 'SomeUnknownTool',
+      tool_input: { x: 1 },
+    };
+    const scriptPath = path.join(__dirname, '..', 'observe', 'main.js');
+    const result = spawnSync('node', [scriptPath, 'pre'], {
+      input: JSON.stringify(hookInput),
+      env: { ...process.env, HOME: process.env.HOME, CLAUDE_PROJECT_DIR: projectRoot },
+      encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+    const obsPath = sessionUtils.getObservationsPath(path.basename(projectRoot));
+    const lines = fs.readFileSync(obsPath, 'utf8').trim().split('\n');
+    const entry = JSON.parse(lines[lines.length - 1]);
+    assert.strictEqual(entry.evidence_status, 'omitted_unsupported_tool');
+    assert.ok(!('semantic' in entry), 'semantic field must not be persisted');
   });
 });
 
@@ -831,7 +786,7 @@ describe('observe: daemon lazy-start (C6)', () => {
     const { getObservationsPath } = require('../../scripts/lib/session-utils');
     const obsPath = getObservationsPath('test-project');
     fs.mkdirSync(path.dirname(obsPath), { recursive: true });
-    const lines = Array.from({ length: 10 }, (_, i) => JSON.stringify({ i })).join('\n') + '\n';
+    const lines = `${Array.from({ length: 10 }, (_, i) => JSON.stringify({ i })).join('\n')}\n`;
     fs.writeFileSync(obsPath, lines, 'utf-8');
 
     assert.strictEqual(spawnDaemonIfNeeded(obsPath), 'below-threshold');
@@ -842,7 +797,7 @@ describe('observe: daemon lazy-start (C6)', () => {
     const { getObservationsPath, getObserverPidFile } = require('../../scripts/lib/session-utils');
     const obsPath = getObservationsPath('test-project');
     fs.mkdirSync(path.dirname(obsPath), { recursive: true });
-    const lines = Array.from({ length: 60 }, (_, i) => JSON.stringify({ i })).join('\n') + '\n';
+    const lines = `${Array.from({ length: 60 }, (_, i) => JSON.stringify({ i })).join('\n')}\n`;
     fs.writeFileSync(obsPath, lines, 'utf-8');
 
     const pidFile = getObserverPidFile();
@@ -871,5 +826,144 @@ describe('observe: daemon lazy-start (C6)', () => {
     fs.writeFileSync(obsPath, lines, 'utf-8');
 
     assert.strictEqual(spawnDaemonIfNeeded(obsPath), 'no-spawn-env');
+  });
+});
+
+// ─────────────────────────────────────────────
+// Slice C — Sanitizer import + buildObservedEvidence
+// ─────────────────────────────────────────────
+
+describe('observe: sanitizer is imported from shared module (Slice C — C5)', () => {
+  beforeEach(() => {
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  it('buildObservedEvidence redacts Authorization Bearer values in Bash commands', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Bash', {
+      command: "curl -H 'Authorization: Bearer sk-abc123' https://api.example.com",
+    });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.ok(patch.input.includes('Authorization: Bearer'), 'keyword preserved');
+    assert.ok(!patch.input.includes('sk-abc123'), 'secret must be redacted');
+  });
+
+  it('buildObservedEvidence redacts OPENAI_API_KEY env-var assignments', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Bash', {
+      command: 'OPENAI_API_KEY=sk-real-secret python run.py',
+    });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.ok(!patch.input.includes('sk-real-secret'), 'secret must be redacted');
+  });
+});
+
+describe('observe: buildObservedEvidence — per-tool SafeEvidencePatch (Slice C — C6)', () => {
+  beforeEach(() => {
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  it('Bash tool returns present evidence with sanitized input and shell operation_kind', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Bash', { command: 'npm test' });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.strictEqual(patch.operation_kind, 'shell');
+    assert.ok('input' in patch, 'Bash must have input field');
+    assert.ok(!('path' in patch), 'Bash must not have path field');
+  });
+
+  it('Bash tool sanitizes secrets in the command', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Bash', {
+      command: 'curl -H "Authorization: Bearer sk-12345" https://api.example.com',
+    });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.ok(!patch.input.includes('sk-12345'), 'Bearer token must be redacted');
+    assert.ok(patch.input.includes('https://api.example.com'), 'URL must be preserved');
+  });
+
+  it('Read tool returns present evidence with path and read operation_kind', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Read', { file_path: 'README.md' });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.strictEqual(patch.operation_kind, 'read');
+    assert.ok('path' in patch, 'Read must have path field');
+    assert.ok(!('input' in patch), 'Read must not have input field');
+  });
+
+  it('Edit tool returns present evidence with path and edit operation_kind', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Edit', {
+      file_path: 'src/foo.js',
+      old_string: 'old',
+      new_string: 'new',
+    });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.strictEqual(patch.operation_kind, 'edit');
+    assert.ok('path' in patch);
+    assert.ok(!JSON.stringify(patch).includes('old'), 'old_string must not be persisted');
+    assert.ok(!JSON.stringify(patch).includes('new'), 'new_string must not be persisted');
+  });
+
+  it('Write tool returns present evidence with path and write operation_kind', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Write', {
+      file_path: 'output.txt',
+      content: 'secret file content',
+    });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.strictEqual(patch.operation_kind, 'write');
+    assert.ok('path' in patch);
+    assert.ok(
+      !JSON.stringify(patch).includes('secret file content'),
+      'content must not be persisted',
+    );
+  });
+
+  it('Grep tool returns present evidence with path and search operation_kind', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Grep', { pattern: 'TODO', path: 'src/' });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.strictEqual(patch.operation_kind, 'search');
+    assert.ok('pattern' in patch || 'path' in patch, 'Grep must have pattern or path');
+  });
+
+  it('Glob tool returns present evidence with glob and glob operation_kind', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Glob', { pattern: '**/*.test.js' });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.strictEqual(patch.operation_kind, 'glob');
+  });
+
+  it('Skill tool returns present evidence with skill name only (no args)', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Skill', {
+      skill: 'arc-debugging',
+      args: { sensitive: 'private' },
+    });
+    assert.strictEqual(patch.evidence_status, 'present');
+    assert.strictEqual(patch.operation_kind, 'skill');
+    assert.strictEqual(patch.skill, 'arc-debugging');
+    assert.ok(!JSON.stringify(patch).includes('private'), 'skill args must not be persisted');
+  });
+
+  it('unknown tool class returns omitted_unsupported_tool', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('SomeUnknownTool', { x: 1 });
+    assert.strictEqual(patch.evidence_status, 'omitted_unsupported_tool');
+    assert.ok(!('input' in patch), 'unsupported tool must not have input');
+  });
+
+  it('returns omitted_no_input when tool_input is missing', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Bash', null);
+    assert.strictEqual(patch.evidence_status, 'omitted_no_input');
+  });
+
+  it('no raw tool_input persisted — evidence_status present on Bash', () => {
+    const { buildObservedEvidence } = require('../observe/main');
+    const patch = buildObservedEvidence('Bash', { command: 'ls', env: { SECRET: 'abc' } });
+    // env dump must not be in the output
+    assert.ok(!JSON.stringify(patch).includes('abc'), 'env dump must not be persisted');
   });
 });

--- a/hooks/observe/main.js
+++ b/hooks/observe/main.js
@@ -25,6 +25,12 @@ const {
   getObserverPidFile,
 } = require('../../scripts/lib/session-utils');
 const { getProjectId, isLearningEnabled } = require('../../scripts/lib/learning');
+const {
+  sanitizeObservationPayload,
+  EVIDENCE_STATUS,
+} = require('../../scripts/lib/sanitize-observation');
+// summarizeToolInput is available for read-time consumers via:
+// require('../../scripts/lib/learning-observation-view').summarizeToolInput
 
 // ─────────────────────────────────────────────
 // Configuration
@@ -86,26 +92,6 @@ function shouldObserve({
 // ─────────────────────────────────────────────
 
 /**
- * Truncate string to max length with indicator.
- */
-function truncate(str, maxLen) {
-  if (!str || str.length <= maxLen) return str || '';
-  return `${str.substring(0, maxLen)}...[truncated]`;
-}
-
-function redactObservationText(value) {
-  return String(value || '')
-    .replace(/\b(api[_-]?key|secret|password|passwd|token)\b\s*[:=]\s*"[^"]*"/gi, '$1="[REDACTED]"')
-    .replace(/\b(api[_-]?key|secret|password|passwd|token)\b\s*[:=]\s*'[^']*'/gi, "$1='[REDACTED]'")
-    .replace(/\b(api[_-]?key|secret|password|passwd|token)\b\s*[:=]\s*[^\s,}]+/gi, '$1=[REDACTED]')
-    .replace(/\bAuthorization\s*:\s*Bearer\s+[^\s,}]+/gi, 'Authorization: Bearer [REDACTED]');
-}
-
-function sanitizeObservationPayload(value, maxLen) {
-  return truncate(redactObservationText(value), maxLen);
-}
-
-/**
  * Extract the skill name from a Skill tool invocation. Returns null when the
  * tool is not Skill, the input is missing, or the skill field is absent.
  * Only the skill name is returned — never the args payload — so this remains
@@ -149,125 +135,165 @@ function responseByteSize(toolResponse) {
   }
 }
 
-function buildObservedToolInput(toolName, toolInput) {
-  if (!toolInput || typeof toolInput !== 'object') return toolInput;
-  if (toolName !== 'Skill') return toolInput;
-  const skillName = extractSkillName(toolName, toolInput);
-  return skillName ? { skill: skillName } : {};
-}
-
 // ---------------------------------------------------------------------------
-// Semantic summaries
+// Per-tool collection contract (Layer 2 — SafeEvidencePatch)
 //
-// Privacy-safe, bounded shape derived from the tool input. We never persist
-// raw command lines, file contents, search queries, or skill args. We classify
-// the call into a small vocabulary so the analyzer can reason about workflows
-// without the redacted text. The contract: the persisted `semantic` object
-// only contains short enums and `payload_saved=false`.
+// Returns a SafeEvidencePatch object. The patch is spread directly into the
+// observation record — no nested `evidence` key.
+//
+// evidence_status values:
+//   "present"                 — safe evidence fields were added
+//   "omitted_no_input"        — no tool_input present
+//   "omitted_unsupported_tool"— tool class not in the allowlist
+//   "omitted_safety"          — payload existed but post-sanitize result is empty
+//
+// Fail-closed: raw fallback is forbidden. When a field cannot be proven safe,
+// it is omitted. An empty post-sanitize result becomes omitted_safety.
 // ---------------------------------------------------------------------------
 
-const PATH_CLASSES = [
-  { key: 'test', regex: /(^|\/)tests?(\/|$)|\.test\.|_test\.|test_/ },
-  { key: 'docs', regex: /(^|\/)docs?(\/|$)|\.md$/i },
-  { key: 'config', regex: /\.(json|ya?ml|toml|ini)$/i },
-  { key: 'script', regex: /^scripts\/|\.sh$/ },
-  { key: 'source', regex: /^(src|lib|scripts)\//i },
-];
-
-function classifyPath(rawPath) {
-  if (typeof rawPath !== 'string' || rawPath.length === 0) return 'unknown';
-  for (const { key, regex } of PATH_CLASSES) if (regex.test(rawPath)) return key;
-  if (/\.(js|ts|py|go|rs|java|rb|c|cpp|h|hpp)$/i.test(rawPath)) return 'source';
-  return 'other';
-}
-
-const ALLOWED_FILE_KINDS = new Set([
-  'js',
-  'ts',
-  'jsx',
-  'tsx',
-  'py',
-  'md',
-  'json',
-  'yaml',
-  'yml',
-  'toml',
-  'sh',
-  'txt',
+/** Tool classes in the Layer 2 allowlist. */
+const SUPPORTED_TOOLS = new Set([
+  'Bash',
+  'Read',
+  'Edit',
+  'Write',
+  'Grep',
+  'Glob',
+  'NotebookEdit',
+  'Skill',
+  'WebFetch',
+  'WebSearch',
 ]);
 
-function fileKindFromPath(rawPath) {
-  if (typeof rawPath !== 'string') return 'unknown';
-  const match = rawPath.match(/\.([a-z0-9]+)$/i);
-  if (!match) return 'none';
-  const ext = match[1].toLowerCase();
-  return ALLOWED_FILE_KINDS.has(ext) ? ext : 'other';
+/**
+ * Build a SafeEvidencePatch from a tool name and (optional) raw tool_input.
+ * The returned object is spread into the observation record alongside the
+ * Layer 1 event skeleton fields.
+ *
+ * @param {string} toolName
+ * @param {object|null|undefined} toolInput
+ * @returns {object} SafeEvidencePatch
+ */
+// Helper: classify the omit reason — empty raw input is omitted_no_input,
+// non-empty raw that the sanitizer strips entirely is omitted_safety. Per
+// Layer 2 spec these are semantically distinct and must not be conflated.
+function classifyOmission(raw, sanitized) {
+  if (!raw || !raw.trim()) return EVIDENCE_STATUS.OMITTED_NO_INPUT;
+  if (!sanitized.trim()) return EVIDENCE_STATUS.OMITTED_SAFETY;
+  return null;
 }
 
-function classifyBashCommand(rawCommand) {
-  if (typeof rawCommand !== 'string' || rawCommand.trim() === '') return 'unknown';
-  const head = rawCommand.trim().split(/\s+/)[0] || '';
-  const lower = head.toLowerCase();
-  if (/^(npm|yarn|pnpm|bun)$/.test(lower)) {
-    if (/\btest\b/.test(rawCommand)) return 'test';
-    if (/\b(lint|format|biome|eslint)\b/.test(rawCommand)) return 'lint';
-    if (/\b(build|compile|tsc)\b/.test(rawCommand)) return 'build';
-    return 'package';
-  }
-  if (/^(jest|pytest|mocha|vitest|cargo|go)$/.test(lower) && /test/.test(rawCommand)) return 'test';
-  if (/^(jest|pytest|mocha|vitest)$/.test(lower)) return 'test';
-  if (/^(biome|eslint|prettier|black|flake8|ruff)$/.test(lower)) return 'lint';
-  if (/^(git)$/.test(lower)) return 'git';
-  if (/^(grep|rg|find|ls|cat|head|tail|wc)$/.test(lower)) return 'inspect';
-  if (/^(node|python3?|deno|bun)$/.test(lower)) return 'run';
-  if (/^(make|cargo|go|gcc|clang)$/.test(lower)) return 'build';
-  if (/^(curl|wget|http)$/.test(lower)) return 'network';
-  return 'other';
-}
-
-function summarizeToolInput(toolName, toolInput) {
+function buildObservedEvidence(toolName, toolInput) {
   if (!toolInput || typeof toolInput !== 'object') {
-    return { tool: toolName, payload_saved: false };
+    return { evidence_status: EVIDENCE_STATUS.OMITTED_NO_INPUT };
   }
-  const base = { tool: toolName, payload_saved: false };
+
+  if (!SUPPORTED_TOOLS.has(toolName)) {
+    return { evidence_status: EVIDENCE_STATUS.OMITTED_UNSUPPORTED_TOOL };
+  }
+
   switch (toolName) {
-    case 'Bash':
+    case 'Bash': {
+      const raw = typeof toolInput.command === 'string' ? toolInput.command : '';
+      const sanitized = sanitizeObservationPayload(raw, MAX_INPUT_LENGTH);
+      const omit = classifyOmission(raw, sanitized);
+      if (omit) return { evidence_status: omit };
       return {
-        ...base,
-        operation: 'shell',
-        command_kind: classifyBashCommand(toolInput.command),
+        evidence_status: EVIDENCE_STATUS.PRESENT,
+        input: sanitized,
+        operation_kind: 'shell',
       };
-    case 'Read':
-      return {
-        ...base,
-        operation: 'read',
-        path_class: classifyPath(toolInput.file_path),
-        file_kind: fileKindFromPath(toolInput.file_path),
-      };
-    case 'Edit':
-    case 'Write':
-      return {
-        ...base,
-        operation: toolName.toLowerCase(),
-        path_class: classifyPath(toolInput.file_path),
-        file_kind: fileKindFromPath(toolInput.file_path),
-      };
-    case 'Grep':
-      return {
-        ...base,
-        operation: 'search',
-        path_class: classifyPath(toolInput.path || toolInput.glob || ''),
-      };
-    case 'Glob':
-      return { ...base, operation: 'glob' };
+    }
+    case 'Read': {
+      const raw = typeof toolInput.file_path === 'string' ? toolInput.file_path : '';
+      const sanitized = sanitizeObservationPayload(raw, 1024);
+      const omit = classifyOmission(raw, sanitized);
+      if (omit) return { evidence_status: omit };
+      return { evidence_status: EVIDENCE_STATUS.PRESENT, path: sanitized, operation_kind: 'read' };
+    }
+    case 'Edit': {
+      const raw = typeof toolInput.file_path === 'string' ? toolInput.file_path : '';
+      const sanitized = sanitizeObservationPayload(raw, 1024);
+      const omit = classifyOmission(raw, sanitized);
+      if (omit) return { evidence_status: omit };
+      return { evidence_status: EVIDENCE_STATUS.PRESENT, path: sanitized, operation_kind: 'edit' };
+    }
+    case 'Write': {
+      const raw = typeof toolInput.file_path === 'string' ? toolInput.file_path : '';
+      const sanitized = sanitizeObservationPayload(raw, 1024);
+      const omit = classifyOmission(raw, sanitized);
+      if (omit) return { evidence_status: omit };
+      return { evidence_status: EVIDENCE_STATUS.PRESENT, path: sanitized, operation_kind: 'write' };
+    }
+    case 'Grep': {
+      const patternRaw = typeof toolInput.pattern === 'string' ? toolInput.pattern : '';
+      const pathRaw = typeof toolInput.path === 'string' ? toolInput.path : '';
+      const pattern = sanitizeObservationPayload(patternRaw, 512);
+      const pathVal = sanitizeObservationPayload(pathRaw, 1024);
+      const noRaw = !patternRaw.trim() && !pathRaw.trim();
+      const noSanitized = !pattern.trim() && !pathVal.trim();
+      if (noRaw) return { evidence_status: EVIDENCE_STATUS.OMITTED_NO_INPUT };
+      if (noSanitized) return { evidence_status: EVIDENCE_STATUS.OMITTED_SAFETY };
+      const patch = { evidence_status: EVIDENCE_STATUS.PRESENT, operation_kind: 'search' };
+      if (pattern.trim()) patch.pattern = pattern;
+      if (pathVal.trim()) patch.path = pathVal;
+      return patch;
+    }
+    case 'Glob': {
+      const raw = typeof toolInput.pattern === 'string' ? toolInput.pattern : '';
+      const sanitized = sanitizeObservationPayload(raw, 512);
+      const omit = classifyOmission(raw, sanitized);
+      if (omit) return { evidence_status: omit };
+      return { evidence_status: EVIDENCE_STATUS.PRESENT, glob: sanitized, operation_kind: 'glob' };
+    }
+    case 'NotebookEdit': {
+      const raw = typeof toolInput.notebook_path === 'string' ? toolInput.notebook_path : '';
+      const sanitized = sanitizeObservationPayload(raw, 1024);
+      const omit = classifyOmission(raw, sanitized);
+      if (omit) return { evidence_status: omit };
+      return { evidence_status: EVIDENCE_STATUS.PRESENT, path: sanitized, operation_kind: 'edit' };
+    }
     case 'Skill': {
       const skillName = extractSkillName(toolName, toolInput);
-      return { ...base, operation: 'skill', ...(skillName ? { skill_name: skillName } : {}) };
+      if (!skillName) return { evidence_status: EVIDENCE_STATUS.OMITTED_NO_INPUT };
+      // Skill args are never persisted.
+      return {
+        evidence_status: EVIDENCE_STATUS.PRESENT,
+        skill: skillName,
+        operation_kind: 'skill',
+      };
+    }
+    case 'WebFetch':
+    case 'WebSearch': {
+      const urlRaw =
+        typeof toolInput.url === 'string'
+          ? toolInput.url
+          : typeof toolInput.query === 'string'
+            ? toolInput.query
+            : '';
+      const sanitized = sanitizeObservationPayload(urlRaw, 1024);
+      const omit = classifyOmission(urlRaw, sanitized);
+      if (omit) return { evidence_status: omit };
+      let domain = '';
+      try {
+        domain = new URL(sanitized).hostname;
+      } catch {
+        domain = sanitized.split('/')[0] || '';
+      }
+      return {
+        evidence_status: EVIDENCE_STATUS.PRESENT,
+        url: sanitized,
+        ...(domain ? { domain } : {}),
+        operation_kind: 'network',
+      };
     }
     default:
-      return { ...base, operation: 'other' };
+      return { evidence_status: EVIDENCE_STATUS.OMITTED_UNSUPPORTED_TOOL };
   }
 }
+
+// summarizeToolInput is now a read-time helper imported from
+// scripts/lib/learning-observation-view (Decision 4 — not persisted).
 
 /**
  * Archive observations file if it exceeds MAX_FILE_SIZE.
@@ -385,20 +411,24 @@ function main() {
       project_id: getProjectId(process.env.CLAUDE_PROJECT_DIR || process.cwd()),
     };
 
-    // Coarse skill-usage signal: when the call is a Skill invocation, record
-    // only the skill name. This lets us answer "are non-learning skills used?"
-    // without storing the args payload.
+    // Coarse skill-usage shortcut: record skill name at top level for both
+    // pre and post phases when the tool is Skill. This preserves the backward-
+    // compatible signal "which skills were used this session?" without storing args.
     const skillName = extractSkillName(toolName, input.tool_input);
     if (skillName) observation.skill = skillName;
 
-    // Add semantic input summary based on phase. PreToolUse deliberately does
-    // not persist raw tool input (commands, file paths, file contents, queries,
-    // or skill args). The bounded semantic object is the durable payload.
-    if (phase === 'pre' && input.tool_input) {
+    // Layer 2: build SafeEvidencePatch and spread into observation record.
+    // Decision 4: no semantic field is persisted; summarizeToolInput is read-time only.
+    // Decision 5: all evidence fields pass through the shared sanitizer.
+    if (phase === 'pre') {
       try {
-        observation.semantic = summarizeToolInput(toolName, input.tool_input);
+        const patch = buildObservedEvidence(toolName, input.tool_input);
+        Object.assign(observation, patch);
       } catch {
-        // Summary is best-effort; never block the observation.
+        // Best-effort: if buildObservedEvidence throws (e.g. unexpected input
+        // shape from a future tool), label as no-input rather than safety so
+        // we don't pollute downstream signal with a fake safety event.
+        observation.evidence_status = EVIDENCE_STATUS.OMITTED_NO_INPUT;
       }
     }
 
@@ -441,17 +471,10 @@ if (require.main === module) {
 }
 
 module.exports = {
-  truncate,
-  redactObservationText,
-  sanitizeObservationPayload,
   extractSkillName,
   classifyOutcome,
   responseByteSize,
-  buildObservedToolInput,
-  summarizeToolInput,
-  classifyPath,
-  classifyBashCommand,
-  fileKindFromPath,
+  buildObservedEvidence,
   getArchiveDir,
   getPidFile,
   shouldObserve,

--- a/scripts/lib/learning-observation-view.js
+++ b/scripts/lib/learning-observation-view.js
@@ -1,0 +1,163 @@
+/**
+ * Learning observation view — read-time semantic derivation (Layer 2, Output B).
+ *
+ * Provides the DerivedSemanticView computed from safe persisted evidence fields
+ * at READ time. This is NOT persisted in observations.jsonl — it is derived
+ * on demand by dashboard rendering, curator batch assembly, and other consumers.
+ *
+ * Decision 4: semantic enum is a derived view, not a persisted field.
+ */
+
+// ---------------------------------------------------------------------------
+// Path classification
+// ---------------------------------------------------------------------------
+
+const PATH_CLASSES = [
+  { key: 'test', regex: /(^|\/)tests?(\/|$)|\.test\.|_test\.|test_/ },
+  { key: 'docs', regex: /(^|\/)docs?(\/|$)|\.md$/i },
+  { key: 'config', regex: /\.(json|ya?ml|toml|ini)$/i },
+  { key: 'script', regex: /^scripts\/|\.sh$/ },
+  { key: 'source', regex: /^(src|lib|scripts)\//i },
+];
+
+function classifyPath(rawPath) {
+  if (typeof rawPath !== 'string' || rawPath.length === 0) return 'unknown';
+  for (const { key, regex } of PATH_CLASSES) if (regex.test(rawPath)) return key;
+  if (/\.(js|ts|py|go|rs|java|rb|c|cpp|h|hpp)$/i.test(rawPath)) return 'source';
+  return 'other';
+}
+
+// ---------------------------------------------------------------------------
+// File kind classification
+// ---------------------------------------------------------------------------
+
+const ALLOWED_FILE_KINDS = new Set([
+  'js',
+  'ts',
+  'jsx',
+  'tsx',
+  'py',
+  'md',
+  'json',
+  'yaml',
+  'yml',
+  'toml',
+  'sh',
+  'txt',
+]);
+
+function fileKindFromPath(rawPath) {
+  if (typeof rawPath !== 'string') return 'unknown';
+  const match = rawPath.match(/\.([a-z0-9]+)$/i);
+  if (!match) return 'none';
+  const ext = match[1].toLowerCase();
+  return ALLOWED_FILE_KINDS.has(ext) ? ext : 'other';
+}
+
+// ---------------------------------------------------------------------------
+// Bash command kind classification
+// ---------------------------------------------------------------------------
+
+function classifyBashCommand(rawCommand) {
+  if (typeof rawCommand !== 'string' || rawCommand.trim() === '') return 'unknown';
+  const head = rawCommand.trim().split(/\s+/)[0] || '';
+  const lower = head.toLowerCase();
+  if (/^(npm|yarn|pnpm|bun)$/.test(lower)) {
+    if (/\btest\b/.test(rawCommand)) return 'test';
+    if (/\b(lint|format|biome|eslint)\b/.test(rawCommand)) return 'lint';
+    if (/\b(build|compile|tsc)\b/.test(rawCommand)) return 'build';
+    return 'package';
+  }
+  if (/^(jest|pytest|mocha|vitest|cargo|go)$/.test(lower) && /test/.test(rawCommand)) return 'test';
+  if (/^(jest|pytest|mocha|vitest)$/.test(lower)) return 'test';
+  if (/^(biome|eslint|prettier|black|flake8|ruff)$/.test(lower)) return 'lint';
+  if (/^(git)$/.test(lower)) return 'git';
+  if (/^(grep|rg|find|ls|cat|head|tail|wc)$/.test(lower)) return 'inspect';
+  if (/^(node|python3?|deno|bun)$/.test(lower)) return 'run';
+  if (/^(make|cargo|go|gcc|clang)$/.test(lower)) return 'build';
+  if (/^(curl|wget|http)$/.test(lower)) return 'network';
+  return 'other';
+}
+
+// ---------------------------------------------------------------------------
+// Skill name extraction (read-only helper — no side effects)
+// ---------------------------------------------------------------------------
+
+function extractSkillNameFromInput(toolName, toolInput) {
+  if (toolName !== 'Skill') return null;
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const raw = toolInput.skill;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 128);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a DerivedSemanticView from a tool name and tool input at read time.
+ *
+ * The signature is intentionally compatible with the function previously
+ * inlined in hooks/observe/main.js so callers can import from this module.
+ *
+ * @param {string} toolName
+ * @param {object|null|undefined} toolInput
+ * @returns {object} DerivedSemanticView
+ */
+function summarizeToolInput(toolName, toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') {
+    return { tool: toolName, payload_saved: false };
+  }
+  const base = { tool: toolName, payload_saved: false };
+  switch (toolName) {
+    case 'Bash':
+      return {
+        ...base,
+        operation_kind: 'shell',
+        command_kind: classifyBashCommand(toolInput.command),
+      };
+    case 'Read':
+      return {
+        ...base,
+        operation_kind: 'read',
+        path_class: classifyPath(toolInput.file_path),
+        file_kind: fileKindFromPath(toolInput.file_path),
+      };
+    case 'Edit':
+    case 'Write':
+      return {
+        ...base,
+        operation_kind: toolName.toLowerCase(),
+        path_class: classifyPath(toolInput.file_path),
+        file_kind: fileKindFromPath(toolInput.file_path),
+      };
+    case 'Grep':
+      return {
+        ...base,
+        operation_kind: 'search',
+        path_class: classifyPath(toolInput.path || toolInput.glob || ''),
+      };
+    case 'Glob':
+      return { ...base, operation_kind: 'glob' };
+    case 'Skill': {
+      const skillName = extractSkillNameFromInput(toolName, toolInput);
+      return {
+        ...base,
+        operation_kind: 'skill',
+        ...(skillName ? { skill_name: skillName } : {}),
+      };
+    }
+    default:
+      return { ...base, operation_kind: 'other' };
+  }
+}
+
+module.exports = {
+  summarizeToolInput,
+  classifyPath,
+  classifyBashCommand,
+  fileKindFromPath,
+};

--- a/scripts/lib/sanitize-observation.js
+++ b/scripts/lib/sanitize-observation.js
@@ -1,0 +1,185 @@
+/**
+ * Shared observation sanitizer — Decision 5 keyword + value form coverage.
+ *
+ * Used by: hooks/observe/main.js (Layer 2), Layer 4 daemon prompt assembly,
+ * Layer 5 queue validation, and dashboard backend sanitization.
+ *
+ * Fail-closed rule (Layer 2): if a field cannot be proven safe, do not persist.
+ * This module ONLY performs redaction; callers decide whether the post-redact
+ * result is safe enough to persist.
+ */
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Truncate a string to maxLen characters, appending '...[truncated]' when cut.
+ * @param {string} str
+ * @param {number} maxLen
+ * @returns {string}
+ */
+function truncate(str, maxLen) {
+  if (!str || str.length <= maxLen) return str || '';
+  return `${str.substring(0, maxLen)}...[truncated]`;
+}
+
+// ---------------------------------------------------------------------------
+// Ordered replacement regexes — most-specific first
+// ---------------------------------------------------------------------------
+
+// 1. Private key blocks (multi-line)
+const PRIVATE_KEY_RE =
+  /-----BEGIN [^-\n]*PRIVATE KEY-----[\s\S]*?-----END [^-\n]*PRIVATE KEY-----/g;
+
+// 2. JWT-shaped strings: eyJ{10+}.{10+}.{10+}
+const JWT_RE = /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g;
+
+// 3. URL credentials: scheme://user:pass@host
+const URL_CREDENTIALS_RE = /(https?:\/\/)[^:@/\s]+:[^@/\s]+@/g;
+
+// 4a. Authorization: Bearer/Basic <token> — standard HTTP header form
+//     Matches full "Authorization: Bearer token" (case-insensitive on keyword)
+const AUTHORIZATION_HEADER_RE = /\bAuthorization\s*:\s*(Bearer|Basic)\s+\S+/gi;
+
+// 4b. auth / authorization keyword with Bearer/Basic followed by a token
+//     Handles "auth: Bearer token123" which isn't matched by 4a
+const AUTH_KEYWORD_BEARER_RE = /\b(auth|authorization)\s*[=:]\s*(Bearer|Basic)\s+\S+/gi;
+
+// 5. Suffixed uppercase env-var assignments: NAME_API_KEY=value, NAME_TOKEN=value
+//    Matches OPENAI_API_KEY=..., GITHUB_TOKEN=..., etc.
+const ENV_VAR_APIKEY_RE = /\b[A-Z][A-Z0-9_]*_API_KEY\s*=\s*\S+/g;
+const ENV_VAR_TOKEN_RE = /\b[A-Z][A-Z0-9_]*_TOKEN\s*=\s*\S+/g;
+
+// 6a–6d. Keyword key=value / key: value forms.
+//
+// Full keyword union — used for quoted-value forms (JSON, YAML) since those
+// are unambiguous. authorization / auth are included so JSON "authorization":
+// and YAML authorization: "..." get redacted even though they are also handled
+// by the dedicated Bearer/Basic steps above.
+const KEYWORD_UNION =
+  'api[_-]key|secret|password|passwd|token|authorization|credentials?|auth|cookie|set-cookie|x-api-key';
+
+// Bare-value keyword union — excludes authorization / auth because:
+//   - Standard "Authorization: Bearer xxx" is handled by step 4a.
+//   - "auth: Bearer xxx" form is handled by step 4b.
+//   - Plain "authorization: somevalue" bare (no quotes) would be mis-processed
+//     because the bare-value regex stops at the first space — leaving multi-word
+//     values like "Bearer token" only half-redacted.
+//   After steps 4a/4b fire, the remaining text contains "Authorization: Bearer [REDACTED]"
+//   which the bare-value regex would partially re-match.
+const KEYWORD_UNION_BARE =
+  'api[_-]key|secret|password|passwd|token|credentials?|cookie|set-cookie|x-api-key';
+
+// 6a. JSON form: "keyword":"value" or "keyword": "value"
+const KW_JSON_DQUOTED_RE = new RegExp(`"(${KEYWORD_UNION})"\\s*:\\s*"[^"]*"`, 'gi');
+
+// 6b. Unquoted key with double-quoted value (colon): keyword: "value"
+const KW_KEY_DQUOTED_VALUE_RE = new RegExp(`\\b(${KEYWORD_UNION})\\b\\s*:\\s*"[^"]*"`, 'gi');
+
+// 6b2. Unquoted key with double-quoted value (equals): keyword="value"
+//      Handles shell assignment forms like api_key="secret"
+const KW_KEY_EQ_DQUOTED_VALUE_RE = new RegExp(`\\b(${KEYWORD_UNION})\\b\\s*=\\s*"[^"]*"`, 'gi');
+
+// 6c. Unquoted key with single-quoted value: keyword: 'value' or keyword='value'
+const KW_KEY_SQUOTED_VALUE_RE = new RegExp(`\\b(${KEYWORD_UNION})\\b\\s*[=:]\\s*'[^']*'`, 'gi');
+
+// 6d. Bare key=value or key: value (stops at whitespace or JSON delimiters).
+//     Uses KEYWORD_UNION_BARE (excludes auth/authorization) to avoid
+//     re-processing already-redacted Authorization Bearer/Basic output.
+//     Excludes '[' and ']' so [REDACTED] markers are not re-matched.
+const KW_KEY_BARE_VALUE_RE = new RegExp(
+  `\\b(${KEYWORD_UNION_BARE})\\b\\s*[=:]\\s*[^\\s,}"'\\[\\]]+`,
+  'gi',
+);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Redact secret-like values from a text string.
+ * Does not truncate — call sanitizeObservationPayload for truncation.
+ *
+ * Replacement steps are ordered from most-specific to most-general:
+ *   1. Private key blocks
+ *   2. JWT-shaped tokens
+ *   3. URL credentials
+ *   4. Authorization Bearer/Basic headers (both standard and auth: keyword form)
+ *   5. Suffixed env-var assignments (*_API_KEY, *_TOKEN)
+ *   6. Keyword key=value / key: value forms (JSON, YAML, dotenv, shell)
+ *
+ * Idempotent: applying twice equals applying once because the [REDACTED] /
+ * [REDACTED-JWT] / [REDACTED-KEY] markers contain '[' which is excluded from
+ * the bare-value charset.
+ *
+ * @param {string|null|undefined} value
+ * @returns {string}
+ */
+function redactObservationText(value) {
+  if (!value) return '';
+  let text = String(value);
+
+  // 1. Private key blocks
+  text = text.replace(PRIVATE_KEY_RE, '[REDACTED-KEY]');
+
+  // 2. JWT-shaped tokens
+  text = text.replace(JWT_RE, '[REDACTED-JWT]');
+
+  // 3. URL credentials
+  text = text.replace(URL_CREDENTIALS_RE, '$1[REDACTED]@');
+
+  // 4a. Authorization: Bearer/Basic headers
+  text = text.replace(AUTHORIZATION_HEADER_RE, 'Authorization: $1 [REDACTED]');
+
+  // 4b. auth/authorization keyword with Bearer/Basic token
+  text = text.replace(AUTH_KEYWORD_BEARER_RE, '$1: $2 [REDACTED]');
+
+  // 5. Suffixed env-var assignments
+  text = text.replace(ENV_VAR_APIKEY_RE, (m) => `${m.slice(0, m.indexOf('=') + 1)}[REDACTED]`);
+  text = text.replace(ENV_VAR_TOKEN_RE, (m) => `${m.slice(0, m.indexOf('=') + 1)}[REDACTED]`);
+
+  // 6. Keyword key=value / key: value forms — most-constrained first
+  text = text.replace(KW_JSON_DQUOTED_RE, (_m, kw) => `"${kw}":"[REDACTED]"`);
+  text = text.replace(KW_KEY_DQUOTED_VALUE_RE, (_m, kw) => `${kw}: "[REDACTED]"`);
+  text = text.replace(KW_KEY_EQ_DQUOTED_VALUE_RE, (_m, kw) => `${kw}="[REDACTED]"`);
+  text = text.replace(KW_KEY_SQUOTED_VALUE_RE, (m, kw) => {
+    const sepIdx = m.search(/[=:]/);
+    const sep = m[sepIdx];
+    return `${kw}${sep}'[REDACTED]'`;
+  });
+  text = text.replace(KW_KEY_BARE_VALUE_RE, (m, kw) => {
+    const sepIdx = m.search(/[=:]/);
+    const sep = m[sepIdx];
+    return `${kw}${sep}[REDACTED]`;
+  });
+
+  return text;
+}
+
+/**
+ * Sanitize and truncate an observation payload.
+ * Applies redaction first, then truncation.
+ *
+ * @param {string|null|undefined} value
+ * @param {number} maxLen  — maximum character count before truncation
+ * @returns {string}
+ */
+function sanitizeObservationPayload(value, maxLen) {
+  return truncate(redactObservationText(value), maxLen);
+}
+
+// Layer 2 SafeEvidencePatch evidence_status enum (canonical source).
+// Importers must use these constants instead of inline string literals.
+const EVIDENCE_STATUS = Object.freeze({
+  PRESENT: 'present',
+  OMITTED_NO_INPUT: 'omitted_no_input',
+  OMITTED_UNSUPPORTED_TOOL: 'omitted_unsupported_tool',
+  OMITTED_SAFETY: 'omitted_safety',
+});
+
+module.exports = {
+  redactObservationText,
+  sanitizeObservationPayload,
+  EVIDENCE_STATUS,
+};

--- a/tests/scripts/learning-observation-view.test.js
+++ b/tests/scripts/learning-observation-view.test.js
@@ -1,0 +1,97 @@
+const { summarizeToolInput } = require('../../scripts/lib/learning-observation-view');
+
+// ---------------------------------------------------------------------------
+// summarizeToolInput — read-time semantic view derivation
+// ---------------------------------------------------------------------------
+
+describe('summarizeToolInput — Bash', () => {
+  it('classifies npm test as test command kind', () => {
+    const view = summarizeToolInput('Bash', { command: 'npm test' });
+    expect(view.tool).toBe('Bash');
+    expect(view.operation_kind).toBe('shell');
+    expect(view.command_kind).toBe('test');
+    expect(view.payload_saved).toBe(false);
+  });
+
+  it('classifies git status as git command kind', () => {
+    const view = summarizeToolInput('Bash', { command: 'git status' });
+    expect(view.command_kind).toBe('git');
+  });
+
+  it('classifies npm run lint as lint command kind', () => {
+    const view = summarizeToolInput('Bash', { command: 'npm run lint' });
+    expect(view.command_kind).toBe('lint');
+  });
+
+  it('classifies npm run build as build command kind', () => {
+    const view = summarizeToolInput('Bash', { command: 'npm run build' });
+    expect(view.command_kind).toBe('build');
+  });
+
+  it('classifies node script.js as run command kind', () => {
+    const view = summarizeToolInput('Bash', { command: 'node scripts/cli.js foo' });
+    expect(view.command_kind).toBe('run');
+  });
+});
+
+describe('summarizeToolInput — file-targeted tools', () => {
+  it('classifies Edit with a test file path', () => {
+    const view = summarizeToolInput('Edit', { file_path: 'tests/scripts/foo.test.js' });
+    expect(view.tool).toBe('Edit');
+    expect(view.operation_kind).toBe('edit');
+    expect(view.path_class).toBe('test');
+    expect(view.file_kind).toBe('js');
+    expect(view.payload_saved).toBe(false);
+    expect(Object.keys(view)).not.toContain('file_path');
+  });
+
+  it('classifies Read with a docs markdown file', () => {
+    const view = summarizeToolInput('Read', { file_path: 'docs/guide/learning.md' });
+    expect(view.operation_kind).toBe('read');
+    expect(view.path_class).toBe('docs');
+    expect(view.file_kind).toBe('md');
+  });
+
+  it('classifies Write with a source JS file', () => {
+    // scripts/ is classified as 'script' by PATH_CLASSES (^scripts\/ pattern)
+    const view = summarizeToolInput('Write', { file_path: 'scripts/lib/foo.js' });
+    expect(view.operation_kind).toBe('write');
+    expect(view.path_class).toBe('script');
+    expect(view.file_kind).toBe('js');
+  });
+});
+
+describe('summarizeToolInput — Skill', () => {
+  it('records skill name without args', () => {
+    const view = summarizeToolInput('Skill', { skill: 'arc-debugging', args: 'private' });
+    expect(view.operation_kind).toBe('skill');
+    expect(view.skill_name).toBe('arc-debugging');
+    expect(Object.keys(view)).not.toContain('args');
+  });
+});
+
+describe('summarizeToolInput — Grep and Glob', () => {
+  it('classifies Grep as search operation', () => {
+    const view = summarizeToolInput('Grep', { pattern: 'foo', path: 'src/' });
+    expect(view.operation_kind).toBe('search');
+  });
+
+  it('classifies Glob as glob operation', () => {
+    const view = summarizeToolInput('Glob', { pattern: '**/*.test.js' });
+    expect(view.operation_kind).toBe('glob');
+  });
+});
+
+describe('summarizeToolInput — unknown/missing input', () => {
+  it('returns other operation for unknown tool', () => {
+    const view = summarizeToolInput('SomeNewTool', { x: 1 });
+    expect(view.operation_kind).toBe('other');
+    expect(view.payload_saved).toBe(false);
+  });
+
+  it('returns minimal view when tool_input is missing', () => {
+    const view = summarizeToolInput('Bash', null);
+    expect(view.tool).toBe('Bash');
+    expect(view.payload_saved).toBe(false);
+  });
+});

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -395,8 +395,9 @@ describe('learning subsystem MVP-1', () => {
   });
 
   it('observe redaction removes common secrets before observations are stored', () => {
-    delete require.cache[require.resolve('../../hooks/observe/main')];
-    const { redactObservationText } = require('../../hooks/observe/main');
+    // redactObservationText moved to scripts/lib/sanitize-observation (Slice C)
+    delete require.cache[require.resolve('../../scripts/lib/sanitize-observation')];
+    const { redactObservationText } = require('../../scripts/lib/sanitize-observation');
 
     const apiKeyName = ['api', '_key'].join('');
     const passwordName = ['pass', 'word'].join('');
@@ -409,14 +410,14 @@ describe('learning subsystem MVP-1', () => {
       `${apiKeyName}="${apiKey}" ${passwordName}: "${password}" Authorization: Bearer ${bearer} ${tokenName}=${token}`,
     );
 
-    expect(redacted).toContain('api_key=[REDACTED]');
-    expect(redacted).toContain('password=[REDACTED]');
-    expect(redacted).toContain('Authorization: Bearer [REDACTED]');
-    expect(redacted).toContain('token=[REDACTED]');
+    // Sanitizer preserves delimiter context: api_key="value" → api_key="[REDACTED]"
+    // and password: "value" → password: "[REDACTED]"
     expect(redacted).not.toContain(apiKey);
     expect(redacted).not.toContain(password);
     expect(redacted).not.toContain(bearer);
     expect(redacted).not.toContain(token);
+    expect(redacted).toContain('[REDACTED]');
+    expect(redacted).toContain('Authorization: Bearer [REDACTED]');
   });
 
   it('observe hook is disabled until project or global learning is explicitly enabled', () => {

--- a/tests/scripts/sanitize-observation.test.js
+++ b/tests/scripts/sanitize-observation.test.js
@@ -1,0 +1,297 @@
+const {
+  sanitizeObservationPayload,
+  redactObservationText,
+} = require('../../scripts/lib/sanitize-observation');
+
+// ---------------------------------------------------------------------------
+// redactObservationText — adversarial fixtures
+// ---------------------------------------------------------------------------
+
+describe('redactObservationText — JSON value forms', () => {
+  it('redacts JSON "api_key": "value" (spaced colon)', () => {
+    const out = redactObservationText('"api_key": "sk-12345"');
+    expect(out).not.toContain('sk-12345');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "api_key":"value" (no space)', () => {
+    const out = redactObservationText('"api_key":"sk-12345"');
+    expect(out).not.toContain('sk-12345');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "api-key": "value"', () => {
+    const out = redactObservationText('"api-key": "abc-xyz"');
+    expect(out).not.toContain('abc-xyz');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "secret": "value"', () => {
+    const out = redactObservationText('"secret": "s3cr3t"');
+    expect(out).not.toContain('s3cr3t');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "password": "value"', () => {
+    const out = redactObservationText('"password": "hunter2"');
+    expect(out).not.toContain('hunter2');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "token": "value"', () => {
+    const out = redactObservationText('"token": "ghp_AAAA"');
+    expect(out).not.toContain('ghp_AAAA');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "authorization": "value"', () => {
+    const out = redactObservationText('"authorization": "Bearer tok123"');
+    expect(out).not.toContain('tok123');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "credentials": "value"', () => {
+    const out = redactObservationText('"credentials": "user:pass"');
+    expect(out).not.toContain('user:pass');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "credential": "value" (singular)', () => {
+    const out = redactObservationText('"credential": "abc"');
+    expect(out).not.toContain('"abc"');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "cookie": "value"', () => {
+    const out = redactObservationText('"cookie": "session=abc123"');
+    expect(out).not.toContain('session=abc123');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON "x-api-key": "value"', () => {
+    const out = redactObservationText('"x-api-key": "apikeyval"');
+    expect(out).not.toContain('apikeyval');
+    expect(out).toContain('[REDACTED]');
+  });
+});
+
+describe('redactObservationText — YAML value forms', () => {
+  it('redacts YAML api_key: value (unquoted)', () => {
+    const out = redactObservationText('api_key: sk-12345');
+    expect(out).not.toContain('sk-12345');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts YAML api_key: "value" (quoted)', () => {
+    const out = redactObservationText('api_key: "sk-12345"');
+    expect(out).not.toContain('sk-12345');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts YAML password: mypassword', () => {
+    const out = redactObservationText('password: mypassword');
+    expect(out).not.toContain('mypassword');
+    expect(out).toContain('[REDACTED]');
+  });
+});
+
+describe('redactObservationText — dotenv / shell export forms', () => {
+  it('redacts dotenv API_KEY=value', () => {
+    const out = redactObservationText('OPENAI_API_KEY=sk-proj-abc');
+    expect(out).not.toContain('sk-proj-abc');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts dotenv GITHUB_TOKEN=value', () => {
+    const out = redactObservationText('GITHUB_TOKEN=ghp_xxxx');
+    expect(out).not.toContain('ghp_xxxx');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts dotenv FOO_TOKEN=value', () => {
+    const out = redactObservationText('FOO_TOKEN=secretvalue');
+    expect(out).not.toContain('secretvalue');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts shell export API_KEY=value', () => {
+    const out = redactObservationText('export OPENAI_API_KEY=sk-proj-xyz');
+    expect(out).not.toContain('sk-proj-xyz');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts shell export GITHUB_TOKEN="value"', () => {
+    const out = redactObservationText('export GITHUB_TOKEN="ghp_secret"');
+    expect(out).not.toContain('ghp_secret');
+    expect(out).toContain('[REDACTED]');
+  });
+});
+
+describe('redactObservationText — Authorization header forms', () => {
+  it('redacts Authorization: Bearer xyz', () => {
+    const out = redactObservationText('Authorization: Bearer sk-12345abc');
+    expect(out).not.toContain('sk-12345abc');
+    expect(out).toMatch(/Authorization: Bearer \[REDACTED\]|\*\*\*/);
+  });
+
+  it('redacts Authorization: Basic xyz', () => {
+    const out = redactObservationText('Authorization: Basic dXNlcjpwYXNz');
+    expect(out).not.toContain('dXNlcjpwYXNz');
+    expect(out).toMatch(/Authorization: Basic \[REDACTED\]|\*\*\*/);
+  });
+
+  it('redacts Authorization header embedded in curl command', () => {
+    const out = redactObservationText(
+      "curl -H 'Authorization: Bearer sk-12345' https://api.example.com",
+    );
+    expect(out).not.toContain('sk-12345');
+    expect(out).toContain('https://api.example.com');
+  });
+});
+
+describe('redactObservationText — URL credentials', () => {
+  it('redacts https://user:pass@host', () => {
+    const out = redactObservationText('https://admin:hunter2@db.internal.io/path');
+    expect(out).not.toContain('hunter2');
+    expect(out).toContain('[REDACTED]');
+    expect(out).toContain('db.internal.io');
+  });
+
+  it('redacts http://user:pass@host', () => {
+    const out = redactObservationText('http://user:secret@example.com');
+    expect(out).not.toContain('secret');
+    expect(out).toContain('[REDACTED]');
+  });
+});
+
+describe('redactObservationText — JWT-shaped strings', () => {
+  it('redacts a JWT-shaped token (eyJ...)', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_here_abc';
+    const out = redactObservationText(jwt);
+    expect(out).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+    expect(out).toContain('[REDACTED-JWT]');
+  });
+
+  it('redacts a JWT embedded in a larger string', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.sig_abc_def_ghi';
+    const out = redactObservationText(`Bearer ${jwt} extra text`);
+    expect(out).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+    expect(out).toContain('[REDACTED-JWT]');
+  });
+});
+
+describe('redactObservationText — private key blocks', () => {
+  it('redacts a private key block', () => {
+    const key = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA2a2rwplBQLzHPZe5TNJQM97pCm9v
+-----END RSA PRIVATE KEY-----`;
+    const out = redactObservationText(key);
+    expect(out).not.toContain('MIIEowIBAAKCAQEA');
+    expect(out).toContain('[REDACTED-KEY]');
+  });
+
+  it('redacts an EC PRIVATE KEY block', () => {
+    const key = `-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIOhwFcfpj1WvDXd4lMwKMKqJ
+-----END EC PRIVATE KEY-----`;
+    const out = redactObservationText(key);
+    expect(out).not.toContain('MHQCAQEEIOhwFcfpj1WvDXd4lMwKMKqJ');
+    expect(out).toContain('[REDACTED-KEY]');
+  });
+});
+
+describe('redactObservationText — suffixed env vars', () => {
+  it('redacts *_API_KEY pattern (STRIPE_API_KEY)', () => {
+    const out = redactObservationText('STRIPE_API_KEY=sk_live_abc123');
+    expect(out).not.toContain('sk_live_abc123');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts *_TOKEN pattern (SLACK_BOT_TOKEN)', () => {
+    const out = redactObservationText('SLACK_BOT_TOKEN=xoxb-123-secret');
+    expect(out).not.toContain('xoxb-123-secret');
+    expect(out).toContain('[REDACTED]');
+  });
+});
+
+describe('redactObservationText — set-cookie and auth keyword', () => {
+  it('redacts set-cookie header value', () => {
+    const out = redactObservationText('set-cookie: session=abc123; Path=/');
+    expect(out).not.toContain('abc123');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts auth: value', () => {
+    const out = redactObservationText('auth: Bearer token123');
+    expect(out).not.toContain('token123');
+    expect(out).toContain('[REDACTED]');
+  });
+});
+
+describe('redactObservationText — edge cases', () => {
+  it('returns empty string for null/undefined input', () => {
+    expect(redactObservationText(null)).toBe('');
+    expect(redactObservationText(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(redactObservationText('')).toBe('');
+  });
+
+  it('does not redact innocent text', () => {
+    const out = redactObservationText('npm test -- --watch');
+    expect(out).toBe('npm test -- --watch');
+  });
+
+  it('handles multiple secrets in one input', () => {
+    const out = redactObservationText('api_key: abc123\npassword: hunter2\ntoken: ghp_xxx');
+    expect(out).not.toContain('abc123');
+    expect(out).not.toContain('hunter2');
+    expect(out).not.toContain('ghp_xxx');
+    expect(out.match(/\[REDACTED\]/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('handles a secret embedded in the middle of a larger text', () => {
+    const out = redactObservationText(
+      'Running curl -H "api_key: secret99" -d data https://api.example.com/endpoint',
+    );
+    expect(out).not.toContain('secret99');
+    expect(out).toContain('https://api.example.com/endpoint');
+  });
+
+  it('is idempotent — applying twice equals applying once', () => {
+    const input = 'Authorization: Bearer sk-12345';
+    const once = redactObservationText(input);
+    const twice = redactObservationText(once);
+    expect(twice).toBe(once);
+  });
+
+  it('redacts passwd keyword', () => {
+    const out = redactObservationText('passwd: mypassword123');
+    expect(out).not.toContain('mypassword123');
+    expect(out).toContain('[REDACTED]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeObservationPayload — truncation + redaction
+// ---------------------------------------------------------------------------
+
+describe('sanitizeObservationPayload — truncation', () => {
+  it('returns the full string when under maxLen', () => {
+    expect(sanitizeObservationPayload('hello', 100)).toBe('hello');
+  });
+
+  it('truncates with [truncated] marker when over maxLen', () => {
+    const out = sanitizeObservationPayload('A'.repeat(200), 100);
+    expect(out.endsWith('...[truncated]')).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(100 + '...[truncated]'.length);
+  });
+
+  it('redacts AND truncates long secret-containing strings', () => {
+    const big = `api_key: ${'x'.repeat(5000)}`;
+    const out = sanitizeObservationPayload(big, 100);
+    expect(out).not.toContain('x'.repeat(50));
+    expect(out).toContain('[REDACTED]');
+  });
+});


### PR DESCRIPTION
## Summary

Third implementation slice. Lays Layer 1 + Layer 2 of the curator architecture: the **canonical sanitizer module** (shared with future Layer 4 + Layer 5) plus the per-tool **SafeEvidencePatch** builder. Removes the Decision-4-violating `semantic` enum from persisted observations.

Reference: implementation plan Section 4 (Slice C) + Section 7 goal template. Layer 1/2 schema contracts in `docs/plans/references/learning-curator-schema/`.

> Chained off Slice B (PR #33). Once both merge, base of this PR will rebase to `feat/learning-curator-pivot`.

## Acceptance criteria (verified)

| # | What | Verification |
|---|---|---|
| 1 | New `scripts/lib/sanitize-observation.js` exports `sanitizeObservationPayload`, `redactObservationText`, `EVIDENCE_STATUS` | file present + 42 Jest cases pass |
| 2 | Decision 5 keyword set covered | tests assert each form |
| 3 | All value forms covered (JSON / YAML / dotenv / shell / Authorization Bearer-Basic / URL credentials / JWT / private-key block) | dedicated test sections |
| 4 | ≥ 30 adversarial fixtures | 42 cases |
| 5 | No inline `redactObservationText` in `hooks/observe/main.js` | replaced by import |
| 6 | `buildObservedEvidence` returns SafeEvidencePatch per Layer 2 — no raw `tool_input`, no `semantic` | grep + read confirms |
| 7 | `scripts/lib/learning-observation-view.js` exports read-time `summarizeToolInput` | 13 unit tests |
| 8 | `npm test` — 1460 Jest+Node + 557 pytest + 7 observer-daemon all green | passed |
| 9 | `npm run lint` clean | passed |

## Process gate

- **Implementer** ran TDD per criterion, produced 4 new files + 3 modified
- **spec-reviewer** — VERDICT ACCEPT, noted two dead-code orphans (`truncate`, `buildObservedToolInput`) — addressed in simplify pass
- **simplify** (3 parallel reviewers) — 5 must/should fixes applied, 7 deferred as out-of-scope or micro-opt
- Decisions logged in `docs/plans/2026-05-20-learning-curator-decisions.html` (orchestrator artifact, not in this PR)

## Simplify-pass changes after initial implementation

1. **`EVIDENCE_STATUS` frozen constants** extracted to sanitizer module — kills 15+ raw-string call sites, makes typos a compile-time error
2. **Layer 2 contract fix**: distinguish `omitted_no_input` (empty raw) from `omitted_safety` (sanitizer-stripped) per spec — new `classifyOmission()` helper applied to every per-tool branch
3. **Outer-catch hardening**: changed from `omitted_safety` (incorrect — implies privacy event) to `omitted_no_input` (accurate — we just didn't capture)
4. **Dead code deletion**: `truncate` (orphan after sanitizer move) and `buildObservedToolInput` (superseded by `buildObservedEvidence`) — both removed with 8 tests
5. **Brittle source-text test rewritten** as behavioral — asserts `Authorization: Bearer ...` + `OPENAI_API_KEY=...` redaction via `buildObservedEvidence` instead of grepping for the literal `require()` path

## Simplify-pass — deferred (scope creep or micro-opt)

- Read/Edit/Write/NotebookEdit branch consolidation (readable as-is)
- `safeDisplayText` dedup in `learning-dashboard.js` (Slice F scope)
- `extractSkillName` parallel helpers in main.js + view module (negligible duplication)
- Regex micro-merges for ~10-20% perf gain (sanitizer already ~35 µs/call on 5KB)
- JWT word-boundary anchors (theoretical false positive only)

## Privacy posture (verified by tests)

Adversarial fixtures with embedded `OPENAI_API_KEY=sk-real-secret`, `Authorization: Bearer sk-abc123`, JWT-shaped strings, and `-----BEGIN PRIVATE KEY-----` blocks all produce sanitized output with the secret replaced by `[REDACTED]`. None appear in the persisted observation record.

## Test plan

- [x] `npm test` — all 4 runners + observer-daemon green
- [x] `npm run lint` — biome check clean
- [x] 42 sanitizer adversarial tests cover Decision 5 keyword + value forms
- [x] 13 view-helper tests cover summarizeToolInput / classifyPath / classifyBashCommand / fileKindFromPath
- [x] C6 per-tool tests cover Bash / Read / Edit / Write / Grep / Glob / NotebookEdit / Skill / WebFetch / WebSearch evidence shape + `omitted_no_input` vs `omitted_safety` distinction
- [x] C5 behavioral tests assert Bearer + env-var redaction round-trip through `buildObservedEvidence`