### PR TITLE
fix(learning): repair 2 H.1 eval scenarios for H.2 SHIP verdict

### DIFF
--- a/evals/scenarios/eval-trial-observation-exclusion.md
+++ b/evals/scenarios/eval-trial-observation-exclusion.md
@@ -126,10 +126,14 @@ try {
   emit('A2', a2, a2 ? '' : `shouldObserve returned ${a2Result} for trial-suffix path — should be false`);
   if (!a2) allPass = false;
 
-  // A3: normal project path — should return true (learning is enabled for trialDir)
-  const a3Result = shouldObserve({ projectRoot: trialDir, homeDir: trialDir });
+  // A3: normal project path — should return true (learning is enabled in HOME config).
+  // Must NOT use trialDir itself: the eval harness places trials under
+  // `.eval-trials/<scenario>-tN-XXXXXX/` — that path matches BOTH skip patterns
+  // (eval-trials segment + trial suffix). Use a synthetic non-skipped path instead.
+  const synthNormalPath = `/tmp/eval-trial-obs-exclusion-positive-control-${process.pid}`;
+  const a3Result = shouldObserve({ projectRoot: synthNormalPath, homeDir: trialDir });
   const a3 = a3Result === true;
-  emit('A3', a3, a3 ? '' : `shouldObserve returned ${a3Result} for normal path — should be true when learning enabled`);
+  emit('A3', a3, a3 ? '' : `shouldObserve returned ${a3Result} for synthetic non-eval-trial path ${synthNormalPath} — should be true when learning enabled in HOME`);
   if (!a3) allPass = false;
 
 } catch (err) {

--- a/evals/scenarios/evolve-quality.md
+++ b/evals/scenarios/evolve-quality.md
@@ -189,12 +189,14 @@ try {
 
   const { sourceCandidateId, homeDir } = JSON.parse(fs.readFileSync(ctxPath, 'utf8'));
 
-  // Invoke the dashboard evolve action
-  const { applyDashboardAction } = require(path.join(projectRoot, 'scripts/lib/learning-dashboard.js'));
-  const result = applyDashboardAction({
-    candidateId: sourceCandidateId,
+  // Invoke the dashboard evolve action.
+  // The real export is `handleDashboardAction` with `candidate_id` snake_case
+  // and no homeDir param — the function uses os.homedir() at call time which
+  // we've redirected via `process.env.HOME = trialDir` above.
+  const { handleDashboardAction } = require(path.join(projectRoot, 'scripts/lib/learning-dashboard.js'));
+  const result = handleDashboardAction({
+    candidate_id: sourceCandidateId,
     action: 'evolve',
-    homeDir,
   });
 
   if (!result || !result.accepted) {


### PR DESCRIPTION
## Summary

H.2 first run surfaced two **scenario-design bugs** in PR #40 (Slice H.1) that caused two scenarios to Verdict: BLOCKED. Neither is SKILL.md drift — both are scenario-internal grader bugs.

| Scenario | Before fix | After fix |
|---|---|---|
| evolve-quality | 0/3 trials PASS → BLOCKED | 3/3 trials PASS → SHIP |
| eval-trial-observation-exclusion | 0/3 trials PASS → BLOCKED | 3/3 trials PASS → SHIP |

## Root causes

### 1. evolve-quality grader called a non-existent API

The grader's Node block did:
```js
const { applyDashboardAction } = require(... 'scripts/lib/learning-dashboard.js');
const result = applyDashboardAction({
  candidateId: sourceCandidateId,
  action: 'evolve',
  homeDir,
});
```

But the real export is `handleDashboardAction` (not `applyDashboardAction`), with `candidate_id` (snake_case) and no `homeDir` param. The function uses `os.homedir()` at call time — and the grader already redirects via `process.env.HOME = trialDir` above, so that part was fine; the call shape was just wrong.

Fix: use the real exported name + parameter shape.

### 2. eval-trial-observation-exclusion A3 positive control was self-defeating

A3 was supposed to verify that a normal (non-eval-trial) project path is observed when learning is enabled. But the grader called:
```js
shouldObserve({ projectRoot: trialDir, homeDir: trialDir })
```

The eval harness places each trial under `.eval-trials/<scenario>-tN-XXXXXX/` — that path matches BOTH skip patterns enforced by `isSkippedPath()`:
- A1's `.eval-trials/` segment match
- A2's `-tN-XXXXXX` suffix match

So `trialDir` would always return `false` from `shouldObserve` — A1+A2 pass (skip filter works), but A3 fails by construction.

Fix: A3 uses a synthetic path outside `.eval-trials/`: `/tmp/eval-trial-obs-exclusion-positive-control-\${pid}` — non-skipped projectRoot + learning enabled in HOME config → returns `true` as intended.

## Full H.2 results after fix

| Scenario | Trials | Verdict |
|---|---|---|
| instinct-adherence | 5/5 | SHIP |
| reflect-pattern-detection | 5/5 | SHIP |
| daemon-candidate-generation | 3/3 | SHIP |
| pending-candidate-boundary | 5/5 | SHIP |
| activated-skill-behavior | 5/5 | SHIP |
| evolve-quality | 3/3 | SHIP |
| eval-trial-observation-exclusion | 3/3 | SHIP |
| **Total** | **29/29** | **7/7 SHIP** |

H.2 gate satisfied — pivot branch is ready for final main merge.

## Test plan

- [x] eval run evolve-quality — 3/3 PASS, Verdict SHIP
- [x] eval run eval-trial-observation-exclusion — 3/3 PASS, Verdict SHIP
- [x] Other 5 scenarios unchanged (PASSed in first H.2 run)
- [x] No code or SKILL.md changes — only scenario file edits