### PR TITLE
fix(learning): expose Deactivate button + accept deactivated status in re-activate/re-materialize

### DIFF
--- a/scripts/lib/learning-curator/activate.js
+++ b/scripts/lib/learning-curator/activate.js
@@ -224,10 +224,11 @@ function activate({
     return { ok: false, failure };
   }
 
-  // L8-1: candidate must be materialized
+  // L8-1: candidate must be materialized (first activation) or deactivated (reactivation).
+  // Matrix-allowed transitions: materialized → activated, deactivated → activated.
   const status = candidate?.lifecycle ? candidate.lifecycle.status : undefined;
-  if (status !== 'materialized') {
-    return fail('invalid_lifecycle_status', `Expected materialized, got: ${status}`);
+  if (status !== 'materialized' && status !== 'deactivated') {
+    return fail('invalid_lifecycle_status', `Expected materialized or deactivated, got: ${status}`);
   }
 
   // L8-2: materializationRecord candidate_id must match

--- a/scripts/lib/learning-curator/materialize.js
+++ b/scripts/lib/learning-curator/materialize.js
@@ -322,10 +322,11 @@ function materialize({
     return { ok: false, failure };
   }
 
-  // L7-1: Reject non-approved candidates
+  // L7-1: candidate must be approved (first materialization) or deactivated (re-materialization).
+  // Matrix-allowed transitions: approved → materialized, deactivated → materialized.
   const status = candidate?.lifecycle ? candidate.lifecycle.status : undefined;
-  if (status !== 'approved') {
-    return fail('invalid_lifecycle_status', `Expected approved, got: ${status}`);
+  if (status !== 'approved' && status !== 'deactivated') {
+    return fail('invalid_lifecycle_status', `Expected approved or deactivated, got: ${status}`);
   }
 
   // L7-2: First-slice supports instinct only
@@ -419,7 +420,7 @@ function materialize({
       source_candidate: {
         candidate_id: candidate.candidate_id,
         candidate_record_hash: recordHash,
-        lifecycle_status_at_materialization: 'approved',
+        lifecycle_status_at_materialization: status,
       },
       artifact_type: artifactType,
       draft_artifacts: [

--- a/scripts/lib/learning-dashboard.html
+++ b/scripts/lib/learning-dashboard.html
@@ -61,12 +61,13 @@
       const refreshEl = document.getElementById('refresh');
       const countsEl = document.getElementById('counts');
 
-      const ACTION_LABELS = { dismiss: 'Dismiss', approve: 'Approve', materialize: 'Materialize', activate: 'Activate', promote: 'Promote', evolve: 'Evolve' };
+      const ACTION_LABELS = { dismiss: 'Dismiss', approve: 'Approve', materialize: 'Materialize', activate: 'Activate', deactivate: 'Deactivate', promote: 'Promote', evolve: 'Evolve' };
       const ACTION_AVAILABLE_FROM = {
         dismiss: ['pending_review', 'needs_more_evidence'],
         approve: ['pending_review'],
         materialize: ['approved', 'deactivated'],
         activate: ['materialized', 'deactivated'],
+        deactivate: ['activated'],
         promote: ['pending_review', 'approved'],
         evolve: ['pending_review', 'approved'],
       };

--- a/tests/scripts/learning-curator-activate.test.js
+++ b/tests/scripts/learning-curator-activate.test.js
@@ -183,6 +183,26 @@ describe('L8-1: reject invalid lifecycle status', () => {
     expect(result.ok).toBe(false);
     expect(result.failure.reason).toBe('invalid_lifecycle_status');
   });
+
+  it('activate accepts deactivated status (reactivation path)', () => {
+    const { candidate, materializationRecord, arcforgeRoot } = runMaterialize();
+    // Simulate the deactivated state after a prior activate → deactivate cycle.
+    const deactivatedCandidate = {
+      ...candidate,
+      lifecycle: { status: 'deactivated', status_changed_at: '2026-05-21T01:00:00Z' },
+    };
+
+    const result = activate({
+      candidate: deactivatedCandidate,
+      materializationRecord,
+      activationRequest: makeActivationRequest({ candidate_id: deactivatedCandidate.candidate_id }),
+      activationPolicy: defaultActivationPolicy(arcforgeRoot),
+      arcforgeRoot,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.record.action).toBe('activate');
+    expect(result.activeArtifacts[0].status).toBe('active');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/scripts/learning-curator-materialize.test.js
+++ b/tests/scripts/learning-curator-materialize.test.js
@@ -144,6 +144,14 @@ describe('L7-1: reject non-approved candidates', () => {
     const result = callMaterialize({});
     expect(result.ok).toBe(true);
   });
+
+  it('does NOT reject deactivated candidate (re-materialization path)', () => {
+    const result = callMaterialize({
+      lifecycle: { status: 'deactivated', status_changed_at: '2026-05-21T01:00:00Z' },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.record.source_candidate.lifecycle_status_at_materialization).toBe('deactivated');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/scripts/learning-dashboard.test.js
+++ b/tests/scripts/learning-dashboard.test.js
@@ -671,6 +671,16 @@ describe('HTML — statistical-pipeline dead code removed (criterion 4)', () => 
     // Should have action buttons defined
     expect(html).toMatch(/dismiss|approve|promote/i);
   });
+
+  it('HTML exposes every lifecycle action in ACTION_LABELS and ACTION_AVAILABLE_FROM', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    for (const action of ['dismiss', 'approve', 'materialize', 'activate', 'deactivate', 'promote', 'evolve']) {
+      expect(html).toMatch(new RegExp(`${action}:\\s*'[A-Z][a-z]+'`));
+      expect(html).toMatch(new RegExp(`${action}:\\s*\\[[^\\]]+\\]`));
+    }
+  });
 });
 
 // ===========================================================================

--- a/tests/scripts/learning-dashboard.test.js
+++ b/tests/scripts/learning-dashboard.test.js
@@ -676,7 +676,15 @@ describe('HTML — statistical-pipeline dead code removed (criterion 4)', () => 
     const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
     const html = fs.readFileSync(htmlPath, 'utf8');
 
-    for (const action of ['dismiss', 'approve', 'materialize', 'activate', 'deactivate', 'promote', 'evolve']) {
+    for (const action of [
+      'dismiss',
+      'approve',
+      'materialize',
+      'activate',
+      'deactivate',
+      'promote',
+      'evolve',
+    ]) {
       expect(html).toMatch(new RegExp(`${action}:\\s*'[A-Z][a-z]+'`));
       expect(html).toMatch(new RegExp(`${action}:\\s*\\[[^\\]]+\\]`));
     }


### PR DESCRIPTION
## Summary

Slice G's deactivate path had two surface-level bugs surfaced during G.3 HITL verification. This PR fixes both.

### Bug 1 — HTML didn't expose Deactivate button

Slice G (PR #39) wired the backend deactivate handler (DH-6 backend test passes) but the HTML's `ACTION_LABELS` / `ACTION_AVAILABLE_FROM` never listed `deactivate`, so the dashboard never rendered a Deactivate button for `activated` candidates.

**Fix**: add `deactivate` to both maps in the HTML; add regression test asserting all 7 lifecycle actions are exposed.

### Bug 2 — Backend rejected reactivation / re-materialization from `deactivated`

`lifecycle.js`'s matrix (extended in Slice G) correctly allows:
- `deactivated → materialize → materialized`
- `deactivated → activate → activated`

But the actual implementations hardcoded their status gates to the FIRST-activation case only:
- `activate.js:229` accepted only `materialized`
- `materialize.js:327` accepted only `approved`

Result: after Deactivate, the UI showed Materialize / Activate buttons (HTML map was already correct for that side), but clicking either returned `invalid_lifecycle_status`. Reactivation broken.

**Fix**:
- `activate.js`: accept `materialized` OR `deactivated`
- `materialize.js`: accept `approved` OR `deactivated`
- `materialize.js` record's `source_candidate.lifecycle_status_at_materialization` now stores actual current status (was hardcoded to `'approved'`).
- 2 new tests: reactivation + re-materialization happy paths.

## Test plan

- [x] `npm test` — 4 runners green; 1747 Jest (was 1744; +3 new regression tests)
- [x] `npm run lint` — Biome clean
- [x] Manual: dashboard refresh shows Deactivate button on `activated` card
- [x] Manual: clicking Deactivate moves file to `.disabled/`; clicking Activate again re-creates active file