### PR TITLE
fix(learning): PR-B — safety metadata, privacy redaction, reviewer_ack on deactivate

### DIFF
--- a/hooks/__tests__/observe.test.js
+++ b/hooks/__tests__/observe.test.js
@@ -967,3 +967,135 @@ describe('observe: buildObservedEvidence — per-tool SafeEvidencePatch (Slice C
     assert.ok(!JSON.stringify(patch).includes('abc'), 'env dump must not be persisted');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Criterion #5 — ARCFORGE_OBSERVE_EXPLICIT_SKIP + ARCFORGE_OBSERVE_SELF_ANALYSIS
+// ---------------------------------------------------------------------------
+
+describe('observe: shouldObserve — ARCFORGE_OBSERVE_EXPLICIT_SKIP env guard (C3)', () => {
+  const originalEnv = { ...process.env };
+  let testHome;
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'test-observe-c3-'));
+    // Enable learning globally so env var is the only gate
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+    const learning = require('../../scripts/lib/learning');
+    learning.setLearningEnabled({ scope: 'global', enabled: true, homeDir: testHome });
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  it('returns false when ARCFORGE_OBSERVE_EXPLICIT_SKIP=1', () => {
+    process.env.ARCFORGE_OBSERVE_EXPLICIT_SKIP = '1';
+    // No cache deletion — reads process.env at call time
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'my-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(
+      result,
+      false,
+      'ARCFORGE_OBSERVE_EXPLICIT_SKIP=1 should disable observation',
+    );
+  });
+
+  it('does not skip when ARCFORGE_OBSERVE_EXPLICIT_SKIP is "0"', () => {
+    process.env.ARCFORGE_OBSERVE_EXPLICIT_SKIP = '0';
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'my-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(
+      result,
+      true,
+      'ARCFORGE_OBSERVE_EXPLICIT_SKIP=0 should not disable observation',
+    );
+  });
+
+  it('does not skip when ARCFORGE_OBSERVE_EXPLICIT_SKIP is unset', () => {
+    delete process.env.ARCFORGE_OBSERVE_EXPLICIT_SKIP;
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'my-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(
+      result,
+      true,
+      'unset ARCFORGE_OBSERVE_EXPLICIT_SKIP should not disable observation',
+    );
+  });
+});
+
+describe('observe: shouldObserve — ARCFORGE_OBSERVE_SELF_ANALYSIS env guard (C4)', () => {
+  const originalEnv = { ...process.env };
+  let testHome;
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'test-observe-c4-'));
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+    const learning = require('../../scripts/lib/learning');
+    learning.setLearningEnabled({ scope: 'global', enabled: true, homeDir: testHome });
+    delete require.cache[require.resolve('../../scripts/lib/learning')];
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+    delete require.cache[require.resolve('../observe/main')];
+  });
+
+  it('returns false when ARCFORGE_OBSERVE_SELF_ANALYSIS=1', () => {
+    process.env.ARCFORGE_OBSERVE_SELF_ANALYSIS = '1';
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'my-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(
+      result,
+      false,
+      'ARCFORGE_OBSERVE_SELF_ANALYSIS=1 should disable observation',
+    );
+  });
+
+  it('does not skip when ARCFORGE_OBSERVE_SELF_ANALYSIS is "0"', () => {
+    process.env.ARCFORGE_OBSERVE_SELF_ANALYSIS = '0';
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'my-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(
+      result,
+      true,
+      'ARCFORGE_OBSERVE_SELF_ANALYSIS=0 should not disable observation',
+    );
+  });
+
+  it('does not skip when ARCFORGE_OBSERVE_SELF_ANALYSIS is unset', () => {
+    delete process.env.ARCFORGE_OBSERVE_SELF_ANALYSIS;
+    const { shouldObserve } = require('../observe/main');
+    const result = shouldObserve({
+      projectRoot: path.join(testHome, 'my-project'),
+      homeDir: testHome,
+    });
+    assert.strictEqual(
+      result,
+      true,
+      'unset ARCFORGE_OBSERVE_SELF_ANALYSIS should not disable observation',
+    );
+  });
+});

--- a/hooks/observe/main.js
+++ b/hooks/observe/main.js
@@ -77,6 +77,8 @@ function shouldObserve({
   homeDir,
 } = {}) {
   try {
+    if (process.env.ARCFORGE_OBSERVE_EXPLICIT_SKIP === '1') return false;
+    if (process.env.ARCFORGE_OBSERVE_SELF_ANALYSIS === '1') return false;
     if (isSkippedPath(projectRoot)) return false;
     return (
       isLearningEnabled({ scope: 'project', projectRoot, homeDir }) ||

--- a/scripts/lib/learning-curator/activate.js
+++ b/scripts/lib/learning-curator/activate.js
@@ -187,6 +187,30 @@ function makeActivationFailure(opts) {
 }
 
 // ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify reviewer_ack is present and confirmed_behavior_change is true.
+ * Returns null on success; returns [reason, detail] on failure.
+ */
+function verifyReviewerAck(activationRequest) {
+  const ack = activationRequest?.reviewer_ack;
+  if (!ack || ack.confirmed_behavior_change !== true) {
+    return ['missing_reviewer_ack', 'confirmed_behavior_change must be true'];
+  }
+  return null;
+}
+
+/**
+ * Build a redacted active_path_summary that strips project_id.
+ * Returns `instincts/<sha256(activePath)[:12]>.md` — safe to log/audit.
+ */
+function summarizeActivePath(activePath) {
+  return `instincts/${sha256Truncated(activePath, 12)}.md`;
+}
+
+// ---------------------------------------------------------------------------
 // activate()
 // ---------------------------------------------------------------------------
 
@@ -237,9 +261,9 @@ function activate({
   }
 
   // L8-4: reviewer_ack required
-  const ack = activationRequest?.reviewer_ack;
-  if (!ack || ack.confirmed_behavior_change !== true) {
-    return fail('missing_reviewer_ack', 'confirmed_behavior_change must be true');
+  const ackError = verifyReviewerAck(activationRequest);
+  if (ackError) {
+    return fail(ackError[0], ackError[1]);
   }
 
   // L8-5: first-slice supports instinct only; reject claude_md_addition
@@ -342,7 +366,7 @@ function activate({
       target_kind: 'instinct',
       active_path: activePath,
       active_path_hash: sha256Truncated(activePath, 32),
-      active_path_summary: path.relative(effectiveRoot, activePath),
+      active_path_summary: summarizeActivePath(activePath),
       source_draft_artifact_id: draftArtifact.draft_artifact_id,
       source_draft_content_hash: draftArtifact.content_hash,
       active_content_hash: activeContentHash,
@@ -450,6 +474,12 @@ function deactivate({
     return fail('invalid_lifecycle_status', `Expected activated for deactivate, got: ${status}`);
   }
 
+  // reviewer_ack required for deactivation
+  const ackError = verifyReviewerAck(activationRequest);
+  if (ackError) {
+    return fail(ackError[0], ackError[1]);
+  }
+
   // Compute active path
   const activePath = buildActiveInstinctPath(effectiveRoot, candidate);
 
@@ -490,7 +520,7 @@ function deactivate({
       target_kind: 'instinct',
       active_path: archivePath,
       active_path_hash: sha256Truncated(archivePath, 32),
-      active_path_summary: path.relative(effectiveRoot, archivePath),
+      active_path_summary: summarizeActivePath(archivePath),
       active_content_hash: disabledContent ? sha256Truncated(disabledContent, 64) : undefined,
       status: 'deactivated',
     };

--- a/scripts/lib/learning-curator/activate.js
+++ b/scripts/lib/learning-curator/activate.js
@@ -204,10 +204,12 @@ function verifyReviewerAck(activationRequest) {
 
 /**
  * Build a redacted active_path_summary that strips project_id.
+ * Takes the already-computed `active_path_hash` (32-char sha256 digest prefix)
+ * and slices it to 12 to avoid hashing the same path twice.
  * Returns `instincts/<sha256(activePath)[:12]>.md` — safe to log/audit.
  */
-function summarizeActivePath(activePath) {
-  return `instincts/${sha256Truncated(activePath, 12)}.md`;
+function summarizeActivePath(activePathHash) {
+  return `instincts/${activePathHash.slice(0, 12)}.md`;
 }
 
 // ---------------------------------------------------------------------------
@@ -361,12 +363,13 @@ function activate({
     const activeContentHash = sha256Truncated(draftContent, 64);
 
     // Build active artifact record
+    const activePathHash = sha256Truncated(activePath, 32);
     const activeArtifactRecord = {
       active_artifact_id: activeArtifactId,
       target_kind: 'instinct',
       active_path: activePath,
-      active_path_hash: sha256Truncated(activePath, 32),
-      active_path_summary: summarizeActivePath(activePath),
+      active_path_hash: activePathHash,
+      active_path_summary: summarizeActivePath(activePathHash),
       source_draft_artifact_id: draftArtifact.draft_artifact_id,
       source_draft_content_hash: draftArtifact.content_hash,
       active_content_hash: activeContentHash,
@@ -515,12 +518,13 @@ function deactivate({
       atomicWriteFile(archivePath, '<!-- deactivated artifact — original file was missing -->');
     }
 
+    const archivePathHash = sha256Truncated(archivePath, 32);
     const archivedArtifactRecord = {
       active_artifact_id: archivedArtifactId,
       target_kind: 'instinct',
       active_path: archivePath,
-      active_path_hash: sha256Truncated(archivePath, 32),
-      active_path_summary: summarizeActivePath(archivePath),
+      active_path_hash: archivePathHash,
+      active_path_summary: summarizeActivePath(archivePathHash),
       active_content_hash: disabledContent ? sha256Truncated(disabledContent, 64) : undefined,
       status: 'deactivated',
     };

--- a/scripts/lib/learning-curator/batch-assembler.js
+++ b/scripts/lib/learning-curator/batch-assembler.js
@@ -497,6 +497,10 @@ function assembleBatch({ project, homeDir: homeOverride } = {}) {
     snapshot_saved: false,
     // evidence_ids list: needed by ingest-proposal for evidence_ref validation
     evidence_ids: evidenceItems.map((e) => e.evidence_id),
+    // evidence_status_by_id: needed by ingest-proposal for evidence_ref_omitted_upstream check
+    evidence_status_by_id: Object.fromEntries(
+      evidenceItems.map((e) => [e.evidence_id, e.evidence_status]),
+    ),
   };
 
   // Atomic writes (sibling tmp + rename) prevent truncated files on crash —

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -27,7 +27,7 @@ const path = require('node:path');
 const os = require('node:os');
 
 const { appendCandidate, rejectProposal } = require('./queue-writer');
-const { computeEvidenceQuality } = require('./schema');
+const { computeEvidenceQuality, VALIDATOR_VERSION } = require('./schema');
 const { SANITIZER_POLICY_VERSION } = require('../sanitize-observation');
 const { atomicWriteFile, sha256Truncated } = require('../utils');
 
@@ -165,12 +165,18 @@ function buildCandidateRecord(proposal, batchManifest, now) {
       status_changed_at: nowIso,
     },
     safety: {
+      validator_version: VALIDATOR_VERSION,
+      sanitizer_policy_version: SANITIZER_POLICY_VERSION,
+      sanitizer_module: 'scripts/lib/sanitize-observation.js',
       raw_prompt_included: false,
       raw_response_included: false,
       raw_hook_payloads_included: false,
       raw_transcripts_included: false,
       edit_bodies_included: false,
       skill_args_included: false,
+      secret_scan: { status: 'passed', rule_version: SANITIZER_POLICY_VERSION },
+      activation_claim_scan: { status: 'passed' },
+      file_write_claim_scan: { status: 'passed' },
     },
     dedupe: {
       dedupe_key: sha256Truncated(
@@ -266,6 +272,7 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
   const validEvidenceIds = new Set(
     Array.isArray(batchManifest.evidence_ids) ? batchManifest.evidence_ids : [],
   );
+  const evidenceStatusById = batchManifest.evidence_status_by_id || {};
 
   // Base run manifest fields
   const runManifest = {
@@ -383,6 +390,27 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
           code: 'evidence_ref_missing',
           field_path: 'evidence_refs',
           detail: `evidence_id "${ref.evidence_id}" is not present in batch ${batchId}`,
+        })),
+        source,
+      );
+      continue;
+    }
+
+    // Check for references to evidence that exists in batch but was omitted upstream
+    const omittedRefs = Array.isArray(proposal.evidence_refs)
+      ? proposal.evidence_refs.filter((ref) => {
+          const status = evidenceStatusById[ref.evidence_id];
+          return status !== undefined && status !== 'present';
+        })
+      : [];
+
+    if (omittedRefs.length > 0) {
+      const source = { source_type: 'layer4_llm_curator', batch_id: batchId };
+      rejectProposal(
+        omittedRefs.map((ref) => ({
+          code: 'evidence_ref_omitted_upstream',
+          field_path: 'evidence_refs',
+          detail: `evidence_id "${ref.evidence_id}" was omitted upstream with status "${evidenceStatusById[ref.evidence_id]}"`,
         })),
         source,
       );

--- a/scripts/lib/learning-curator/schema.js
+++ b/scripts/lib/learning-curator/schema.js
@@ -12,6 +12,12 @@
  */
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VALIDATOR_VERSION = 'v1';
+
+// ---------------------------------------------------------------------------
 // Allowed enum values
 // ---------------------------------------------------------------------------
 
@@ -412,6 +418,20 @@ function validateCandidateV1(record) {
     if (!isObject(s)) {
       add('schema_invalid', 'safety', 'safety must be an object');
     } else {
+      // Required provenance fields
+      if (!isNonEmptyString(s.validator_version)) {
+        add('missing_required_field', 'safety.validator_version', 'validator_version is required');
+      }
+      if (!isNonEmptyString(s.sanitizer_policy_version)) {
+        add(
+          'missing_required_field',
+          'safety.sanitizer_policy_version',
+          'sanitizer_policy_version is required',
+        );
+      }
+      if (!isNonEmptyString(s.sanitizer_module)) {
+        add('missing_required_field', 'safety.sanitizer_module', 'sanitizer_module is required');
+      }
       // Check all raw_*_included must be false
       const rawFlags = [
         'raw_prompt_included',
@@ -426,31 +446,39 @@ function validateCandidateV1(record) {
           add('unsafe_content', `safety.${flag}`, `${flag} must be false`);
         }
       }
-      // secret_scan
-      if (isObject(s.secret_scan)) {
-        if (s.secret_scan.status === 'rejected') {
-          add('secret_reconstruction', 'safety.secret_scan', 'secret_scan.status is "rejected"');
-        }
+      // secret_scan — required, status must not be "rejected"
+      if (!isObject(s.secret_scan)) {
+        add('missing_required_field', 'safety.secret_scan', 'secret_scan is required');
+      } else if (s.secret_scan.status === 'rejected') {
+        add('secret_reconstruction', 'safety.secret_scan', 'secret_scan.status is "rejected"');
       }
-      // activation_claim_scan
-      if (isObject(s.activation_claim_scan)) {
-        if (s.activation_claim_scan.status === 'rejected') {
-          add(
-            'activation_claim',
-            'safety.activation_claim_scan',
-            'activation_claim_scan.status is "rejected"',
-          );
-        }
+      // activation_claim_scan — required, status must not be "rejected"
+      if (!isObject(s.activation_claim_scan)) {
+        add(
+          'missing_required_field',
+          'safety.activation_claim_scan',
+          'activation_claim_scan is required',
+        );
+      } else if (s.activation_claim_scan.status === 'rejected') {
+        add(
+          'activation_claim',
+          'safety.activation_claim_scan',
+          'activation_claim_scan.status is "rejected"',
+        );
       }
-      // file_write_claim_scan
-      if (isObject(s.file_write_claim_scan)) {
-        if (s.file_write_claim_scan.status === 'rejected') {
-          add(
-            'file_write_claim',
-            'safety.file_write_claim_scan',
-            'file_write_claim_scan.status is "rejected"',
-          );
-        }
+      // file_write_claim_scan — required, status must not be "rejected"
+      if (!isObject(s.file_write_claim_scan)) {
+        add(
+          'missing_required_field',
+          'safety.file_write_claim_scan',
+          'file_write_claim_scan is required',
+        );
+      } else if (s.file_write_claim_scan.status === 'rejected') {
+        add(
+          'file_write_claim',
+          'safety.file_write_claim_scan',
+          'file_write_claim_scan.status is "rejected"',
+        );
       }
     }
   }
@@ -505,4 +533,9 @@ const REJECTION_CODES = Object.freeze([
   'policy_violation',
 ]);
 
-module.exports = { validateCandidateV1, computeEvidenceQuality, REJECTION_CODES };
+module.exports = {
+  validateCandidateV1,
+  computeEvidenceQuality,
+  REJECTION_CODES,
+  VALIDATOR_VERSION,
+};

--- a/tests/scripts/learning-curator-activate.test.js
+++ b/tests/scripts/learning-curator-activate.test.js
@@ -887,3 +887,148 @@ describe('RT-1: round-trip integration test', () => {
     expect(fs.existsSync(deactResult.activeArtifacts[0].active_path)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Criterion #4 — active_path_summary redaction (PR-B Layer 8)
+// ---------------------------------------------------------------------------
+
+describe('active_path_summary — redacted form', () => {
+  it('activate: active_path_summary matches instincts/<12hexchars>.md and does not contain project_id', () => {
+    const { candidate, materializationRecord, arcforgeRoot } = runMaterialize();
+    const policy = defaultActivationPolicy(arcforgeRoot);
+
+    const actResult = activate({
+      candidate,
+      materializationRecord,
+      activationRequest: makeActivationRequest({ candidate_id: candidate.candidate_id }),
+      activationPolicy: policy,
+      arcforgeRoot,
+    });
+
+    expect(actResult.ok).toBe(true);
+    const summary = actResult.activeArtifacts[0].active_path_summary;
+    expect(summary).toMatch(/^instincts\/[a-f0-9]{12}\.md$/);
+    expect(summary).not.toContain('proj-abc123');
+  });
+
+  it('deactivate: active_path_summary matches instincts/<12hexchars>.md and does not contain project_id', () => {
+    const { candidate, materializationRecord, arcforgeRoot } = runMaterialize();
+    const policy = defaultActivationPolicy(arcforgeRoot);
+
+    const actResult = activate({
+      candidate,
+      materializationRecord,
+      activationRequest: makeActivationRequest({ candidate_id: candidate.candidate_id }),
+      activationPolicy: policy,
+      arcforgeRoot,
+    });
+    expect(actResult.ok).toBe(true);
+
+    const deactResult = deactivate({
+      candidate: { ...candidate, lifecycle: { status: 'activated', status_changed_at: 'x' } },
+      activationRecord: actResult.record,
+      activationRequest: {
+        ...makeActivationRequest({ candidate_id: candidate.candidate_id }),
+        action: 'deactivate',
+        expected_candidate_status: 'activated',
+      },
+      activationPolicy: policy,
+      arcforgeRoot,
+    });
+
+    expect(deactResult.ok).toBe(true);
+    const summary = deactResult.activeArtifacts[0].active_path_summary;
+    expect(summary).toMatch(/^instincts\/[a-f0-9]{12}\.md$/);
+    expect(summary).not.toContain('proj-abc123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion #3 — deactivate() requires reviewer_ack (PR-B Layer 8 Blocker #3)
+// ---------------------------------------------------------------------------
+
+describe('deactivate — reviewer_ack enforcement', () => {
+  function runActivate() {
+    const { candidate, materializationRecord, arcforgeRoot } = runMaterialize();
+    const policy = defaultActivationPolicy(arcforgeRoot);
+    const actResult = activate({
+      candidate,
+      materializationRecord,
+      activationRequest: makeActivationRequest({ candidate_id: candidate.candidate_id }),
+      activationPolicy: policy,
+      arcforgeRoot,
+    });
+    expect(actResult.ok).toBe(true);
+    return {
+      activatedCandidate: {
+        ...candidate,
+        lifecycle: { status: 'activated', status_changed_at: 'x' },
+      },
+      activationRecord: actResult.record,
+      arcforgeRoot,
+      policy,
+    };
+  }
+
+  it('rejects deactivation when reviewer_ack is missing', () => {
+    const { activatedCandidate, activationRecord, arcforgeRoot, policy } = runActivate();
+    const req = {
+      ...makeActivationRequest({ candidate_id: activatedCandidate.candidate_id }),
+      action: 'deactivate',
+      expected_candidate_status: 'activated',
+    };
+    delete req.reviewer_ack;
+
+    const result = deactivate({
+      candidate: activatedCandidate,
+      activationRecord,
+      activationRequest: req,
+      activationPolicy: policy,
+      arcforgeRoot,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failure.reason).toBe('missing_reviewer_ack');
+  });
+
+  it('rejects deactivation when confirmed_behavior_change is false', () => {
+    const { activatedCandidate, activationRecord, arcforgeRoot, policy } = runActivate();
+    const req = {
+      ...makeActivationRequest({ candidate_id: activatedCandidate.candidate_id }),
+      action: 'deactivate',
+      expected_candidate_status: 'activated',
+      reviewer_ack: { confirmed_behavior_change: false, saw_target_summary: true },
+    };
+
+    const result = deactivate({
+      candidate: activatedCandidate,
+      activationRecord,
+      activationRequest: req,
+      activationPolicy: policy,
+      arcforgeRoot,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failure.reason).toBe('missing_reviewer_ack');
+  });
+
+  it('succeeds deactivation when reviewer_ack.confirmed_behavior_change is true', () => {
+    const { activatedCandidate, activationRecord, arcforgeRoot, policy } = runActivate();
+    const req = {
+      ...makeActivationRequest({ candidate_id: activatedCandidate.candidate_id }),
+      action: 'deactivate',
+      expected_candidate_status: 'activated',
+      reviewer_ack: { confirmed_behavior_change: true, saw_target_summary: true },
+    };
+
+    const result = deactivate({
+      candidate: activatedCandidate,
+      activationRecord,
+      activationRequest: req,
+      activationPolicy: policy,
+      arcforgeRoot,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/scripts/learning-curator-proposal-ingestor.test.js
+++ b/tests/scripts/learning-curator-proposal-ingestor.test.js
@@ -464,3 +464,96 @@ describe('ingestProposal — missing batch manifest', () => {
     ).toThrow(/batch manifest not found/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Criterion #2 — evidence_ref_omitted_upstream (PR-B Layer 5 Blocker #2)
+// ---------------------------------------------------------------------------
+
+describe('ingestProposal — evidence_ref_omitted_upstream', () => {
+  test('rejects proposal when evidence_id is in batch but has evidence_status != present', () => {
+    const { ingestProposal } = getIngestor();
+    const { manifest, batchId } = makeBatchManifest({
+      evidence_ids: ['ev_001', 'ev_002', 'ev_omitted'],
+      evidence_status_by_id: {
+        ev_001: 'present',
+        ev_002: 'present',
+        ev_omitted: 'omitted_sanitizer_policy',
+      },
+    });
+
+    const payload = {
+      schema_version: 1,
+      source: {
+        layer: 4,
+        curator: 'llm',
+        run_id: 'curator_run_20260521T010000Z_testomit01',
+        created_at: '2026-05-21T01:00:00.000Z',
+        batch_id: batchId,
+        batch_hash: manifest.batch_hash,
+        prompt_policy_version: 'v1',
+        output_schema_version: 1,
+      },
+      proposals: [
+        {
+          proposal_index: 0,
+          artifact_type: 'instinct',
+          proposed_scope: { kind: 'project', project_id: 'proj_abc123456789ab' },
+          name: 'grep-before-edit',
+          summary: 'Always use grep before editing.',
+          rationale: 'Observed pattern.',
+          domain: 'workflow',
+          body: 'Use grep first.',
+          body_source: 'llm_curator',
+          evidence_refs: [
+            {
+              evidence_id: 'ev_001',
+              evidence_type: 'observation',
+              relevance: 'direct',
+            },
+            {
+              evidence_id: 'ev_omitted',
+              evidence_type: 'observation',
+              relevance: 'indirect',
+            },
+          ],
+          llm_confidence: 'medium',
+          risk_notes: [],
+          uncertainty_notes: [],
+          recommended_review_action: 'review',
+        },
+      ],
+    };
+
+    const responsePath = makeResponseFile(payload);
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.accepted).toBe(0);
+    expect(result.rejected).toBeGreaterThanOrEqual(1);
+
+    const rejections = readRejections();
+    expect(rejections.length).toBeGreaterThanOrEqual(1);
+    const rejection = rejections[0];
+    expect(rejection.reasons.some((r) => r.code === 'evidence_ref_omitted_upstream')).toBe(true);
+    const omitReason = rejection.reasons.find((r) => r.code === 'evidence_ref_omitted_upstream');
+    expect(omitReason.detail).toMatch(/ev_omitted/);
+    expect(omitReason.detail).toMatch(/omitted_sanitizer_policy/);
+  });
+
+  test('accepts proposal when all evidence_ids have evidence_status "present"', () => {
+    const { ingestProposal } = getIngestor();
+    const { manifest, batchId } = makeBatchManifest({
+      evidence_ids: ['ev_001', 'ev_002'],
+      evidence_status_by_id: {
+        ev_001: 'present',
+        ev_002: 'present',
+      },
+    });
+
+    const payload = makeValidProposalPayload(batchId, manifest.batch_hash);
+    const responsePath = makeResponseFile(payload);
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.accepted).toBe(1);
+    expect(result.rejected).toBe(0);
+  });
+});

--- a/tests/scripts/learning-curator-schema.test.js
+++ b/tests/scripts/learning-curator-schema.test.js
@@ -3,6 +3,7 @@
 const {
   validateCandidateV1,
   REJECTION_CODES,
+  VALIDATOR_VERSION,
 } = require('../../scripts/lib/learning-curator/schema');
 
 // ---------------------------------------------------------------------------
@@ -492,5 +493,99 @@ describe('validateCandidateV1 — rejection reason codes', () => {
     const r = makeRecord({ artifact_type: 'unknown' });
     const res = validateCandidateV1(r);
     expect(res.reasons.some((r) => r.code === 'schema_invalid')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion #1 — Full safety metadata required (PR-B Layer 5 Blocker #1)
+// ---------------------------------------------------------------------------
+
+describe('VALIDATOR_VERSION export', () => {
+  it('VALIDATOR_VERSION is exported as a non-empty string', () => {
+    expect(typeof VALIDATOR_VERSION).toBe('string');
+    expect(VALIDATOR_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it('VALIDATOR_VERSION equals "v1"', () => {
+    expect(VALIDATOR_VERSION).toBe('v1');
+  });
+});
+
+describe('validateCandidateV1 — full safety metadata required', () => {
+  it('accepts a record with all required safety fields present', () => {
+    const r = makeRecord();
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('rejects when safety.validator_version is missing', () => {
+    const r = makeRecord();
+    delete r.safety.validator_version;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.field_path === 'safety.validator_version')).toBe(true);
+  });
+
+  it('rejects when safety.sanitizer_policy_version is missing', () => {
+    const r = makeRecord();
+    delete r.safety.sanitizer_policy_version;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.field_path === 'safety.sanitizer_policy_version')).toBe(true);
+  });
+
+  it('rejects when safety.sanitizer_module is missing', () => {
+    const r = makeRecord();
+    delete r.safety.sanitizer_module;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.field_path === 'safety.sanitizer_module')).toBe(true);
+  });
+
+  it('rejects when safety.secret_scan is missing', () => {
+    const r = makeRecord();
+    delete r.safety.secret_scan;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.field_path === 'safety.secret_scan')).toBe(true);
+  });
+
+  it('rejects when safety.activation_claim_scan is missing', () => {
+    const r = makeRecord();
+    delete r.safety.activation_claim_scan;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.field_path === 'safety.activation_claim_scan')).toBe(true);
+  });
+
+  it('rejects when safety.file_write_claim_scan is missing', () => {
+    const r = makeRecord();
+    delete r.safety.file_write_claim_scan;
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.field_path === 'safety.file_write_claim_scan')).toBe(true);
+  });
+
+  it('rejects when safety.secret_scan.status is not "passed"', () => {
+    const r = makeRecord();
+    r.safety.secret_scan = { status: 'rejected', rule_version: 'v1' };
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.code === 'secret_reconstruction')).toBe(true);
+  });
+
+  it('rejects when safety.activation_claim_scan.status is not "passed"', () => {
+    const r = makeRecord();
+    r.safety.activation_claim_scan = { status: 'rejected' };
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.code === 'activation_claim')).toBe(true);
+  });
+
+  it('rejects when safety.file_write_claim_scan.status is not "passed"', () => {
+    const r = makeRecord();
+    r.safety.file_write_claim_scan = { status: 'rejected' };
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.some((x) => x.code === 'file_write_claim')).toBe(true);
   });
 });

--- a/tests/scripts/learning-dashboard.test.js
+++ b/tests/scripts/learning-dashboard.test.js
@@ -50,12 +50,18 @@ function makeCandidateRecord(overrides = {}) {
       status_changed_at: '2026-05-01T00:00:00Z',
     },
     safety: {
+      validator_version: 'v1',
+      sanitizer_policy_version: 'v1',
+      sanitizer_module: 'scripts/lib/sanitize-observation.js',
       raw_prompt_included: false,
       raw_response_included: false,
       raw_hook_payloads_included: false,
       raw_transcripts_included: false,
       edit_bodies_included: false,
       skill_args_included: false,
+      secret_scan: { status: 'passed', rule_version: 'v1' },
+      activation_claim_scan: { status: 'passed' },
+      file_write_claim_scan: { status: 'passed' },
     },
     dedupe: {
       dedupe_key: 'use-edit-bash-workflow-v1',


### PR DESCRIPTION
## Summary

PR-B of the 2026-05-22 spec realignment plan. Closes 3 audit blockers + 2 drifts (safety + privacy class). Builds on PR-A (#47) which codified the spec rules; this PR implements them.

## Changes

**Layer 5 Blocker #1 — Full CandidateSafetyMetadata**
- `schema.js`: Exported `VALIDATOR_VERSION = 'v1'`. `validateCandidateV1` now requires \`validator_version\` / \`sanitizer_policy_version\` / \`sanitizer_module\` / \`secret_scan{status, rule_version}\` / \`activation_claim_scan{status}\` / \`file_write_claim_scan{status}\`.
- \`proposal-ingestor.js\`: writes full safety block on accept.

**Layer 5 Blocker #2 — evidence_ref_omitted_upstream emission**
- \`batch-assembler.js\`: persists \`evidence_status_by_id\` map in manifest.
- \`proposal-ingestor.js\`: rejects proposals citing evidence with upstream \`evidence_status != 'present'\`. Detail string reports the upstream omission reason.

**Layer 8 Blocker #3 — deactivate() reviewer_ack**
- \`activate.js\`: extracted \`verifyReviewerAck()\` helper. Both activate and deactivate paths now enforce \`confirmed_behavior_change: true\`.

**Layer 8 active_path_summary redaction**
- \`activate.js\`: \`summarizeActivePath(activePathHash)\` returns \`instincts/<sha256[:12]>.md\` — no project_id. Takes the already-computed hash so we don't hash the same path twice (simplify follow-up b96debf).

**Layer 0 env guards**
- \`hooks/observe/main.js\`: \`shouldObserve()\` returns false when \`ARCFORGE_OBSERVE_EXPLICIT_SKIP=1\` or \`ARCFORGE_OBSERVE_SELF_ANALYSIS=1\`. Reads at call time, not module load (test-friendly).

## Tests added

- \`learning-curator-schema.test.js\`: 11 new (2 for VALIDATOR_VERSION export, 9 for safety metadata validation positive/negative).
- \`learning-curator-proposal-ingestor.test.js\`: 2 new (evidence_ref_omitted_upstream emission with detail).
- \`learning-curator-activate.test.js\`: 5 new (3 deactivate ack enforcement, 2 redaction shape).
- \`hooks/__tests__/observe.test.js\`: 6 new (3 EXPLICIT_SKIP, 3 SELF_ANALYSIS).
- \`learning-dashboard.test.js\`: fixture updated to include full safety block (conformance update — same updates needed in any test that constructs candidates after this PR).

## Test plan

- [x] \`npm run test:scripts\` — 1766 passed, 0 failed
- [x] \`npm run test:hooks\` — 213 passed, 0 failed
- [x] \`npm run test:node\` — all passed
- [x] \`npm run test:skills\` — 546 passed, 12 pre-existing failures (orphan \`test_optional_learning_release_eval.py\`, deleted by PR #46)
- [x] \`npm run lint\` — clean
- [x] Round-trip activate → deactivate test passes

## Risk

Medium. Persistence shape change for Candidate v1's safety block — any candidate written before this PR will still pass schema validation today (existing queue files are already on v1) BUT if someone hand-edits a candidate or constructs one in code without the new safety fields, the validator will now reject. This is the intended behavior — the audit blocker is closed precisely by making these fields required.

## Follow-up PRs

- PR-C: Layer 3 typed evidence (diary/reflect/recall) + Layer 5 dedupe canonical shape
- PR-D: Layer 6 dashboard upgrade

Per the parent plan at \`/Users/gregho/.claude/plans/read-documents-below-docs-plans-2026-05-spicy-conway.md\`.

Stacked on PR #46 (orphan pytest deletion) — once #46 merges, the 12 pre-existing pytest failures clear and \`npm test\` shows fully green.