### PR TITLE
feat(learning): Slice D — Candidate v1 schema + Layer 5 module (Migration step 3)

### DIFF
--- a/scripts/lib/learning-curator/lifecycle.js
+++ b/scripts/lib/learning-curator/lifecycle.js
@@ -1,0 +1,138 @@
+/**
+ * lifecycle.js — Layer 5 canonical lifecycle state machine.
+ *
+ * Owns the Action × Status legality matrix from PR #31 reconcile 1.5.
+ * Stateless pure functions — no I/O.
+ */
+
+// ---------------------------------------------------------------------------
+// Action × Status legality matrix (canonical)
+//
+// Rows: current status
+// Cols: action
+//
+// promote / evolve are candidate-PRODUCING actions.  They are legal from certain
+// statuses (callers use isLegalAction to gate the UI), but they do NOT transition
+// the SOURCE candidate's status.  applyTransition throws for those two actions so
+// callers are forced to handle them separately (creating a new candidate record).
+//
+//  status \ action     | dismiss | approve | materialize | activate | promote | evolve
+//  pending_review      |   ✓     |   ✓     |     ✗       |    ✗     |   ✓     |   ✓
+//  needs_more_evidence |   ✓     |   ✗     |     ✗       |    ✗     |   ✗     |   ✗
+//  approved            |   ✗     |   ✗     |     ✓       |    ✗     |   ✓     |   ✓
+//  materialized        |   ✗     |   ✗     |     ✗       |    ✓     |   ✗     |   ✗
+//  activated           |   ✗     |   ✗     |     ✗       |    ✗     |   ✗     |   ✗
+//  deactivated         |   ✗     |   ✗     |     ✓       |    ✓     |   ✗     |   ✗
+//  dismissed           |   ✗     |   ✗     |     ✗       |    ✗     |   ✗     |   ✗
+//  superseded          |   ✗     |   ✗     |     ✗       |    ✗     |   ✗     |   ✗
+// ---------------------------------------------------------------------------
+
+// Canonical lifecycle status set (Layer 5 spec — CandidateLifecycleStatus).
+// Exported so callers reference constants instead of raw string literals.
+const LIFECYCLE_STATUS = Object.freeze({
+  PENDING_REVIEW: 'pending_review',
+  NEEDS_MORE_EVIDENCE: 'needs_more_evidence',
+  APPROVED: 'approved',
+  MATERIALIZED: 'materialized',
+  ACTIVATED: 'activated',
+  DEACTIVATED: 'deactivated',
+  DISMISSED: 'dismissed',
+  SUPERSEDED: 'superseded',
+});
+
+const LIFECYCLE_STATUSES = Object.freeze(Object.values(LIFECYCLE_STATUS));
+
+// Canonical action set (Layer 5 spec — Action × Status matrix columns).
+const LIFECYCLE_ACTION = Object.freeze({
+  DISMISS: 'dismiss',
+  APPROVE: 'approve',
+  MATERIALIZE: 'materialize',
+  ACTIVATE: 'activate',
+  PROMOTE: 'promote',
+  EVOLVE: 'evolve',
+});
+
+const ACTIONS = Object.freeze(Object.values(LIFECYCLE_ACTION));
+
+// true  = action is legal from this status
+// false = action must be rejected with policy_violation
+// Index order matches ACTIONS above
+const MATRIX = {
+  pending_review: [true, true, false, false, true, true],
+  needs_more_evidence: [true, false, false, false, false, false],
+  approved: [false, false, true, false, true, true],
+  materialized: [false, false, false, true, false, false],
+  activated: [false, false, false, false, false, false],
+  deactivated: [false, false, true, true, false, false],
+  dismissed: [false, false, false, false, false, false],
+  superseded: [false, false, false, false, false, false],
+};
+
+// Status produced after a legal status-changing action
+// promote and evolve are intentionally absent — they don't change source status
+const NEXT_STATUS = {
+  dismiss: 'dismissed',
+  approve: 'approved',
+  materialize: 'materialized',
+  activate: 'activated',
+};
+
+/**
+ * Return true when action is listed as ✓ for currentStatus in the matrix.
+ * Returns false for unknown statuses or actions.
+ *
+ * @param {string} currentStatus
+ * @param {string} action
+ * @returns {boolean}
+ */
+function isLegalAction(currentStatus, action) {
+  const row = MATRIX[currentStatus];
+  if (!row) return false;
+  const idx = ACTIONS.indexOf(action);
+  if (idx === -1) return false;
+  return row[idx];
+}
+
+/**
+ * Compute the next lifecycle status after applying action to currentStatus.
+ *
+ * Throws for:
+ *   - illegal transitions (isLegalAction returns false)
+ *   - promote / evolve (candidate-producing; do not transition source status)
+ *
+ * @param {string} currentStatus
+ * @param {string} action
+ * @returns {string} next status
+ */
+function applyTransition(currentStatus, action) {
+  if (action === 'promote' || action === 'evolve') {
+    throw new Error(
+      `"${action}" is a candidate-producing action and does not transition the source ` +
+        `candidate's status. Use isLegalAction to gate the UI, then create a new candidate ` +
+        `record rather than calling applyTransition.`,
+    );
+  }
+
+  if (!isLegalAction(currentStatus, action)) {
+    throw new Error(
+      `Illegal lifecycle transition: cannot apply action "${action}" to status "${currentStatus}". ` +
+        `This violates the Layer 5 Action × Status matrix.`,
+    );
+  }
+
+  const next = NEXT_STATUS[action];
+  if (!next) {
+    throw new Error(`No next-status mapping for action "${action}" — this is a lifecycle.js bug.`);
+  }
+  return next;
+}
+
+module.exports = {
+  isLegalAction,
+  applyTransition,
+  LIFECYCLE_STATUS,
+  LIFECYCLE_STATUSES,
+  LIFECYCLE_ACTION,
+  ACTIONS,
+  MATRIX,
+};

--- a/scripts/lib/learning-curator/queue-writer.js
+++ b/scripts/lib/learning-curator/queue-writer.js
@@ -1,0 +1,323 @@
+/**
+ * queue-writer.js — Layer 5 candidate store writer.
+ *
+ * Public API:
+ *   appendCandidate(record, options)  — validate, sanitize, append to queue.jsonl
+ *   rejectProposal(reasons, source)   — append rejection record to rejections.jsonl
+ *   readCurrentCandidates()           — replay queue.jsonl, return current candidate map
+ *
+ * Paths are derived at call time from HOME so tests can redirect via process.env.HOME.
+ *
+ * All writes acquire ~/.arcforge/learning/candidates/store.lock (exclusive).
+ * Sanitizer (scripts/lib/sanitize-observation.js) runs on body and every
+ * evidence field before append (PR #31 reconcile 1.9).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+
+const { validateCandidateV1 } = require('./schema');
+const { redactObservationText } = require('../sanitize-observation');
+
+// ---------------------------------------------------------------------------
+// Path helpers — evaluated lazily so tests can redirect HOME
+// ---------------------------------------------------------------------------
+
+function getCandidatesDir() {
+  return path.join(os.homedir(), '.arcforge', 'learning', 'candidates');
+}
+
+function getQueuePath() {
+  return path.join(getCandidatesDir(), 'queue.jsonl');
+}
+
+function getRejectionsPath() {
+  return path.join(getCandidatesDir(), 'rejections.jsonl');
+}
+
+function getLockPath() {
+  return path.join(getCandidatesDir(), 'store.lock');
+}
+
+// ---------------------------------------------------------------------------
+// Inline exclusive lock (cannot reuse locking.js — it hardcodes .arcforge-lock)
+// ---------------------------------------------------------------------------
+
+const LOCK_TIMEOUT = 5000;
+const LOCK_STALE_THRESHOLD = 30000;
+
+function acquireStoreLock() {
+  const lockPath = getLockPath();
+  const dir = path.dirname(lockPath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const timeout = LOCK_TIMEOUT;
+  const startTime = Date.now();
+  let interval = 50;
+
+  while (true) {
+    try {
+      const fd = fs.openSync(
+        lockPath,
+        fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+      );
+      fs.writeSync(fd, JSON.stringify({ pid: process.pid, ts: new Date().toISOString() }));
+      fs.closeSync(fd);
+      return lockPath;
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+
+      // Check if stale
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_THRESHOLD) {
+          try {
+            fs.unlinkSync(lockPath);
+          } catch {
+            // Another process may have removed it — retry
+          }
+          continue;
+        }
+      } catch {
+        // File may have been removed between check and stat — retry
+        continue;
+      }
+
+      if (Date.now() - startTime > timeout) {
+        throw new Error(`Failed to acquire store.lock after ${timeout}ms: ${lockPath}`);
+      }
+
+      const waitMs = Math.min(interval, 500);
+      const end = Date.now() + waitMs;
+      while (Date.now() < end) {
+        // Busy-wait (matches locking.js pattern; avoids async dependency)
+      }
+      interval = Math.min(interval * 2, 500);
+    }
+  }
+}
+
+function releaseStoreLock(lockPath) {
+  try {
+    fs.unlinkSync(lockPath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+function withStoreLock(fn) {
+  const lockPath = acquireStoreLock();
+  try {
+    return fn();
+  } finally {
+    releaseStoreLock(lockPath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Atomic JSONL append — one line, newline-terminated
+// ---------------------------------------------------------------------------
+
+function appendJsonlLine(filePath, obj) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, `${JSON.stringify(obj)}\n`, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Sanitizer — run on body and every evidence field (PR #31 reconcile 1.9)
+// Per advisor guidance: use redactObservationText (no truncation) because
+// validation already enforces length limits on the input.
+// ---------------------------------------------------------------------------
+
+function sanitizeRecord(record) {
+  const r = { ...record };
+
+  // Sanitize body
+  if (typeof r.body === 'string') {
+    r.body = redactObservationText(r.body);
+  }
+
+  // Sanitize every evidence field's summary and relevance
+  if (Array.isArray(r.evidence)) {
+    r.evidence = r.evidence.map((ev) => ({
+      ...ev,
+      summary: typeof ev.summary === 'string' ? redactObservationText(ev.summary) : ev.summary,
+      relevance:
+        typeof ev.relevance === 'string' ? redactObservationText(ev.relevance) : ev.relevance,
+    }));
+  }
+
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// Event ID generation
+// ---------------------------------------------------------------------------
+
+function generateEventId() {
+  return `evt_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a CandidateQueueRecord, sanitize it, and append to queue.jsonl.
+ * If invalid, writes a rejection record to rejections.jsonl instead.
+ *
+ * @param {object} record — CandidateQueueRecord
+ * @param {object} [options]
+ * @param {object} [options.actor] — actor metadata for the queue event
+ */
+function appendCandidate(record, options = {}) {
+  const validation = validateCandidateV1(record);
+
+  if (!validation.ok) {
+    // Invalid → write rejection
+    withStoreLock(() => {
+      const rejection = {
+        schema_version: 1,
+        rejection_id: `rej_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`,
+        rejected_at: new Date().toISOString(),
+        source: record.source || { source_type: 'unknown' },
+        reasons: validation.reasons,
+        artifact_type: record.artifact_type,
+        // Sanitize before persistence — a malformed proposal could carry a
+        // secret in its name field. The 120-char cap is the spec FIELD_LIMIT.
+        normalized_name:
+          typeof record.name === 'string'
+            ? redactObservationText(record.name).slice(0, 120)
+            : undefined,
+        scope: record.scope,
+        safety: {
+          raw_prompt_included: false,
+          raw_response_included: false,
+          raw_hook_payloads_included: false,
+          raw_transcripts_included: false,
+          edit_bodies_included: false,
+          skill_args_included: false,
+        },
+        raw_proposal_saved: false,
+      };
+      appendJsonlLine(getRejectionsPath(), rejection);
+    });
+    return;
+  }
+
+  // Valid → sanitize then append to queue
+  const sanitized = sanitizeRecord(record);
+
+  withStoreLock(() => {
+    const event = {
+      schema_version: 1,
+      event_id: generateEventId(),
+      ts: new Date().toISOString(),
+      candidate_id: sanitized.candidate_id,
+      event_type: 'candidate.created',
+      actor: options.actor || { layer: 5, actor_type: 'validator' },
+      record: sanitized,
+    };
+    appendJsonlLine(getQueuePath(), event);
+  });
+}
+
+/**
+ * Write a rejection record directly (for pre-validation or upstream rejections).
+ *
+ * @param {object[]} reasons — CandidateRejectionReason[]
+ * @param {object} source — CandidateSourceRef (or partial)
+ */
+function rejectProposal(reasons, source) {
+  withStoreLock(() => {
+    const rejection = {
+      schema_version: 1,
+      rejection_id: `rej_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`,
+      rejected_at: new Date().toISOString(),
+      source: source || { source_type: 'unknown' },
+      reasons,
+      safety: {
+        raw_prompt_included: false,
+        raw_response_included: false,
+        raw_hook_payloads_included: false,
+        raw_transcripts_included: false,
+        edit_bodies_included: false,
+        skill_args_included: false,
+      },
+      raw_proposal_saved: false,
+    };
+    appendJsonlLine(getRejectionsPath(), rejection);
+  });
+}
+
+/**
+ * Replay queue.jsonl events and return current candidate map.
+ * Corrupted lines are skipped (not fatal).
+ *
+ * @returns {Record<string, object>} candidate_id → CandidateQueueRecord
+ */
+function readCurrentCandidates() {
+  const queuePath = getQueuePath();
+  if (!fs.existsSync(queuePath)) return {};
+
+  const content = fs.readFileSync(queuePath, 'utf8');
+  const lines = content.split('\n').filter((l) => l.trim().length > 0);
+
+  const candidates = {};
+
+  for (const line of lines) {
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      // Corrupted line — skip (spec: "partial trailing JSONL lines are ignored")
+      continue;
+    }
+
+    if (!event || typeof event !== 'object') continue;
+
+    const { event_type, candidate_id } = event;
+
+    if (!candidate_id) continue;
+
+    if (event_type === 'candidate.created') {
+      if (event.record) {
+        candidates[candidate_id] = { ...event.record };
+      }
+    } else if (event_type === 'candidate.transitioned') {
+      if (candidates[candidate_id] && event.next_status) {
+        candidates[candidate_id] = {
+          ...candidates[candidate_id],
+          lifecycle: {
+            ...candidates[candidate_id].lifecycle,
+            status: event.next_status,
+            status_changed_at: event.ts || new Date().toISOString(),
+          },
+        };
+      }
+    } else if (event_type === 'candidate.updated') {
+      if (candidates[candidate_id] && event.patch) {
+        candidates[candidate_id] = {
+          ...candidates[candidate_id],
+          ...event.patch,
+        };
+      }
+    } else if (event_type === 'candidate.related') {
+      if (candidates[candidate_id] && event.patch) {
+        candidates[candidate_id] = {
+          ...candidates[candidate_id],
+          relationships: {
+            ...(candidates[candidate_id].relationships || {}),
+            ...event.patch,
+          },
+        };
+      }
+    }
+  }
+
+  return candidates;
+}
+
+module.exports = { appendCandidate, rejectProposal, readCurrentCandidates };

--- a/scripts/lib/learning-curator/schema.js
+++ b/scripts/lib/learning-curator/schema.js
@@ -1,0 +1,508 @@
+/**
+ * schema.js — Layer 5 CandidateQueueRecord validator.
+ *
+ * Exports: validateCandidateV1(record) → { ok: true } | { ok: false, reasons: CandidateRejectionReason[] }
+ *
+ * Covers every field defined in the Layer 5 spec (layer-5-candidate-queue-lifecycle.md).
+ * PR #31 reconcile patches applied:
+ *   - 1.2: body_source enum uses "llm_curator" (not "llm_draft")
+ *   - 1.3: promoted_from_* must NOT appear on CandidateScope
+ *   - 1.4: evidence_ref_omitted_upstream rejection code
+ *   - 1.11: evidence_quality formula pins to project_obs_count only
+ */
+
+// ---------------------------------------------------------------------------
+// Allowed enum values
+// ---------------------------------------------------------------------------
+
+const ARTIFACT_TYPES = ['instinct', 'skill', 'command', 'agent', 'claude_md_addition'];
+
+const BODY_SOURCES = ['llm_curator', 'manual_recall', 'reflect', 'dashboard_evolve'];
+
+const DOMAINS = [
+  'workflow',
+  'tool-preference',
+  'error-handling',
+  'code-style',
+  'verification',
+  'privacy-safety',
+  'other',
+];
+
+const LIFECYCLE_STATUSES = [
+  'pending_review',
+  'needs_more_evidence',
+  'dismissed',
+  'approved',
+  'materialized',
+  'activated',
+  'deactivated',
+  'superseded',
+];
+
+const EVIDENCE_TYPES = ['observation', 'session_summary', 'diary', 'reflect', 'recall'];
+
+const SOURCE_TYPES = [
+  'layer4_llm_curator',
+  'manual_recall',
+  'reflect',
+  'dashboard_promote',
+  'dashboard_evolve',
+  'future_import_or_repair',
+];
+
+// ---------------------------------------------------------------------------
+// First-slice field length limits (layer-5 spec lines ~1136-1141)
+// ---------------------------------------------------------------------------
+
+const FIELD_LIMITS = {
+  name: 120,
+  summary: 600,
+  rationale: 2000,
+  trigger: 600,
+  body: 6000,
+};
+
+// ---------------------------------------------------------------------------
+// Evidence quality formula (v1) — project_obs_count only
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute expected evidence_quality from project_obs_count.
+ * @param {number} projectObsCount
+ * @returns {'high'|'medium'|'low'}
+ */
+function computeEvidenceQuality(projectObsCount) {
+  if (typeof projectObsCount !== 'number' || !Number.isFinite(projectObsCount)) {
+    throw new Error(
+      `computeEvidenceQuality requires a finite number; got ${typeof projectObsCount}: ${projectObsCount}`,
+    );
+  }
+  if (projectObsCount < 0) {
+    throw new Error(`computeEvidenceQuality requires a non-negative count; got ${projectObsCount}`);
+  }
+  if (projectObsCount >= 1000) return 'high';
+  if (projectObsCount >= 100) return 'medium';
+  return 'low';
+}
+
+// ---------------------------------------------------------------------------
+// Reason builder
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} code
+ * @param {string} [fieldPath]
+ * @param {string} [detail]
+ * @returns {object}
+ */
+function reason(code, fieldPath, detail) {
+  const r = { code };
+  if (fieldPath !== undefined) r.field_path = fieldPath;
+  if (detail !== undefined) r.detail = String(detail).slice(0, 500);
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function isString(v) {
+  return typeof v === 'string';
+}
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function isNumber(v) {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isArray(v) {
+  return Array.isArray(v);
+}
+
+// ---------------------------------------------------------------------------
+// validateCandidateV1
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a CandidateQueueRecord against the Layer 5 v1 schema.
+ *
+ * @param {object} record
+ * @returns {{ ok: true } | { ok: false, reasons: object[] }}
+ */
+function validateCandidateV1(record) {
+  const reasons = [];
+
+  function add(code, fieldPath, detail) {
+    reasons.push(reason(code, fieldPath, detail));
+  }
+
+  function requireField(field, parent = null) {
+    const obj = parent ? record[parent] : record;
+    const path = parent ? `${parent}.${field}` : field;
+    if (obj == null || !(field in obj)) {
+      add('missing_required_field', path, `Required field "${path}" is missing`);
+      return false;
+    }
+    return true;
+  }
+
+  if (!isObject(record)) {
+    add('schema_invalid', undefined, 'Record must be a non-null object');
+    return { ok: false, reasons };
+  }
+
+  // schema_version
+  if (!requireField('schema_version')) {
+    // continue — collect all errors
+  } else if (record.schema_version !== 1) {
+    add(
+      'schema_invalid',
+      'schema_version',
+      `Expected schema_version 1, got ${record.schema_version}`,
+    );
+  }
+
+  // candidate_id
+  if (!requireField('candidate_id')) {
+    // missing
+  } else if (!isNonEmptyString(record.candidate_id)) {
+    add('missing_required_field', 'candidate_id', 'candidate_id must be a non-empty string');
+  }
+
+  // created_at / updated_at
+  for (const f of ['created_at', 'updated_at']) {
+    if (!requireField(f)) {
+      // missing
+    } else if (!isNonEmptyString(record[f])) {
+      add('missing_required_field', f, `${f} must be a non-empty string`);
+    }
+  }
+
+  // artifact_type
+  if (!requireField('artifact_type')) {
+    // missing
+  } else if (!ARTIFACT_TYPES.includes(record.artifact_type)) {
+    add(
+      'schema_invalid',
+      'artifact_type',
+      `artifact_type "${record.artifact_type}" is not allowed`,
+    );
+  }
+
+  // scope
+  if (!requireField('scope')) {
+    // missing
+  } else {
+    const scope = record.scope;
+    if (!isObject(scope)) {
+      add('schema_invalid', 'scope', 'scope must be an object');
+    } else {
+      if (!['project', 'global'].includes(scope.kind)) {
+        add(
+          'schema_invalid',
+          'scope.kind',
+          `scope.kind "${scope.kind}" must be "project" or "global"`,
+        );
+      }
+      // Per PR #31 reconcile 1.3: promoted_from_* must NOT appear on scope
+      if ('promoted_from_candidate_id' in scope) {
+        add(
+          'schema_invalid',
+          'scope.promoted_from_candidate_id',
+          'promoted_from_candidate_id must live on relationships, not scope (PR #31 reconcile 1.3)',
+        );
+      }
+      if ('promoted_from_project_id' in scope) {
+        add(
+          'schema_invalid',
+          'scope.promoted_from_project_id',
+          'promoted_from_project_id must live on relationships, not scope (PR #31 reconcile 1.3)',
+        );
+      }
+      if (scope.kind === 'project') {
+        if (!isNonEmptyString(scope.project)) {
+          add('missing_required_field', 'scope.project', 'project scope requires scope.project');
+        }
+        if (!isNonEmptyString(scope.project_id)) {
+          add(
+            'missing_required_field',
+            'scope.project_id',
+            'project scope requires scope.project_id',
+          );
+        }
+      }
+    }
+  }
+
+  // source
+  if (!requireField('source')) {
+    // missing
+  } else {
+    const src = record.source;
+    if (!isObject(src)) {
+      add('schema_invalid', 'source', 'source must be an object');
+    } else if (!isNonEmptyString(src.source_type) || !SOURCE_TYPES.includes(src.source_type)) {
+      add(
+        'schema_invalid',
+        'source.source_type',
+        `source.source_type "${src.source_type}" is not allowed`,
+      );
+    }
+  }
+
+  // String fields with length limits
+  const stringFields = ['name', 'summary', 'rationale', 'body'];
+  for (const f of stringFields) {
+    if (!requireField(f)) {
+      // missing
+    } else if (!isString(record[f])) {
+      add('missing_required_field', f, `${f} must be a string`);
+    } else if (FIELD_LIMITS[f] && record[f].length > FIELD_LIMITS[f]) {
+      add(
+        'field_too_long',
+        f,
+        `${f} exceeds ${FIELD_LIMITS[f]} characters (got ${record[f].length})`,
+      );
+    }
+  }
+
+  // trigger (optional, but length-limited if present)
+  if ('trigger' in record && record.trigger !== undefined && record.trigger !== null) {
+    if (!isString(record.trigger)) {
+      add('schema_invalid', 'trigger', 'trigger must be a string');
+    } else if (record.trigger.length > FIELD_LIMITS.trigger) {
+      add('field_too_long', 'trigger', `trigger exceeds ${FIELD_LIMITS.trigger} characters`);
+    }
+  }
+
+  // body_source
+  if (!requireField('body_source')) {
+    // missing
+  } else if (!BODY_SOURCES.includes(record.body_source)) {
+    add('schema_invalid', 'body_source', `body_source "${record.body_source}" is not allowed`);
+  }
+
+  // domain
+  if (!requireField('domain')) {
+    // missing
+  } else if (!DOMAINS.includes(record.domain)) {
+    add('schema_invalid', 'domain', `domain "${record.domain}" is not allowed`);
+  }
+
+  // evidence
+  if (!requireField('evidence')) {
+    // missing
+  } else if (!isArray(record.evidence)) {
+    add('schema_invalid', 'evidence', 'evidence must be an array');
+  } else {
+    for (let i = 0; i < record.evidence.length; i++) {
+      const ev = record.evidence[i];
+      if (!isObject(ev)) {
+        add('schema_invalid', `evidence[${i}]`, 'Each evidence entry must be an object');
+        continue;
+      }
+      if (!isNonEmptyString(ev.evidence_id)) {
+        add('missing_required_field', `evidence[${i}].evidence_id`, 'evidence_id is required');
+      }
+      if (!isString(ev.evidence_type) || !EVIDENCE_TYPES.includes(ev.evidence_type)) {
+        add(
+          'schema_invalid',
+          `evidence[${i}].evidence_type`,
+          `evidence_type "${ev.evidence_type}" is not allowed`,
+        );
+      }
+      if (!isNonEmptyString(ev.relevance)) {
+        add('missing_required_field', `evidence[${i}].relevance`, 'relevance is required');
+      }
+      if (!isNonEmptyString(ev.summary)) {
+        add('missing_required_field', `evidence[${i}].summary`, 'summary is required');
+      }
+    }
+  }
+
+  // evidence_quality
+  if (!requireField('evidence_quality')) {
+    // missing
+  } else if (!['high', 'medium', 'low'].includes(record.evidence_quality)) {
+    add(
+      'schema_invalid',
+      'evidence_quality',
+      `evidence_quality "${record.evidence_quality}" is not allowed`,
+    );
+  }
+
+  // evidence_quality_metadata — validate and verify formula consistency
+  if (!requireField('evidence_quality_metadata')) {
+    // missing
+  } else {
+    const eqm = record.evidence_quality_metadata;
+    if (!isObject(eqm)) {
+      add('schema_invalid', 'evidence_quality_metadata', 'must be an object');
+    } else {
+      if (!isNonEmptyString(eqm.rule_version)) {
+        add(
+          'missing_required_field',
+          'evidence_quality_metadata.rule_version',
+          'rule_version required',
+        );
+      }
+      if (!isObject(eqm.basis)) {
+        add('missing_required_field', 'evidence_quality_metadata.basis', 'basis required');
+      } else {
+        if (!isNumber(eqm.basis.project_obs_count)) {
+          add(
+            'missing_required_field',
+            'evidence_quality_metadata.basis.project_obs_count',
+            'project_obs_count must be a number',
+          );
+        } else {
+          // Verify formula: evidence_quality must match project_obs_count
+          const expectedQuality = computeEvidenceQuality(eqm.basis.project_obs_count);
+          if (record.evidence_quality && record.evidence_quality !== expectedQuality) {
+            add(
+              'schema_invalid',
+              'evidence_quality',
+              `evidence_quality "${record.evidence_quality}" does not match computed value ` +
+                `"${expectedQuality}" for project_obs_count=${eqm.basis.project_obs_count} (v1 formula)`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // lifecycle
+  if (!requireField('lifecycle')) {
+    // missing
+  } else {
+    const lc = record.lifecycle;
+    if (!isObject(lc)) {
+      add('schema_invalid', 'lifecycle', 'lifecycle must be an object');
+    } else {
+      if (!isString(lc.status) || !LIFECYCLE_STATUSES.includes(lc.status)) {
+        add(
+          'schema_invalid',
+          'lifecycle.status',
+          `lifecycle.status "${lc.status}" is not a valid status`,
+        );
+      }
+      if (!isNonEmptyString(lc.status_changed_at)) {
+        add(
+          'missing_required_field',
+          'lifecycle.status_changed_at',
+          'status_changed_at is required',
+        );
+      }
+    }
+  }
+
+  // safety
+  if (!requireField('safety')) {
+    // missing
+  } else {
+    const s = record.safety;
+    if (!isObject(s)) {
+      add('schema_invalid', 'safety', 'safety must be an object');
+    } else {
+      // Check all raw_*_included must be false
+      const rawFlags = [
+        'raw_prompt_included',
+        'raw_response_included',
+        'raw_hook_payloads_included',
+        'raw_transcripts_included',
+        'edit_bodies_included',
+        'skill_args_included',
+      ];
+      for (const flag of rawFlags) {
+        if (flag in s && s[flag] !== false) {
+          add('unsafe_content', `safety.${flag}`, `${flag} must be false`);
+        }
+      }
+      // secret_scan
+      if (isObject(s.secret_scan)) {
+        if (s.secret_scan.status === 'rejected') {
+          add('secret_reconstruction', 'safety.secret_scan', 'secret_scan.status is "rejected"');
+        }
+      }
+      // activation_claim_scan
+      if (isObject(s.activation_claim_scan)) {
+        if (s.activation_claim_scan.status === 'rejected') {
+          add(
+            'activation_claim',
+            'safety.activation_claim_scan',
+            'activation_claim_scan.status is "rejected"',
+          );
+        }
+      }
+      // file_write_claim_scan
+      if (isObject(s.file_write_claim_scan)) {
+        if (s.file_write_claim_scan.status === 'rejected') {
+          add(
+            'file_write_claim',
+            'safety.file_write_claim_scan',
+            'file_write_claim_scan.status is "rejected"',
+          );
+        }
+      }
+    }
+  }
+
+  // dedupe
+  if (!requireField('dedupe')) {
+    // missing
+  } else {
+    const d = record.dedupe;
+    if (!isObject(d)) {
+      add('schema_invalid', 'dedupe', 'dedupe must be an object');
+    } else {
+      if (!isNonEmptyString(d.dedupe_key)) {
+        add('missing_required_field', 'dedupe.dedupe_key', 'dedupe_key is required');
+      }
+      if (!isObject(d.dedupe_basis)) {
+        add('missing_required_field', 'dedupe.dedupe_basis', 'dedupe_basis is required');
+      }
+    }
+  }
+
+  if (reasons.length > 0) {
+    return { ok: false, reasons };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Canonical CandidateRejectionReason code union (spec lines 227-245)
+// PR #31 reconcile 1.4: evidence_ref_omitted_upstream is part of this union
+// ---------------------------------------------------------------------------
+
+// Canonical Layer 5 spec union (layer-5-candidate-queue-lifecycle.md, CandidateRejectionReason.code).
+const REJECTION_CODES = Object.freeze([
+  'schema_invalid',
+  'artifact_type_not_allowed',
+  'scope_not_allowed',
+  'missing_required_field',
+  'field_too_long',
+  'evidence_ref_missing',
+  'evidence_ref_omitted_upstream',
+  'evidence_type_mismatch',
+  'too_few_evidence_refs',
+  'too_many_evidence_refs',
+  'unsafe_content',
+  'secret_reconstruction',
+  'activation_claim',
+  'file_write_claim',
+  'duplicate_candidate',
+  'source_manifest_missing',
+  'source_hash_mismatch',
+  'policy_violation',
+]);
+
+module.exports = { validateCandidateV1, computeEvidenceQuality, REJECTION_CODES };

--- a/tests/scripts/learning-curator-lifecycle.test.js
+++ b/tests/scripts/learning-curator-lifecycle.test.js
@@ -1,0 +1,363 @@
+// tests/scripts/learning-curator-lifecycle.test.js
+
+const {
+  isLegalAction,
+  applyTransition,
+  LIFECYCLE_STATUS,
+  LIFECYCLE_STATUSES,
+  LIFECYCLE_ACTION,
+  ACTIONS,
+} = require('../../scripts/lib/learning-curator/lifecycle');
+
+// ---------------------------------------------------------------------------
+// Matrix self-test — guards against silent drift from the Layer 5 spec
+// (docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md
+// section "Action × Status legality matrix (canonical)").
+// ---------------------------------------------------------------------------
+
+describe('Action × Status matrix — canonical spec', () => {
+  // Expected matrix, transcribed from the spec — one ✓/✗ per cell.
+  const EXPECTED = {
+    pending_review: {
+      dismiss: true,
+      approve: true,
+      materialize: false,
+      activate: false,
+      promote: true,
+      evolve: true,
+    },
+    needs_more_evidence: {
+      dismiss: true,
+      approve: false,
+      materialize: false,
+      activate: false,
+      promote: false,
+      evolve: false,
+    },
+    approved: {
+      dismiss: false,
+      approve: false,
+      materialize: true,
+      activate: false,
+      promote: true,
+      evolve: true,
+    },
+    materialized: {
+      dismiss: false,
+      approve: false,
+      materialize: false,
+      activate: true,
+      promote: false,
+      evolve: false,
+    },
+    activated: {
+      dismiss: false,
+      approve: false,
+      materialize: false,
+      activate: false,
+      promote: false,
+      evolve: false,
+    },
+    deactivated: {
+      dismiss: false,
+      approve: false,
+      materialize: true,
+      activate: true,
+      promote: false,
+      evolve: false,
+    },
+    dismissed: {
+      dismiss: false,
+      approve: false,
+      materialize: false,
+      activate: false,
+      promote: false,
+      evolve: false,
+    },
+    superseded: {
+      dismiss: false,
+      approve: false,
+      materialize: false,
+      activate: false,
+      promote: false,
+      evolve: false,
+    },
+  };
+
+  it('LIFECYCLE_STATUSES covers all 8 spec statuses', () => {
+    expect([...LIFECYCLE_STATUSES].sort()).toEqual(Object.keys(EXPECTED).sort());
+  });
+
+  it('ACTIONS covers all 6 spec actions', () => {
+    expect([...ACTIONS].sort()).toEqual(
+      ['dismiss', 'approve', 'materialize', 'activate', 'promote', 'evolve'].sort(),
+    );
+  });
+
+  it('every (status × action) cell matches the spec', () => {
+    for (const status of Object.keys(EXPECTED)) {
+      for (const action of Object.keys(EXPECTED[status])) {
+        expect({ status, action, legal: isLegalAction(status, action) }).toEqual({
+          status,
+          action,
+          legal: EXPECTED[status][action],
+        });
+      }
+    }
+  });
+});
+
+describe('LIFECYCLE_STATUS / LIFECYCLE_ACTION constants are frozen', () => {
+  it('LIFECYCLE_STATUS is frozen and matches spec values', () => {
+    expect(Object.isFrozen(LIFECYCLE_STATUS)).toBe(true);
+    expect(LIFECYCLE_STATUS.PENDING_REVIEW).toBe('pending_review');
+    expect(LIFECYCLE_STATUS.SUPERSEDED).toBe('superseded');
+  });
+
+  it('LIFECYCLE_ACTION is frozen and matches spec values', () => {
+    expect(Object.isFrozen(LIFECYCLE_ACTION)).toBe(true);
+    expect(LIFECYCLE_ACTION.APPROVE).toBe('approve');
+    expect(LIFECYCLE_ACTION.EVOLVE).toBe('evolve');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legal transitions — isLegalAction returns true
+// ---------------------------------------------------------------------------
+
+describe('isLegalAction — legal cells (✓)', () => {
+  it('pending_review → dismiss is legal', () => {
+    expect(isLegalAction('pending_review', 'dismiss')).toBe(true);
+  });
+
+  it('pending_review → approve is legal', () => {
+    expect(isLegalAction('pending_review', 'approve')).toBe(true);
+  });
+
+  it('pending_review → promote is legal', () => {
+    expect(isLegalAction('pending_review', 'promote')).toBe(true);
+  });
+
+  it('pending_review → evolve is legal', () => {
+    expect(isLegalAction('pending_review', 'evolve')).toBe(true);
+  });
+
+  it('needs_more_evidence → dismiss is legal', () => {
+    expect(isLegalAction('needs_more_evidence', 'dismiss')).toBe(true);
+  });
+
+  it('approved → materialize is legal', () => {
+    expect(isLegalAction('approved', 'materialize')).toBe(true);
+  });
+
+  it('approved → promote is legal', () => {
+    expect(isLegalAction('approved', 'promote')).toBe(true);
+  });
+
+  it('approved → evolve is legal', () => {
+    expect(isLegalAction('approved', 'evolve')).toBe(true);
+  });
+
+  it('materialized → activate is legal', () => {
+    expect(isLegalAction('materialized', 'activate')).toBe(true);
+  });
+
+  it('deactivated → materialize is legal', () => {
+    expect(isLegalAction('deactivated', 'materialize')).toBe(true);
+  });
+
+  it('deactivated → activate is legal', () => {
+    expect(isLegalAction('deactivated', 'activate')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Illegal transitions — isLegalAction returns false
+// ---------------------------------------------------------------------------
+
+describe('isLegalAction — illegal cells (✗)', () => {
+  it('pending_review → materialize is illegal', () => {
+    expect(isLegalAction('pending_review', 'materialize')).toBe(false);
+  });
+
+  it('pending_review → activate is illegal', () => {
+    expect(isLegalAction('pending_review', 'activate')).toBe(false);
+  });
+
+  it('needs_more_evidence → approve is illegal', () => {
+    expect(isLegalAction('needs_more_evidence', 'approve')).toBe(false);
+  });
+
+  it('needs_more_evidence → materialize is illegal', () => {
+    expect(isLegalAction('needs_more_evidence', 'materialize')).toBe(false);
+  });
+
+  it('needs_more_evidence → activate is illegal', () => {
+    expect(isLegalAction('needs_more_evidence', 'activate')).toBe(false);
+  });
+
+  it('needs_more_evidence → promote is illegal', () => {
+    expect(isLegalAction('needs_more_evidence', 'promote')).toBe(false);
+  });
+
+  it('needs_more_evidence → evolve is illegal', () => {
+    expect(isLegalAction('needs_more_evidence', 'evolve')).toBe(false);
+  });
+
+  it('approved → dismiss is illegal', () => {
+    expect(isLegalAction('approved', 'dismiss')).toBe(false);
+  });
+
+  it('approved → approve is illegal', () => {
+    expect(isLegalAction('approved', 'approve')).toBe(false);
+  });
+
+  it('approved → activate is illegal', () => {
+    expect(isLegalAction('approved', 'activate')).toBe(false);
+  });
+
+  it('materialized → dismiss is illegal', () => {
+    expect(isLegalAction('materialized', 'dismiss')).toBe(false);
+  });
+
+  it('materialized → approve is illegal', () => {
+    expect(isLegalAction('materialized', 'approve')).toBe(false);
+  });
+
+  it('activated → dismiss is illegal', () => {
+    expect(isLegalAction('activated', 'dismiss')).toBe(false);
+  });
+
+  it('activated → approve is illegal', () => {
+    expect(isLegalAction('activated', 'approve')).toBe(false);
+  });
+
+  it('activated → activate is illegal', () => {
+    expect(isLegalAction('activated', 'activate')).toBe(false);
+  });
+
+  it('dismissed → dismiss is illegal (terminal)', () => {
+    expect(isLegalAction('dismissed', 'dismiss')).toBe(false);
+  });
+
+  it('dismissed → approve is illegal (terminal)', () => {
+    expect(isLegalAction('dismissed', 'approve')).toBe(false);
+  });
+
+  it('superseded → approve is illegal (terminal)', () => {
+    expect(isLegalAction('superseded', 'approve')).toBe(false);
+  });
+
+  it('superseded → materialize is illegal (terminal)', () => {
+    expect(isLegalAction('superseded', 'materialize')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyTransition — status-changing actions
+// ---------------------------------------------------------------------------
+
+describe('applyTransition — successful transitions', () => {
+  it('pending_review + dismiss → dismissed', () => {
+    expect(applyTransition('pending_review', 'dismiss')).toBe('dismissed');
+  });
+
+  it('pending_review + approve → approved', () => {
+    expect(applyTransition('pending_review', 'approve')).toBe('approved');
+  });
+
+  it('needs_more_evidence + dismiss → dismissed', () => {
+    expect(applyTransition('needs_more_evidence', 'dismiss')).toBe('dismissed');
+  });
+
+  it('approved + materialize → materialized', () => {
+    expect(applyTransition('approved', 'materialize')).toBe('materialized');
+  });
+
+  it('materialized + activate → activated', () => {
+    expect(applyTransition('materialized', 'activate')).toBe('activated');
+  });
+
+  it('deactivated + materialize → materialized', () => {
+    expect(applyTransition('deactivated', 'materialize')).toBe('materialized');
+  });
+
+  it('deactivated + activate → activated', () => {
+    expect(applyTransition('deactivated', 'activate')).toBe('activated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyTransition — promote/evolve throw (candidate-producing, not transitions)
+// ---------------------------------------------------------------------------
+
+describe('applyTransition — promote and evolve throw (not source transitions)', () => {
+  it('pending_review + promote throws even though isLegalAction returns true', () => {
+    expect(isLegalAction('pending_review', 'promote')).toBe(true);
+    expect(() => applyTransition('pending_review', 'promote')).toThrow();
+  });
+
+  it('pending_review + evolve throws even though isLegalAction returns true', () => {
+    expect(isLegalAction('pending_review', 'evolve')).toBe(true);
+    expect(() => applyTransition('pending_review', 'evolve')).toThrow();
+  });
+
+  it('approved + promote throws even though isLegalAction returns true', () => {
+    expect(isLegalAction('approved', 'promote')).toBe(true);
+    expect(() => applyTransition('approved', 'promote')).toThrow();
+  });
+
+  it('approved + evolve throws with descriptive message', () => {
+    const err = (() => {
+      try {
+        applyTransition('approved', 'evolve');
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err.message).toMatch(/evolve|candidate-producing/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyTransition — illegal transitions throw with descriptive error
+// ---------------------------------------------------------------------------
+
+describe('applyTransition — throws for illegal transitions', () => {
+  it('needs_more_evidence + approve throws with descriptive error', () => {
+    expect(() => applyTransition('needs_more_evidence', 'approve')).toThrow(
+      /illegal.*transition|cannot.*approve|action.*not.*allowed/i,
+    );
+  });
+
+  it('approved + dismiss throws', () => {
+    expect(() => applyTransition('approved', 'dismiss')).toThrow();
+  });
+
+  it('materialized + dismiss throws', () => {
+    expect(() => applyTransition('materialized', 'dismiss')).toThrow();
+  });
+
+  it('activated + activate throws', () => {
+    expect(() => applyTransition('activated', 'activate')).toThrow();
+  });
+
+  it('dismissed + dismiss throws (terminal)', () => {
+    expect(() => applyTransition('dismissed', 'dismiss')).toThrow();
+  });
+
+  it('superseded + materialize throws (terminal)', () => {
+    expect(() => applyTransition('superseded', 'materialize')).toThrow();
+  });
+
+  it('throw message includes current status and action', () => {
+    let msg = '';
+    try {
+      applyTransition('activated', 'dismiss');
+    } catch (e) {
+      msg = e.message;
+    }
+    expect(msg).toMatch(/activated/);
+    expect(msg).toMatch(/dismiss/);
+  });
+});

--- a/tests/scripts/learning-curator-queue-writer.test.js
+++ b/tests/scripts/learning-curator-queue-writer.test.js
@@ -1,0 +1,420 @@
+// tests/scripts/learning-curator-queue-writer.test.js
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+// ---------------------------------------------------------------------------
+// Setup — redirect HOME to a temp directory for each test using jest.spyOn
+// ---------------------------------------------------------------------------
+
+let tmpDir;
+let homedirSpy;
+
+beforeEach(() => {
+  jest.resetModules();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qw-test-'));
+  // Spy on os.homedir so both the test helpers AND the freshly required module
+  // return tmpDir — avoids process.env.HOME propagation issues in Jest.
+  homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tmpDir);
+});
+
+afterEach(() => {
+  homedirSpy.mockRestore();
+  jest.resetModules();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function getWriter() {
+  // Always require fresh after jest.resetModules()
+  return require('../../scripts/lib/learning-curator/queue-writer');
+}
+
+// Helper: get candidate store paths using current mocked HOME
+function getCandidatesDir() {
+  return path.join(os.homedir(), '.arcforge', 'learning', 'candidates');
+}
+
+function getQueuePath() {
+  return path.join(getCandidatesDir(), 'queue.jsonl');
+}
+
+function getRejectionsPath() {
+  return path.join(getCandidatesDir(), 'rejections.jsonl');
+}
+
+// ---------------------------------------------------------------------------
+// Record fixture
+// ---------------------------------------------------------------------------
+
+function makeValidRecord(overrides = {}) {
+  return {
+    schema_version: 1,
+    candidate_id: 'cand_instinct_20260521T010000Z_a1b2c3d4e5f6',
+    created_at: '2026-05-21T01:00:00.000Z',
+    updated_at: '2026-05-21T01:00:00.000Z',
+    artifact_type: 'instinct',
+    scope: { kind: 'project', project: 'arcforge', project_id: 'proj_abc' },
+    source: { source_type: 'layer4_llm_curator' },
+    name: 'grep before editing',
+    summary: 'Always grep for existing patterns before making edits',
+    rationale: 'Prevents duplicate code and missed context',
+    domain: 'workflow',
+    body: 'When editing files, first grep for existing patterns to avoid duplication',
+    body_source: 'llm_curator',
+    evidence: [
+      {
+        evidence_id: 'ev_abc123',
+        evidence_type: 'observation',
+        relevance: 'User repeatedly used grep before editing files',
+        summary: 'Observed grep-first pattern 5 times across 3 sessions',
+      },
+    ],
+    evidence_quality: 'medium',
+    evidence_quality_metadata: {
+      rule_version: 'v1',
+      basis: {
+        project_obs_count: 500,
+        cited_evidence_count: 1,
+        cited_evidence_by_type: {
+          observation: 1,
+          diary: 0,
+          reflect: 0,
+          recall: 0,
+          session_summary: 0,
+        },
+        has_user_correction: false,
+        has_manual_recall: false,
+        has_reflect_pattern: false,
+        has_error_repair_sequence: false,
+      },
+    },
+    lifecycle: {
+      status: 'pending_review',
+      status_changed_at: '2026-05-21T01:00:00.000Z',
+    },
+    safety: {
+      validator_version: 'v1',
+      sanitizer_policy_version: 'v1',
+      sanitizer_module: 'scripts/lib/sanitize-observation.js',
+      raw_prompt_included: false,
+      raw_response_included: false,
+      raw_hook_payloads_included: false,
+      raw_transcripts_included: false,
+      edit_bodies_included: false,
+      skill_args_included: false,
+      secret_scan: { status: 'passed', rule_version: 'v1' },
+      activation_claim_scan: { status: 'passed' },
+      file_write_claim_scan: { status: 'passed' },
+    },
+    dedupe: {
+      dedupe_key: 'project:proj_abc:instinct:grep-before-editing',
+      dedupe_basis: {
+        scope_kind: 'project',
+        project_id: 'proj_abc',
+        artifact_type: 'instinct',
+        normalized_name: 'grep-before-editing',
+        normalized_body_hash: 'abc123def456',
+      },
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// appendCandidate — valid record goes to queue.jsonl
+// ---------------------------------------------------------------------------
+
+describe('appendCandidate — successful append', () => {
+  it('writes a JSONL line to queue.jsonl for a valid record', () => {
+    const { appendCandidate } = getWriter();
+    appendCandidate(makeValidRecord());
+
+    const queuePath = getQueuePath();
+    expect(fs.existsSync(queuePath)).toBe(true);
+
+    const lines = fs.readFileSync(queuePath, 'utf8').trim().split('\n');
+    expect(lines.length).toBe(1);
+
+    const event = JSON.parse(lines[0]);
+    expect(event.event_type).toBe('candidate.created');
+    expect(event.candidate_id).toBe('cand_instinct_20260521T010000Z_a1b2c3d4e5f6');
+    expect(event.record).toBeDefined();
+    expect(event.schema_version).toBe(1);
+  });
+
+  it('does NOT write to rejections.jsonl for a valid record', () => {
+    const { appendCandidate } = getWriter();
+    appendCandidate(makeValidRecord());
+
+    const rejectPath = getRejectionsPath();
+    expect(fs.existsSync(rejectPath)).toBe(false);
+  });
+
+  it('creates parent directories if they do not exist', () => {
+    const { appendCandidate } = getWriter();
+    appendCandidate(makeValidRecord());
+
+    const dir = getCandidatesDir();
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendCandidate — invalid record goes to rejections.jsonl
+// ---------------------------------------------------------------------------
+
+describe('appendCandidate — invalid record rejected', () => {
+  it('writes to rejections.jsonl when record is invalid', () => {
+    const { appendCandidate } = getWriter();
+    const badRecord = makeValidRecord({ artifact_type: 'unknown_type' });
+    appendCandidate(badRecord);
+
+    const rejectPath = getRejectionsPath();
+    expect(fs.existsSync(rejectPath)).toBe(true);
+
+    const lines = fs.readFileSync(rejectPath, 'utf8').trim().split('\n');
+    expect(lines.length).toBe(1);
+    const rejection = JSON.parse(lines[0]);
+    expect(rejection.reasons).toBeDefined();
+    expect(rejection.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('does NOT write to queue.jsonl when record is invalid', () => {
+    const { appendCandidate } = getWriter();
+    appendCandidate(makeValidRecord({ artifact_type: 'unknown_type' }));
+
+    const queuePath = getQueuePath();
+    expect(fs.existsSync(queuePath)).toBe(false);
+  });
+
+  it('rejection record has schema_version 1', () => {
+    const { appendCandidate } = getWriter();
+    appendCandidate(makeValidRecord({ name: 'x'.repeat(200) }));
+
+    const rejectPath = getRejectionsPath();
+    const rejection = JSON.parse(fs.readFileSync(rejectPath, 'utf8').trim());
+    expect(rejection.schema_version).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rejectProposal — direct rejection
+// ---------------------------------------------------------------------------
+
+describe('rejectProposal', () => {
+  it('appends a rejection record with provided reasons', () => {
+    const { rejectProposal } = getWriter();
+    rejectProposal(
+      [{ code: 'schema_invalid', field_path: 'artifact_type', detail: 'test rejection' }],
+      { source_type: 'layer4_llm_curator' },
+    );
+
+    const rejectPath = getRejectionsPath();
+    expect(fs.existsSync(rejectPath)).toBe(true);
+
+    const rejection = JSON.parse(fs.readFileSync(rejectPath, 'utf8').trim());
+    expect(rejection.reasons[0].code).toBe('schema_invalid');
+    expect(rejection.schema_version).toBe(1);
+    expect(rejection.raw_proposal_saved).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCurrentCandidates — replay events
+// ---------------------------------------------------------------------------
+
+describe('readCurrentCandidates — event replay', () => {
+  it('returns empty map when queue.jsonl does not exist', () => {
+    const { readCurrentCandidates } = getWriter();
+    const result = readCurrentCandidates();
+    expect(result).toEqual({});
+  });
+
+  it('returns candidate map after appendCandidate', () => {
+    const { appendCandidate, readCurrentCandidates } = getWriter();
+    appendCandidate(makeValidRecord());
+
+    const candidates = readCurrentCandidates();
+    expect(Object.keys(candidates).length).toBe(1);
+    expect(candidates.cand_instinct_20260521T010000Z_a1b2c3d4e5f6).toBeDefined();
+    expect(candidates.cand_instinct_20260521T010000Z_a1b2c3d4e5f6.artifact_type).toBe('instinct');
+  });
+
+  it('reflects lifecycle transition events (candidate.transitioned)', () => {
+    const { appendCandidate, readCurrentCandidates } = getWriter();
+    appendCandidate(makeValidRecord());
+
+    // Manually write a transition event
+    const queuePath = getQueuePath();
+    const transitionEvent = JSON.stringify({
+      schema_version: 1,
+      event_id: 'evt_trans_001',
+      ts: '2026-05-21T02:00:00.000Z',
+      candidate_id: 'cand_instinct_20260521T010000Z_a1b2c3d4e5f6',
+      event_type: 'candidate.transitioned',
+      actor: { layer: 6, actor_type: 'dashboard' },
+      previous_status: 'pending_review',
+      next_status: 'approved',
+      transition: { reason: 'looks good' },
+    });
+    fs.appendFileSync(queuePath, `\n${transitionEvent}\n`);
+
+    const candidates = readCurrentCandidates();
+    const cand = candidates.cand_instinct_20260521T010000Z_a1b2c3d4e5f6;
+    expect(cand.lifecycle.status).toBe('approved');
+  });
+
+  it('reflects patch events (candidate.updated)', () => {
+    const { appendCandidate, readCurrentCandidates } = getWriter();
+    appendCandidate(makeValidRecord());
+
+    const queuePath = getQueuePath();
+    const patchEvent = JSON.stringify({
+      schema_version: 1,
+      event_id: 'evt_patch_001',
+      ts: '2026-05-21T02:00:00.000Z',
+      candidate_id: 'cand_instinct_20260521T010000Z_a1b2c3d4e5f6',
+      event_type: 'candidate.updated',
+      actor: { layer: 6, actor_type: 'dashboard' },
+      patch: { name: 'updated name' },
+    });
+    fs.appendFileSync(queuePath, `\n${patchEvent}\n`);
+
+    const candidates = readCurrentCandidates();
+    const cand = candidates.cand_instinct_20260521T010000Z_a1b2c3d4e5f6;
+    expect(cand.name).toBe('updated name');
+  });
+
+  it('ignores corrupted trailing line — does not throw', () => {
+    const { appendCandidate, readCurrentCandidates } = getWriter();
+    appendCandidate(makeValidRecord());
+
+    const queuePath = getQueuePath();
+    // Append a corrupted partial line
+    fs.appendFileSync(queuePath, '\n{corrupted json line without closing\n');
+
+    // Should not throw; corrupted line ignored
+    expect(() => readCurrentCandidates()).not.toThrow();
+    const candidates = readCurrentCandidates();
+    // The valid event was already appended; corrupted line skipped
+    expect(Object.keys(candidates).length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent appends — serialize via store.lock (real processes)
+// ---------------------------------------------------------------------------
+
+describe('concurrent appends — locking', () => {
+  it('serializes two concurrent appends without data loss', (done) => {
+    // Write a worker script that appends one candidate and exits
+    const workerScript = path.join(tmpDir, 'worker.js');
+    const workerContent = `
+const path = require('node:path');
+process.env.HOME = ${JSON.stringify(tmpDir)};
+// Ensure fresh module load in this worker process
+const { appendCandidate } = require(${JSON.stringify(
+      path.join(__dirname, '../../scripts/lib/learning-curator/queue-writer'),
+    )});
+const id = process.argv[2];
+appendCandidate({
+  schema_version: 1,
+  candidate_id: id,
+  created_at: '2026-05-21T01:00:00.000Z',
+  updated_at: '2026-05-21T01:00:00.000Z',
+  artifact_type: 'instinct',
+  scope: { kind: 'project', project: 'p', project_id: 'p1' },
+  source: { source_type: 'layer4_llm_curator' },
+  name: 'x',
+  summary: 'x',
+  rationale: 'x',
+  domain: 'workflow',
+  body: 'x',
+  body_source: 'llm_curator',
+  evidence: [{
+    evidence_id: 'e1',
+    evidence_type: 'observation',
+    relevance: 'r',
+    summary: 's',
+  }],
+  evidence_quality: 'low',
+  evidence_quality_metadata: {
+    rule_version: 'v1',
+    basis: {
+      project_obs_count: 0,
+      cited_evidence_count: 1,
+      cited_evidence_by_type: { observation: 1, diary: 0, reflect: 0, recall: 0, session_summary: 0 },
+      has_user_correction: false,
+      has_manual_recall: false,
+      has_reflect_pattern: false,
+      has_error_repair_sequence: false,
+    },
+  },
+  lifecycle: { status: 'pending_review', status_changed_at: '2026-05-21T01:00:00.000Z' },
+  safety: {
+    validator_version: 'v1',
+    sanitizer_policy_version: 'v1',
+    sanitizer_module: 'scripts/lib/sanitize-observation.js',
+    raw_prompt_included: false,
+    raw_response_included: false,
+    raw_hook_payloads_included: false,
+    raw_transcripts_included: false,
+    edit_bodies_included: false,
+    skill_args_included: false,
+    secret_scan: { status: 'passed', rule_version: 'v1' },
+    activation_claim_scan: { status: 'passed' },
+    file_write_claim_scan: { status: 'passed' },
+  },
+  dedupe: {
+    dedupe_key: 'dk-' + id,
+    dedupe_basis: {
+      scope_kind: 'project',
+      project_id: 'p1',
+      artifact_type: 'instinct',
+      normalized_name: 'x',
+      normalized_body_hash: 'h1',
+    },
+  },
+});
+`;
+    fs.writeFileSync(workerScript, workerContent);
+
+    const id1 = 'cand_instinct_20260521T010000Z_aaa111222333';
+    const id2 = 'cand_instinct_20260521T010001Z_bbb444555666';
+
+    try {
+      // Run two processes "concurrently" (fork is non-blocking, both start quickly)
+      const { fork } = require('node:child_process');
+      let done1 = false;
+      let done2 = false;
+
+      function check() {
+        if (!done1 || !done2) return;
+        const queuePath = getQueuePath();
+        const lines = fs
+          .readFileSync(queuePath, 'utf8')
+          .split('\n')
+          .filter((l) => l.trim());
+        expect(lines.length).toBe(2);
+        const ids = lines.map((l) => JSON.parse(l).candidate_id);
+        expect(ids).toContain(id1);
+        expect(ids).toContain(id2);
+        done();
+      }
+
+      const p1 = fork(workerScript, [id1]);
+      const p2 = fork(workerScript, [id2]);
+      p1.on('exit', () => {
+        done1 = true;
+        check();
+      });
+      p2.on('exit', () => {
+        done2 = true;
+        check();
+      });
+    } catch (e) {
+      done(e);
+    }
+  }, 10000);
+});

--- a/tests/scripts/learning-curator-schema.test.js
+++ b/tests/scripts/learning-curator-schema.test.js
@@ -1,0 +1,496 @@
+// tests/scripts/learning-curator-schema.test.js
+
+const {
+  validateCandidateV1,
+  REJECTION_CODES,
+} = require('../../scripts/lib/learning-curator/schema');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvidence(overrides = {}) {
+  return {
+    evidence_id: 'ev_abc123',
+    evidence_type: 'observation',
+    relevance: 'User repeatedly used grep before editing files',
+    summary: 'Observed grep-first pattern 5 times across 3 sessions',
+    ...overrides,
+  };
+}
+
+function makeRecord(overrides = {}) {
+  return {
+    schema_version: 1,
+    candidate_id: 'cand_instinct_20260521T010000Z_a1b2c3d4e5f6',
+    created_at: '2026-05-21T01:00:00.000Z',
+    updated_at: '2026-05-21T01:00:00.000Z',
+    artifact_type: 'instinct',
+    scope: { kind: 'project', project: 'arcforge', project_id: 'proj_abc' },
+    source: { source_type: 'layer4_llm_curator' },
+    name: 'grep before editing',
+    summary: 'Always grep for existing patterns before making edits',
+    rationale: 'Prevents duplicate code and missed context',
+    domain: 'workflow',
+    body: 'When editing files, first grep for existing patterns to avoid duplication',
+    body_source: 'llm_curator',
+    evidence: [makeEvidence()],
+    evidence_quality: 'medium',
+    evidence_quality_metadata: {
+      rule_version: 'v1',
+      basis: {
+        project_obs_count: 500,
+        cited_evidence_count: 1,
+        cited_evidence_by_type: {
+          observation: 1,
+          diary: 0,
+          reflect: 0,
+          recall: 0,
+          session_summary: 0,
+        },
+        has_user_correction: false,
+        has_manual_recall: false,
+        has_reflect_pattern: false,
+        has_error_repair_sequence: false,
+      },
+    },
+    lifecycle: {
+      status: 'pending_review',
+      status_changed_at: '2026-05-21T01:00:00.000Z',
+    },
+    safety: {
+      validator_version: 'v1',
+      sanitizer_policy_version: 'v1',
+      sanitizer_module: 'scripts/lib/sanitize-observation.js',
+      raw_prompt_included: false,
+      raw_response_included: false,
+      raw_hook_payloads_included: false,
+      raw_transcripts_included: false,
+      edit_bodies_included: false,
+      skill_args_included: false,
+      secret_scan: { status: 'passed', rule_version: 'v1' },
+      activation_claim_scan: { status: 'passed' },
+      file_write_claim_scan: { status: 'passed' },
+    },
+    dedupe: {
+      dedupe_key: 'project:proj_abc:instinct:grep-before-editing',
+      dedupe_basis: {
+        scope_kind: 'project',
+        project_id: 'proj_abc',
+        artifact_type: 'instinct',
+        normalized_name: 'grep-before-editing',
+        normalized_body_hash: 'abc123def456',
+      },
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Positive tests — valid records pass
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — valid records (positive)', () => {
+  it('accepts a minimal valid instinct record', () => {
+    const result = validateCandidateV1(makeRecord());
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts artifact_type skill', () => {
+    const r = makeRecord({ artifact_type: 'skill' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts artifact_type command', () => {
+    const r = makeRecord({ artifact_type: 'command' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts artifact_type agent', () => {
+    const r = makeRecord({ artifact_type: 'agent' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts artifact_type claude_md_addition', () => {
+    const r = makeRecord({ artifact_type: 'claude_md_addition' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts scope.kind global (no project fields)', () => {
+    const r = makeRecord({ scope: { kind: 'global' } });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts scope.kind project with project + project_id', () => {
+    const r = makeRecord({ scope: { kind: 'project', project: 'myproj', project_id: 'p_123' } });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts body_source manual_recall', () => {
+    const r = makeRecord({ body_source: 'manual_recall' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts body_source reflect', () => {
+    const r = makeRecord({ body_source: 'reflect' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts body_source dashboard_evolve', () => {
+    const r = makeRecord({ body_source: 'dashboard_evolve' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts optional trigger field', () => {
+    const r = makeRecord({ trigger: 'when editing files' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts optional relationships field', () => {
+    const r = makeRecord({ relationships: { promoted_from_candidate_id: 'cand_instinct_abc' } });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evidence quality boundary tests
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — evidence_quality boundaries', () => {
+  function makeWithObsCount(count, quality) {
+    const m = makeRecord({
+      evidence_quality: quality,
+      evidence_quality_metadata: {
+        rule_version: 'v1',
+        basis: {
+          project_obs_count: count,
+          cited_evidence_count: 1,
+          cited_evidence_by_type: {
+            observation: 1,
+            diary: 0,
+            reflect: 0,
+            recall: 0,
+            session_summary: 0,
+          },
+          has_user_correction: false,
+          has_manual_recall: false,
+          has_reflect_pattern: false,
+          has_error_repair_sequence: false,
+        },
+      },
+    });
+    return m;
+  }
+
+  it('project_obs_count >= 1000 → evidence_quality must be high', () => {
+    expect(validateCandidateV1(makeWithObsCount(1000, 'high')).ok).toBe(true);
+  });
+
+  it('project_obs_count = 999 → evidence_quality must be medium', () => {
+    expect(validateCandidateV1(makeWithObsCount(999, 'medium')).ok).toBe(true);
+  });
+
+  it('project_obs_count = 100 → evidence_quality must be medium', () => {
+    expect(validateCandidateV1(makeWithObsCount(100, 'medium')).ok).toBe(true);
+  });
+
+  it('project_obs_count = 99 → evidence_quality must be low', () => {
+    expect(validateCandidateV1(makeWithObsCount(99, 'low')).ok).toBe(true);
+  });
+
+  it('project_obs_count = 0 → evidence_quality must be low', () => {
+    expect(validateCandidateV1(makeWithObsCount(0, 'low')).ok).toBe(true);
+  });
+
+  it('project_obs_count = 1000 with wrong quality "medium" → fails', () => {
+    const r = makeWithObsCount(1000, 'medium');
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.field_path?.includes('evidence_quality'))).toBe(true);
+  });
+
+  it('project_obs_count = 50 with wrong quality "high" → fails', () => {
+    const r = makeWithObsCount(50, 'high');
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+  });
+
+  it('project_obs_count = 500 with wrong quality "high" → fails', () => {
+    const r = makeWithObsCount(500, 'high');
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative — required field missing
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — required field missing', () => {
+  const requiredFields = [
+    'schema_version',
+    'candidate_id',
+    'created_at',
+    'updated_at',
+    'artifact_type',
+    'scope',
+    'source',
+    'name',
+    'summary',
+    'rationale',
+    'domain',
+    'body',
+    'body_source',
+    'evidence',
+    'evidence_quality',
+    'evidence_quality_metadata',
+    'lifecycle',
+    'safety',
+    'dedupe',
+  ];
+
+  for (const field of requiredFields) {
+    it(`fails when "${field}" is missing`, () => {
+      const r = makeRecord();
+      delete r[field];
+      const res = validateCandidateV1(r);
+      expect(res.ok).toBe(false);
+      expect(res.reasons.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Negative — enum violations
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — enum violations', () => {
+  it('rejects unknown artifact_type', () => {
+    const r = makeRecord({ artifact_type: 'bot' });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'schema_invalid')).toBe(true);
+  });
+
+  it('rejects unknown body_source', () => {
+    const r = makeRecord({ body_source: 'llm_draft' });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects unknown domain', () => {
+    const r = makeRecord({ domain: 'unknown_domain_xyz' });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects unknown lifecycle status', () => {
+    const r = makeRecord({
+      lifecycle: { status: 'in_review', status_changed_at: '2026-05-21T00:00:00.000Z' },
+    });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects unknown scope.kind', () => {
+    const r = makeRecord({ scope: { kind: 'team' } });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative — field length limits
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — field length limits', () => {
+  it('rejects name > 120 chars', () => {
+    const r = makeRecord({ name: 'x'.repeat(121) });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'field_too_long')).toBe(true);
+  });
+
+  it('accepts name = 120 chars', () => {
+    const r = makeRecord({ name: 'x'.repeat(120) });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('rejects summary > 600 chars', () => {
+    const r = makeRecord({ summary: 'x'.repeat(601) });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'field_too_long')).toBe(true);
+  });
+
+  it('accepts summary = 600 chars', () => {
+    const r = makeRecord({ summary: 'x'.repeat(600) });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('rejects rationale > 2000 chars', () => {
+    const r = makeRecord({ rationale: 'x'.repeat(2001) });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'field_too_long')).toBe(true);
+  });
+
+  it('accepts rationale = 2000 chars', () => {
+    const r = makeRecord({ rationale: 'x'.repeat(2000) });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('rejects trigger > 600 chars', () => {
+    const r = makeRecord({ trigger: 'x'.repeat(601) });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'field_too_long')).toBe(true);
+  });
+
+  it('rejects body > 6000 chars', () => {
+    const r = makeRecord({ body: 'x'.repeat(6001) });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'field_too_long')).toBe(true);
+  });
+
+  it('accepts body = 6000 chars', () => {
+    const r = makeRecord({ body: 'x'.repeat(6000) });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative — safety rule violations
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — safety rule violations', () => {
+  it('rejects when raw_prompt_included is true', () => {
+    const r = makeRecord();
+    r.safety.raw_prompt_included = true;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'unsafe_content')).toBe(true);
+  });
+
+  it('rejects when raw_response_included is true', () => {
+    const r = makeRecord();
+    r.safety.raw_response_included = true;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'unsafe_content')).toBe(true);
+  });
+
+  it('rejects when secret_scan status is rejected', () => {
+    const r = makeRecord();
+    r.safety.secret_scan = { status: 'rejected', rule_version: 'v1' };
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'secret_reconstruction')).toBe(true);
+  });
+
+  it('rejects when activation_claim_scan status is rejected', () => {
+    const r = makeRecord();
+    r.safety.activation_claim_scan = { status: 'rejected' };
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'activation_claim')).toBe(true);
+  });
+
+  it('rejects when file_write_claim_scan status is rejected', () => {
+    const r = makeRecord();
+    r.safety.file_write_claim_scan = { status: 'rejected' };
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'file_write_claim')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative — promoted_from_* must NOT appear on scope (PR #31 reconcile 1.3)
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — scope must not contain promoted_from fields', () => {
+  it('rejects scope with promoted_from_candidate_id on scope object', () => {
+    const r = makeRecord({
+      scope: {
+        kind: 'global',
+        promoted_from_candidate_id: 'cand_instinct_abc',
+      },
+    });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'schema_invalid')).toBe(true);
+  });
+
+  it('rejects scope with promoted_from_project_id on scope object', () => {
+    const r = makeRecord({
+      scope: {
+        kind: 'global',
+        promoted_from_project_id: 'proj_xyz',
+      },
+    });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection codes coverage
+// ---------------------------------------------------------------------------
+
+describe('REJECTION_CODES — canonical code union', () => {
+  it('includes evidence_ref_omitted_upstream (PR #31 reconcile 1.4)', () => {
+    expect(REJECTION_CODES).toContain('evidence_ref_omitted_upstream');
+  });
+
+  it('includes the canonical Layer 5 spec union', () => {
+    // From docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md
+    // CandidateRejectionReason.code
+    const canonicalUnion = [
+      'schema_invalid',
+      'artifact_type_not_allowed',
+      'scope_not_allowed',
+      'missing_required_field',
+      'field_too_long',
+      'evidence_ref_missing',
+      'evidence_ref_omitted_upstream',
+      'evidence_type_mismatch',
+      'too_few_evidence_refs',
+      'too_many_evidence_refs',
+      'unsafe_content',
+      'secret_reconstruction',
+      'activation_claim',
+      'file_write_claim',
+      'duplicate_candidate',
+      'source_manifest_missing',
+      'source_hash_mismatch',
+      'policy_violation',
+    ];
+    for (const code of canonicalUnion) {
+      expect(REJECTION_CODES).toContain(code);
+    }
+  });
+});
+
+describe('validateCandidateV1 — rejection reason codes', () => {
+  it('emits missing_required_field when name is missing', () => {
+    const r = makeRecord();
+    delete r.name;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'missing_required_field')).toBe(true);
+  });
+
+  it('emits field_too_long when name exceeds limit', () => {
+    const r = makeRecord({ name: 'x'.repeat(200) });
+    const res = validateCandidateV1(r);
+    expect(res.reasons.some((r) => r.code === 'field_too_long')).toBe(true);
+  });
+
+  it('emits schema_invalid for unknown artifact_type', () => {
+    const r = makeRecord({ artifact_type: 'unknown' });
+    const res = validateCandidateV1(r);
+    expect(res.reasons.some((r) => r.code === 'schema_invalid')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fourth implementation slice. Introduces the **canonical candidate authority** for the learning system — three Node modules that own schema validation, lifecycle state machine, and atomic queue persistence. **Pure new code**: no daemon touch, no hook touch, no behavior change. Consumed by Slice E (daemon rewires to write through this) and Slice F (dashboard reads + transitions through this).

Reference: implementation plan Section 4 (Slice D) + Section 7. Layer 5 spec at `docs/plans/references/learning-curator-schema/layer-5-candidate-queue-lifecycle.md` — canonical action × status matrix, schema, rejection codes, evidence quality formula (all reconciled in PR #31).

> Chained off Slice C (PR #34). Base auto-rebases to `feat/learning-curator-pivot` when Slice C merges.

## Acceptance criteria (verified)

| # | What | Verification |
|---|---|---|
| 1 | `validateCandidateV1` + `computeEvidenceQuality` + `REJECTION_CODES` | 65 schema tests pass |
| 2 | `isLegalAction` + `applyTransition` + matrix + constants | 48 lifecycle tests incl. self-test |
| 3 | `appendCandidate` + `rejectProposal` + `readCurrentCandidates` + `store.lock` | 13 queue-writer tests incl. fork-based concurrency |
| 4 | `evidence_ref_omitted_upstream` in REJECTION_CODES (PR #31 reconcile 1.4) | schema.js:486 |
| 5 | `promoted_from_*` rejected on scope (PR #31 reconcile 1.3) | schema.js:212-225 + test:441-459 |
| 6 | ≥ 30 schema cases | 65 cases |
| 7 | ≥ 25 lifecycle cases | 48 cases |
| 8 | ≥ 10 queue-writer cases | 13 cases |
| 9 | `npm test` — 1591 Jest+Node + 557 pytest + 7 observer-daemon all green | passed |
| 10 | `npm run lint` clean | passed |

## Process gate

- **Implementer** ran TDD per module — 126 new test cases
- **spec-reviewer** — VERDICT ACCEPT, flagged `REJECTION_CODES` enum drift + `_isBoolean` dead — both fixed
- **simplify** (3 parallel reviewers) — 5 quality fixes applied, 7 findings deferred as out-of-slice or first-slice-acceptable
- Decisions logged in `docs/plans/2026-05-20-learning-curator-decisions.html` (orchestrator artifact, not in this PR)

## Spec-review pass — applied

1. `REJECTION_CODES` array dedup'd and replaced with the canonical 18-code union from the Layer 5 spec (was missing 8 codes, had 2 non-canonical: `safety_violation`, `evidence_quality_too_low`)
2. Dead `_isBoolean` function removed (was rename-to-underscore lint-suppression residue — deletion is the correct fix)

## Simplify-pass — applied

1. **`LIFECYCLE_STATUS` + `LIFECYCLE_ACTION` frozen constants** exported, plus `LIFECYCLE_STATUSES` / `ACTIONS` / `MATRIX` arrays — same pattern as `EVIDENCE_STATUS` in Slice C; kills raw-string drift
2. **Matrix self-test** added — transcribes the canonical 8×6 matrix from the Layer 5 spec and iterates every cell; any drift between code and spec fails the test
3. **`computeEvidenceQuality` hardened** — throws on non-finite or negative input (was silently returning `'low'`)
4. **Rejection records sanitize `normalized_name`** — closes the privacy gap where a malformed proposal could leak a secret into `rejections.jsonl`

## Simplify-pass — deferred (out-of-scope or first-slice OK)

- Parameterize `scripts/lib/locking.js` (touches shared module)
- Lift `appendJsonlLine` helper to `utils.js` (third caller arrives in Slice E)
- Incremental replay in `readCurrentCandidates` (acceptable until Slice F polls)
- Self-reentry detection in `acquireStoreLock` (no nesting caller today)
- Replay event sort by `(ts, event_id)` (single-host file lock guarantees order)
- Extract `validateScope` / `validateEvidence` / `validateSafety` from monolith (readable at 340 lines)

## Implementer judgment calls (reasonable scope cuts)

- **`evidence_ref_missing` / `evidence_ref_omitted_upstream` NOT emitted by standalone validator** — these codes require batch context that only source adapters (Slice E daemon, `/recall`, `/reflect`) have. Defined in the union so adapters can emit them.
- **`candidate_id` format validated but generation deferred to callers** — Slice E will own it.

## Test plan

- [x] `npm test` — 1591 Jest+Node + 557 pytest + 7 observer-daemon green
- [x] `npm run lint` — clean
- [x] 65 schema cases: every artifact_type, scope variant, required field, length limit, enum violation, evidence_quality boundary
- [x] 48 lifecycle cases: matrix self-test + every legal transition + 16 illegal transition assertions
- [x] 13 queue-writer cases: append, validation-reject-to-rejections.jsonl, real-fork concurrent appends, replay (created → transitioned → patched), corrupted trailing line tolerance, sanitizer on body + evidence + rejection records