### PR TITLE
feat(learning): Slice E.2b — daemon uses --json-schema for structured output

### DIFF
--- a/scripts/lib/learning-curator/candidate-proposal-schema.json
+++ b/scripts/lib/learning-curator/candidate-proposal-schema.json
@@ -1,0 +1,86 @@
+{
+  "type": "object",
+  "required": ["schema_version", "source", "proposals"],
+  "properties": {
+    "schema_version": { "type": "integer" },
+    "source": {
+      "type": "object",
+      "required": [
+        "layer",
+        "curator",
+        "run_id",
+        "created_at",
+        "batch_id",
+        "batch_hash",
+        "prompt_policy_version",
+        "output_schema_version"
+      ],
+      "properties": {
+        "layer": { "type": "integer" },
+        "curator": { "type": "string" },
+        "run_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "batch_id": { "type": "string" },
+        "batch_hash": { "type": "string" },
+        "prompt_policy_version": { "type": "string" },
+        "output_schema_version": { "type": "integer" }
+      }
+    },
+    "proposals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "proposal_index",
+          "artifact_type",
+          "proposed_scope",
+          "name",
+          "summary",
+          "rationale",
+          "domain",
+          "body",
+          "body_source",
+          "evidence_refs",
+          "llm_confidence",
+          "risk_notes",
+          "uncertainty_notes",
+          "recommended_review_action"
+        ],
+        "properties": {
+          "proposal_index": { "type": "integer" },
+          "artifact_type": { "type": "string" },
+          "proposed_scope": {
+            "type": "object",
+            "required": ["kind", "project_id"],
+            "properties": {
+              "kind": { "type": "string" },
+              "project_id": { "type": "string" }
+            }
+          },
+          "name": { "type": "string" },
+          "summary": { "type": "string" },
+          "rationale": { "type": "string" },
+          "domain": { "type": "string" },
+          "body": { "type": "string" },
+          "body_source": { "type": "string" },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["evidence_id", "evidence_type", "relevance"],
+              "properties": {
+                "evidence_id": { "type": "string" },
+                "evidence_type": { "type": "string" },
+                "relevance": { "type": "string" }
+              }
+            }
+          },
+          "llm_confidence": { "type": "string" },
+          "risk_notes": { "type": "array", "items": { "type": "string" } },
+          "uncertainty_notes": { "type": "array", "items": { "type": "string" } },
+          "recommended_review_action": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -294,19 +294,44 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
     raw_response_saved: false,
   };
 
-  // Parse response
-  let payload;
+  // Parse response. Daemon uses `claude --output-format json --json-schema ...`
+  // so rawResponse is a CLI envelope; the actual CandidateProposalPayload lives
+  // under .structured_output. (Pre-Slice-E.2b ingestors expected the raw payload
+  // at the top level — that path is removed since the daemon never emits it now.)
+  let envelope;
   try {
-    payload = JSON.parse(rawResponse);
+    envelope = JSON.parse(rawResponse);
   } catch {
     runManifest.parse_status = 'malformed_json';
+    runManifest.detail = 'envelope JSON parse failed';
     persistRunManifest(runManifest, homeDir);
     return { run_id: runId, parse_status: 'malformed_json', accepted: 0, rejected: 0 };
   }
 
-  // Must be a non-null object
-  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+  if (envelope === null || typeof envelope !== 'object' || Array.isArray(envelope)) {
     runManifest.parse_status = 'non_object';
+    persistRunManifest(runManifest, homeDir);
+    return { run_id: runId, parse_status: 'non_object', accepted: 0, rejected: 0 };
+  }
+
+  // CLI envelope error signal — model timeout, API error, schema-validation reject.
+  if (envelope.is_error === true || envelope.subtype === 'error') {
+    runManifest.parse_status = 'transport_error';
+    runManifest.detail = envelope.api_error_status || envelope.subtype || 'cli reported error';
+    persistRunManifest(runManifest, homeDir);
+    return { run_id: runId, parse_status: 'transport_error', accepted: 0, rejected: 0 };
+  }
+
+  const payload = envelope.structured_output;
+  if (payload === undefined || payload === null) {
+    runManifest.parse_status = 'malformed_json';
+    runManifest.detail = 'envelope missing structured_output field';
+    persistRunManifest(runManifest, homeDir);
+    return { run_id: runId, parse_status: 'malformed_json', accepted: 0, rejected: 0 };
+  }
+  if (typeof payload !== 'object' || Array.isArray(payload)) {
+    runManifest.parse_status = 'non_object';
+    runManifest.detail = 'structured_output is not an object';
     persistRunManifest(runManifest, homeDir);
     return { run_id: runId, parse_status: 'non_object', accepted: 0, rejected: 0 };
   }

--- a/skills/arc-observing/scripts/observer-daemon.sh
+++ b/skills/arc-observing/scripts/observer-daemon.sh
@@ -202,12 +202,28 @@ analyze_project() {
   fi
 
   # ── Layer 4: Call claude with watchdog ────────────────────────────────────
+  # Uses Anthropic structured output (--json-schema) to force the model to emit
+  # a payload conforming to CandidateProposalPayload v1. Without this, claude
+  # CLI's default Code-mode system prompt biases the model to wrap JSON in
+  # markdown code fences (verified E.3). With --json-schema + --output-format
+  # json, the model cannot wrap — the CLI returns an envelope containing the
+  # structured payload under the `structured_output` field.
+  #
   # Response file: transient, cleaned in EXIT trap and after ingestion.
   # Note: Layer 4 spec says tool_access=false — no --tools flag.
   local response_file="${INSTINCTS_DIR}/.curator-response.${batch_id}.json"
   local analysis_success=false
   local retry_count=0
   local max_retries=1
+  local schema_path="${ARCFORGE_ROOT}/scripts/lib/learning-curator/candidate-proposal-schema.json"
+  if [ ! -f "$schema_path" ]; then
+    log_msg "ERROR: candidate-proposal-schema.json not found at ${schema_path}"
+    echo $((fail_count + 1)) > "$fail_count_file"
+    return
+  fi
+  # Read schema once per analyze_project call so the inner loop reuses it.
+  local schema_json
+  schema_json=$(cat "$schema_path")
 
   # Ensure INSTINCTS_DIR exists for the response file
   mkdir -p "$INSTINCTS_DIR"
@@ -222,11 +238,15 @@ analyze_project() {
       local claude_pid=""
       local watchdog_pid=""
 
-      # Pipe prompt file to claude; capture JSON output to response_file.
-      # No --tools flag: Layer 4 LLM curator must not have tool access.
+      # Pipe prompt file to claude; capture JSON envelope to response_file.
+      # --output-format json + --json-schema forces structured output (no
+      # markdown wrap possible). The payload lives at .structured_output in
+      # the envelope; ingest-proposal extracts it.
       (claude --model haiku \
         --max-turns 15 \
         --print \
+        --output-format json \
+        --json-schema "$schema_json" \
         --disable-slash-commands \
         --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
         < "$prompt_path" \

--- a/skills/arc-observing/tests/run-tests.sh
+++ b/skills/arc-observing/tests/run-tests.sh
@@ -310,16 +310,18 @@ done
 # Actually: simplest approach — stub only 'claude' to emit known JSON.
 # Let node calls go to real node (ARCFORGE_ROOT is set to repo root).
 
-# Known CandidateProposalPayload that the stub 'claude' will emit.
-# Using a simplified payload that matches the required schema shape.
+# Slice E.2b: daemon calls claude with `--output-format json --json-schema ...`,
+# so the response file is a CLI envelope whose .structured_output holds the payload.
+# The stub mimics that envelope shape — proposal-ingestor.js extracts structured_output.
 STUB_PAYLOAD='{"schema_version":1,"source":{"layer":4,"curator":"llm","run_id":"curator_run_20260521T030000Z_aabbccddee11","created_at":"2026-05-21T03:00:00.000Z","batch_id":"STUB_BATCH","batch_hash":"STUB_HASH","prompt_policy_version":"v1","output_schema_version":1},"proposals":[{"proposal_index":0,"artifact_type":"instinct","proposed_scope":{"kind":"project","project_id":"proj_abc123456789ab"},"name":"e2-test-instinct","summary":"Test instinct from E2 stub","rationale":"Observed in E2 test fixture","domain":"workflow","body":"When in E2 test, always write tests first.","body_source":"llm_curator","evidence_refs":[],"llm_confidence":"medium","risk_notes":[],"uncertainty_notes":[],"recommended_review_action":"review"}]}'
+STUB_ENVELOPE='{"type":"result","subtype":"success","is_error":false,"api_error_status":null,"duration_ms":100,"result":"stub success","structured_output":'$STUB_PAYLOAD'}'
 
-# Stub claude that outputs the stub payload (ignores --max-turns, --print, etc.)
+# Stub claude that emits the CLI envelope (matches --output-format json + --json-schema)
 cat > "${STUB_BIN_G3}/claude" << STUB_EOF
 #!/usr/bin/env bash
-# Consume stdin (prompt file piped in), emit the known payload
+# Consume stdin (prompt file piped in), emit the known envelope
 cat > /dev/null
-printf '%s\n' '$STUB_PAYLOAD'
+printf '%s\n' '$STUB_ENVELOPE'
 STUB_EOF
 chmod +x "${STUB_BIN_G3}/claude"
 

--- a/tests/scripts/learning-curator-proposal-ingestor.test.js
+++ b/tests/scripts/learning-curator-proposal-ingestor.test.js
@@ -161,11 +161,37 @@ function makeValidProposalPayload(batchId, batchHash) {
   };
 }
 
-function makeResponseFile(payload) {
+// Wrap a CandidateProposalPayload in the claude --output-format json envelope
+// the daemon writes to the response file. Slice E.2b switched to structured
+// output; the model can no longer wrap in markdown because the CLI enforces
+// the schema via --json-schema and exposes the result under structured_output.
+function makeCliEnvelope(payload, overrides = {}) {
+  return {
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    api_error_status: null,
+    duration_ms: 32000,
+    result: 'analysis complete',
+    structured_output: payload,
+    ...overrides,
+  };
+}
+
+function makeResponseFile(payload, envelopeOverrides) {
   const responseDir = path.join(tmpDir, '.arcforge', 'learning', 'responses');
   fs.mkdirSync(responseDir, { recursive: true });
   const responsePath = path.join(responseDir, `response-${Date.now()}.json`);
-  fs.writeFileSync(responsePath, JSON.stringify(payload, null, 2), 'utf8');
+  const envelope = makeCliEnvelope(payload, envelopeOverrides);
+  fs.writeFileSync(responsePath, JSON.stringify(envelope, null, 2), 'utf8');
+  return responsePath;
+}
+
+function writeRawResponseFile(rawContents) {
+  const responseDir = path.join(tmpDir, '.arcforge', 'learning', 'responses');
+  fs.mkdirSync(responseDir, { recursive: true });
+  const responsePath = path.join(responseDir, `response-${Date.now()}.json`);
+  fs.writeFileSync(responsePath, rawContents, 'utf8');
   return responsePath;
 }
 
@@ -249,10 +275,7 @@ describe('ingestProposal — malformed JSON', () => {
   test('garbage response text produces parse_status malformed_json, no queue change', () => {
     const { ingestProposal } = getIngestor();
     const { batchId } = makeBatchManifest();
-    const responseDir = path.join(tmpDir, '.arcforge', 'learning', 'responses');
-    fs.mkdirSync(responseDir, { recursive: true });
-    const responsePath = path.join(responseDir, 'garbage.json');
-    fs.writeFileSync(responsePath, 'this is not json {{{', 'utf8');
+    const responsePath = writeRawResponseFile('this is not json {{{');
 
     const result = ingestProposal({ batchId, responseFile: responsePath });
 
@@ -270,6 +293,80 @@ describe('ingestProposal — malformed JSON', () => {
     const runManifest = JSON.parse(fs.readFileSync(runManifestPath, 'utf8'));
     expect(runManifest.parse_status).toBe('malformed_json');
     expect(runManifest.handed_to_layer5).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice E.2b — CLI envelope (--output-format json --json-schema)
+// ---------------------------------------------------------------------------
+
+describe('ingestProposal — CLI envelope (--output-format json)', () => {
+  test('envelope with is_error:true produces transport_error', () => {
+    const { ingestProposal } = getIngestor();
+    const { batchId } = makeBatchManifest();
+    const responsePath = writeRawResponseFile(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        api_error_status: { code: 'rate_limit_exceeded' },
+      }),
+    );
+
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.parse_status).toBe('transport_error');
+    expect(result.accepted).toBe(0);
+
+    const runsDir = path.join(tmpDir, '.arcforge', 'learning', 'curator-runs');
+    const runManifestPath = path.join(runsDir, `${result.run_id}.manifest.json`);
+    const runManifest = JSON.parse(fs.readFileSync(runManifestPath, 'utf8'));
+    expect(runManifest.parse_status).toBe('transport_error');
+  });
+
+  test('envelope missing structured_output produces malformed_json with detail', () => {
+    const { ingestProposal } = getIngestor();
+    const { batchId } = makeBatchManifest();
+    const responsePath = writeRawResponseFile(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'analysis complete but no structured output emitted',
+        // no structured_output field at all
+      }),
+    );
+
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.parse_status).toBe('malformed_json');
+
+    const runsDir = path.join(tmpDir, '.arcforge', 'learning', 'curator-runs');
+    const runManifestPath = path.join(runsDir, `${result.run_id}.manifest.json`);
+    const runManifest = JSON.parse(fs.readFileSync(runManifestPath, 'utf8'));
+    expect(runManifest.detail).toMatch(/structured_output/i);
+  });
+
+  test('envelope with structured_output:null produces malformed_json', () => {
+    const { ingestProposal } = getIngestor();
+    const { batchId } = makeBatchManifest();
+    const responsePath = writeRawResponseFile(
+      JSON.stringify({ type: 'result', is_error: false, structured_output: null }),
+    );
+
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+    expect(result.parse_status).toBe('malformed_json');
+  });
+
+  test('envelope with subtype:error produces transport_error', () => {
+    const { ingestProposal } = getIngestor();
+    const { batchId } = makeBatchManifest();
+    const responsePath = writeRawResponseFile(
+      JSON.stringify({ type: 'result', subtype: 'error', is_error: false }),
+    );
+
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+    expect(result.parse_status).toBe('transport_error');
   });
 });
 


### PR DESCRIPTION
## Summary

E.3 real-daemon verification (follow-up to PR #37) found that **claude CLI default mode wraps JSON in markdown code fences** regardless of model (haiku, sonnet — both). The original Slice E.2 ingestor did `JSON.parse(rawResponse)` directly, which fails on markdown wrappers → `parse_status: malformed_json` → no queue write. Layer 5 fail-closed correctly (no bad data) but the **daemon → candidate path was effectively broken in production**.

**Fix**: switch the daemon's `claude` invocation to Anthropic's structured-output mode via `--output-format json --json-schema`. The model is forced by the API to emit a payload conforming to the schema; markdown wrapping is impossible by construction.

## Schema complexity finding

Anthropic structured output **silently falls through to text mode** when the schema exceeds the supported subset. Tested:
- 4893-char schema with `$defs`/`$ref`/`const`/`enum`/`pattern`/`additionalProperties:false` → envelope has no `structured_output`, `result` field has markdown-wrapped JSON
- 2619-char schema with structure-only types + required arrays → `structured_output` populated correctly

**Design decision**: schema enforces STRUCTURE; semantic validation (artifact_type=instinct, body_source=llm_curator, scope rules) stays at Layer 5's `validateCandidateV1`. Clean separation — API enforces shape, Layer 5 enforces policy.

## Files

| Path | Change |
|---|---|
| `scripts/lib/learning-curator/candidate-proposal-schema.json` | **new** — structure-only schema used by `--json-schema` |
| `scripts/lib/learning-curator/proposal-ingestor.js` | parses CLI envelope, extracts `structured_output`, new `transport_error` branch for envelope-reported errors (`is_error:true`, `subtype:error`) |
| `skills/arc-observing/scripts/observer-daemon.sh` | adds `--output-format json --json-schema <schema>`; schema loaded once per `analyze_project`; existence check before claude invocation |
| `skills/arc-observing/tests/run-tests.sh` | E2-G3 stub claude now emits the envelope shape (wraps payload in CLI result envelope) |
| `tests/scripts/learning-curator-proposal-ingestor.test.js` | fixtures wrap payloads in envelopes; **4 new envelope-error tests** |

## Test plan

- [x] 1652 Jest+Node tests pass (was 1648; +4 envelope tests)
- [x] 557 pytest pass
- [x] 14 observer-daemon bash tests pass
- [x] `npm run lint` clean

## E.3 verification result (real claude haiku)

Ran daemon `analyze_project` against real claude haiku via isolated worktree:

| Step | Result |
|---|---|
| Layer 3 batch assembly | ✓ |
| claude returned envelope with `structured_output` | ✓ |
| Ingestor extracted payload correctly | ✓ |
| LLM judged 48 (and 180) fixture observations weak → `proposals:[]` → `parse_status: empty` → no queue write | ✓ (correct fail-closed) |
| No `.md` instinct files written (Slice E.2 rewire intact) | ✓ |
| Both batch + run manifests persist | ✓ |

The "queue gets a candidate" path remains covered by E2-G3 with stub envelope (now updated to envelope shape). The claude-judges-empty behavior on synthetic fixture data is **correct LLM judgment** (no outcome signals in fixtures), not a pipeline defect.

## Refs

- PR #37 (Slice E.1+E.2) — what this builds on
- Layer 4 spec: `docs/plans/references/learning-curator-schema/layer-4-llm-curator-analysis.md`
- Decision log entries appended (`docs/plans/2026-05-20-learning-curator-decisions.html`, orchestrator artifact not in PR)