### PR TITLE
feat(learning): PR-C — Layer 3 typed evidence + dedupe canonical shape + operation records

### DIFF
--- a/scripts/lib/learning-curator/batch-assembler.js
+++ b/scripts/lib/learning-curator/batch-assembler.js
@@ -32,6 +32,8 @@ const { atomicWriteFile, sha256Truncated } = require('../utils');
 // Per Section 4 Slice E + Layer 3 open question #2: first-slice bounds
 const MAX_OBSERVATIONS = 200;
 const MAX_DIARIES = 5;
+const MAX_REFLECTS = 10;
+const MAX_RECALLS = 10;
 const MAX_CHARS_PER_ITEM = 1000;
 const MAX_CHARS_TOTAL = 100000;
 const SELECTION_POLICY_VERSION = 'v1';
@@ -50,6 +52,14 @@ function getObsDir(homeDir) {
 
 function getDiariesDir(homeDir) {
   return path.join(getArcforgeDir(homeDir), 'diaries');
+}
+
+function getReflectionsDir(homeDir) {
+  return path.join(getArcforgeDir(homeDir), 'reflections');
+}
+
+function getRecallsDir(homeDir) {
+  return path.join(getArcforgeDir(homeDir), 'recalls');
 }
 
 function getBatchesDir(homeDir) {
@@ -89,58 +99,171 @@ function readObservations(homeDir, project) {
 }
 
 // ---------------------------------------------------------------------------
-// Read recent diaries (at most MAX_DIARIES)
+// Walk a directory recursively, collecting files matching a name pattern.
+// Returns { path, mtime } sorted by mtime descending.
 // ---------------------------------------------------------------------------
 
-function readRecentDiaries(homeDir, project) {
-  const diaryDir = path.join(getDiariesDir(homeDir), project);
-  if (!fs.existsSync(diaryDir)) return [];
-
-  // Collect all diary-*.md files recursively under diaryDir
-  const diaryFiles = [];
-  function walk(dir) {
+function walkFilesByMtime(dir, namePattern) {
+  const files = [];
+  function walk(d) {
     let entries;
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      entries = fs.readdirSync(d, { withFileTypes: true });
     } catch {
       return;
     }
     for (const entry of entries) {
-      const full = path.join(dir, entry.name);
+      const full = path.join(d, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (entry.isFile() && /^diary-.*\.md$/.test(entry.name)) {
-        diaryFiles.push(full);
+      } else if (entry.isFile() && namePattern.test(entry.name)) {
+        let mtime = 0;
+        try {
+          mtime = fs.statSync(full).mtimeMs;
+        } catch {
+          // unreadable; sort to the end
+        }
+        files.push({ path: full, mtime });
       }
     }
   }
-  walk(diaryDir);
+  walk(dir);
+  files.sort((a, b) => b.mtime - a.mtime);
+  return files;
+}
 
-  // Precompute mtime once per file — sort comparator would otherwise call
-  // statSync O(N log N) times. Files we can't stat fall through to mtime=0.
-  const withMtime = diaryFiles.map((p) => {
-    let mtime = 0;
-    try {
-      mtime = fs.statSync(p).mtimeMs;
-    } catch {
-      // unreadable; sort to the end
-    }
-    return { path: p, mtime };
-  });
-  withMtime.sort((a, b) => b.mtime - a.mtime);
-  const selected = withMtime.slice(0, MAX_DIARIES).map((x) => x.path);
+// ---------------------------------------------------------------------------
+// Read recent diaries (at most MAX_DIARIES) → DiaryEvidenceItem[]
+// ---------------------------------------------------------------------------
 
-  // Read content (sanitized)
-  const entries = [];
-  for (const filePath of selected) {
+function readRecentDiaries(homeDir, project) {
+  const diaryDir = path.join(getDiariesDir(homeDir), project);
+  if (!fs.existsSync(diaryDir)) return { items: [], scanned: 0, selected: 0 };
+
+  const allFiles = walkFilesByMtime(diaryDir, /^diary-.*\.md$/);
+  const scanned = allFiles.length;
+  const selected = allFiles.slice(0, MAX_DIARIES);
+
+  const items = [];
+  for (const { path: filePath } of selected) {
     try {
       const raw = fs.readFileSync(filePath, 'utf8');
-      entries.push(sanitizeObservationPayload(raw, 2000));
+      const sanitized = sanitizeObservationPayload(raw, 2000);
+
+      // Derive diary_id from filename (e.g. diary-abc123.md → diary-abc123)
+      const diaryId = path.basename(filePath, '.md');
+      const evidenceId = `evd-diary-${sha256Truncated(filePath, 12)}`;
+
+      items.push({
+        evidence_id: evidenceId,
+        evidence_type: 'diary',
+        diary_id: diaryId,
+        project,
+        project_id: '',
+        created_at: '',
+        summary: sanitized,
+        source_ref: {
+          store: 'diary',
+          path_hash: sha256Truncated(filePath, 16),
+          content_hash: sha256Truncated(raw, 16),
+        },
+      });
     } catch {
       // skip unreadable files
     }
   }
-  return entries;
+
+  return { items, scanned, selected: items.length };
+}
+
+// ---------------------------------------------------------------------------
+// Read recent reflections (at most MAX_REFLECTS) → ReflectEvidenceItem[]
+// ---------------------------------------------------------------------------
+
+function readRecentReflects(homeDir, project) {
+  const reflDir = path.join(getReflectionsDir(homeDir), project);
+  if (!fs.existsSync(reflDir)) return { items: [], scanned: 0, selected: 0 };
+
+  const allFiles = walkFilesByMtime(reflDir, /^reflect-.*\.md$/);
+  const scanned = allFiles.length;
+  const selected = allFiles.slice(0, MAX_REFLECTS);
+
+  const items = [];
+  for (const { path: filePath } of selected) {
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const sanitized = sanitizeObservationPayload(raw, 2000);
+
+      // Parse reflect_id from frontmatter or filename
+      const reflectId = path.basename(filePath, '.md');
+      const evidenceId = `evd-reflect-${sha256Truncated(filePath, 12)}`;
+
+      items.push({
+        evidence_id: evidenceId,
+        evidence_type: 'reflect',
+        reflect_id: reflectId,
+        project,
+        project_id: '',
+        created_at: '',
+        pattern_summary: sanitized,
+        supporting_sessions: [],
+        support_count: 0,
+        source_ref: {
+          store: 'reflect',
+          path_hash: sha256Truncated(filePath, 16),
+          content_hash: sha256Truncated(raw, 16),
+        },
+      });
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  return { items, scanned, selected: items.length };
+}
+
+// ---------------------------------------------------------------------------
+// Read recent recalls (at most MAX_RECALLS) → RecallEvidenceItem[]
+// ---------------------------------------------------------------------------
+
+function readRecentRecalls(homeDir, project) {
+  const recallDir = path.join(getRecallsDir(homeDir), project);
+  if (!fs.existsSync(recallDir)) return { items: [], scanned: 0, selected: 0 };
+
+  const allFiles = walkFilesByMtime(recallDir, /^recall-.*\.md$/);
+  const scanned = allFiles.length;
+  const selected = allFiles.slice(0, MAX_RECALLS);
+
+  const items = [];
+  for (const { path: filePath } of selected) {
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const sanitized = sanitizeObservationPayload(raw, 2000);
+
+      const recallId = path.basename(filePath, '.md');
+      const evidenceId = `evd-recall-${sha256Truncated(filePath, 12)}`;
+
+      items.push({
+        evidence_id: evidenceId,
+        evidence_type: 'recall',
+        recall_id: recallId,
+        project,
+        project_id: '',
+        created_at: '',
+        user_authored: true,
+        summary: sanitized,
+        source_ref: {
+          store: 'recall',
+          path_hash: sha256Truncated(filePath, 16),
+          content_hash: sha256Truncated(raw, 16),
+        },
+      });
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  return { items, scanned, selected: items.length };
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +392,7 @@ function buildAggregateContext(evidenceItems) {
 // Prompt template rendering
 // ---------------------------------------------------------------------------
 
-function renderPrompt({ projectName, batchId, batchHash, evidenceItems, diaryEntries }) {
+function renderPrompt({ projectName, batchId, batchHash, evidenceItems, diaryItems }) {
   const promptTemplatePath = path.join(
     __dirname,
     '../../../skills/arc-observing/scripts/observer-prompt.md',
@@ -303,10 +426,15 @@ function renderPrompt({ projectName, batchId, batchHash, evidenceItems, diaryEnt
     })
     .join('\n\n---\n\n');
 
-  // Build diary section
+  // Build diary section from DiaryEvidenceItem[]
   let diarySection;
-  if (diaryEntries.length > 0) {
-    diarySection = diaryEntries.map((d, i) => `### Diary ${i + 1}\n\n${d}`).join('\n\n');
+  if (diaryItems.length > 0) {
+    diarySection = diaryItems
+      .map((item, i) => {
+        const body = item.summary || '';
+        return `### Diary ${i + 1} (${item.evidence_id})\n\n${body}`;
+      })
+      .join('\n\n');
   } else {
     diarySection = 'None';
   }
@@ -371,14 +499,31 @@ function assembleBatch({ project, homeDir: homeOverride } = {}) {
   const allObs = readObservations(homeDir, project);
   const projectId = deriveProjectId(allObs, project);
   const {
-    items: evidenceItems,
+    items: obsItems,
     scanned,
     selected,
     omissions,
   } = buildEvidenceItems(allObs, project, projectId);
 
-  // Read diary context
-  const diaryEntries = readRecentDiaries(homeDir, project);
+  // Read diary, reflect, recall evidence
+  const {
+    items: diaryItems,
+    scanned: diaryScanned,
+    selected: diarySelected,
+  } = readRecentDiaries(homeDir, project);
+  const {
+    items: reflectItems,
+    scanned: reflectScanned,
+    selected: reflectSelected,
+  } = readRecentReflects(homeDir, project);
+  const {
+    items: recallItems,
+    scanned: recallScanned,
+    selected: recallSelected,
+  } = readRecentRecalls(homeDir, project);
+
+  // Merge all evidence items: observations first, then diary/reflect/recall
+  const evidenceItems = [...obsItems, ...diaryItems, ...reflectItems, ...recallItems];
 
   // Compute batch_id components
   const idTimestamp = compactUtc(now);
@@ -388,28 +533,28 @@ function assembleBatch({ project, homeDir: homeOverride } = {}) {
   const batchId = `batch_${idTimestamp}_${batchIdHash}`;
 
   // Aggregate context
-  const aggregateContext = buildAggregateContext(evidenceItems);
+  const aggregateContext = buildAggregateContext(obsItems);
 
   // Quality inputs (v1 formula: project_obs_count only)
   const qualityInputs = {
     project_observation_count: allObs.length,
     selected_evidence_count: evidenceItems.length,
     selected_by_type: {
-      observation: evidenceItems.filter((e) => e.evidence_type === 'observation').length,
-      diary: 0,
-      reflect: 0,
-      recall: 0,
+      observation: obsItems.length,
+      diary: diaryItems.length,
+      reflect: reflectItems.length,
+      recall: recallItems.length,
       session_summary: 0,
     },
     session_span: {
       session_count: aggregateContext.session_count,
-      first_ts: evidenceItems.length > 0 ? evidenceItems[0].ts : undefined,
-      last_ts: evidenceItems.length > 0 ? evidenceItems[evidenceItems.length - 1].ts : undefined,
+      first_ts: obsItems.length > 0 ? obsItems[0].ts : undefined,
+      last_ts: obsItems.length > 0 ? obsItems[obsItems.length - 1].ts : undefined,
     },
     signal_mix: {
       has_user_correction: false,
-      has_manual_recall: false,
-      has_reflect_pattern: false,
+      has_manual_recall: recallItems.length > 0,
+      has_reflect_pattern: reflectItems.length > 0,
       has_error_repair_sequence: false,
       has_repeated_observation_sequence: false,
     },
@@ -448,7 +593,7 @@ function assembleBatch({ project, homeDir: homeOverride } = {}) {
     batchId,
     batchHash,
     evidenceItems,
-    diaryEntries,
+    diaryItems,
   });
 
   // Persist manifest and prompt
@@ -462,8 +607,8 @@ function assembleBatch({ project, homeDir: homeOverride } = {}) {
     policy_version: SELECTION_POLICY_VERSION,
     max_observations: MAX_OBSERVATIONS,
     max_diaries: MAX_DIARIES,
-    max_reflections: 0,
-    max_recalls: 0,
+    max_reflections: MAX_REFLECTS,
+    max_recalls: MAX_RECALLS,
     max_transcript_summaries: 0,
     ordering: 'chronological',
     selection_rules: ['recent'],
@@ -483,6 +628,18 @@ function assembleBatch({ project, homeDir: homeOverride } = {}) {
         records_scanned: scanned,
         records_selected: selected,
         records_omitted: scanned - selected,
+      },
+      diaries: {
+        records_scanned: diaryScanned,
+        records_selected: diarySelected,
+      },
+      reflects: {
+        records_scanned: reflectScanned,
+        records_selected: reflectSelected,
+      },
+      recalls: {
+        records_scanned: recallScanned,
+        records_selected: recallSelected,
       },
       transcript_summaries: {
         available: false,

--- a/scripts/lib/learning-curator/batch-assembler.js
+++ b/scripts/lib/learning-curator/batch-assembler.js
@@ -133,37 +133,75 @@ function walkFilesByMtime(dir, namePattern) {
 }
 
 // ---------------------------------------------------------------------------
-// Read recent diaries (at most MAX_DIARIES) → DiaryEvidenceItem[]
+// Read recent typed-evidence files (diary / reflect / recall)
 // ---------------------------------------------------------------------------
 
-function readRecentDiaries(homeDir, project) {
-  const diaryDir = path.join(getDiariesDir(homeDir), project);
-  if (!fs.existsSync(diaryDir)) return { items: [], scanned: 0, selected: 0 };
+// Per-kind config: dir resolver, filename regex, max-count, ID field name on the item,
+// and a builder for the kind-specific extra fields. Shared shape across all three is
+// applied in readRecentEvidence below.
+//
+// Note: evidence_id is derived from filePath (sha256[:12]). It's stable across runs
+// for the same file, but not content-addressed — content rename = same id. Content
+// identity is captured separately by source_ref.content_hash.
+const EVIDENCE_KIND_CONFIG = {
+  diary: {
+    getDir: getDiariesDir,
+    pattern: /^diary-.*\.md$/,
+    maxN: () => MAX_DIARIES,
+    idField: 'diary_id',
+    store: 'diary',
+    buildExtra: (sanitized) => ({ summary: sanitized }),
+  },
+  reflect: {
+    getDir: getReflectionsDir,
+    pattern: /^reflect-.*\.md$/,
+    maxN: () => MAX_REFLECTS,
+    idField: 'reflect_id',
+    store: 'reflect',
+    buildExtra: (sanitized) => ({
+      pattern_summary: sanitized,
+      supporting_sessions: [],
+      support_count: 0,
+    }),
+  },
+  recall: {
+    getDir: getRecallsDir,
+    pattern: /^recall-.*\.md$/,
+    maxN: () => MAX_RECALLS,
+    idField: 'recall_id',
+    store: 'recall',
+    buildExtra: (sanitized) => ({ user_authored: true, summary: sanitized }),
+  },
+};
 
-  const allFiles = walkFilesByMtime(diaryDir, /^diary-.*\.md$/);
+function readRecentEvidence(kind, homeDir, project) {
+  const cfg = EVIDENCE_KIND_CONFIG[kind];
+  if (!cfg) throw new Error(`readRecentEvidence: unknown kind "${kind}"`);
+
+  const dir = path.join(cfg.getDir(homeDir), project);
+  if (!fs.existsSync(dir)) return { items: [], scanned: 0, selected: 0 };
+
+  const allFiles = walkFilesByMtime(dir, cfg.pattern);
   const scanned = allFiles.length;
-  const selected = allFiles.slice(0, MAX_DIARIES);
+  const selected = allFiles.slice(0, cfg.maxN());
 
   const items = [];
   for (const { path: filePath } of selected) {
     try {
       const raw = fs.readFileSync(filePath, 'utf8');
       const sanitized = sanitizeObservationPayload(raw, 2000);
-
-      // Derive diary_id from filename (e.g. diary-abc123.md → diary-abc123)
-      const diaryId = path.basename(filePath, '.md');
-      const evidenceId = `evd-diary-${sha256Truncated(filePath, 12)}`;
+      const itemId = path.basename(filePath, '.md');
 
       items.push({
-        evidence_id: evidenceId,
-        evidence_type: 'diary',
-        diary_id: diaryId,
+        evidence_id: `evd-${kind}-${sha256Truncated(filePath, 12)}`,
+        evidence_type: kind,
+        [cfg.idField]: itemId,
         project,
         project_id: '',
         created_at: '',
-        summary: sanitized,
+        ...cfg.buildExtra(sanitized),
         source_ref: {
-          store: 'diary',
+          store: cfg.store,
           path_hash: sha256Truncated(filePath, 16),
           content_hash: sha256Truncated(raw, 16),
         },
@@ -176,95 +214,9 @@ function readRecentDiaries(homeDir, project) {
   return { items, scanned, selected: items.length };
 }
 
-// ---------------------------------------------------------------------------
-// Read recent reflections (at most MAX_REFLECTS) → ReflectEvidenceItem[]
-// ---------------------------------------------------------------------------
-
-function readRecentReflects(homeDir, project) {
-  const reflDir = path.join(getReflectionsDir(homeDir), project);
-  if (!fs.existsSync(reflDir)) return { items: [], scanned: 0, selected: 0 };
-
-  const allFiles = walkFilesByMtime(reflDir, /^reflect-.*\.md$/);
-  const scanned = allFiles.length;
-  const selected = allFiles.slice(0, MAX_REFLECTS);
-
-  const items = [];
-  for (const { path: filePath } of selected) {
-    try {
-      const raw = fs.readFileSync(filePath, 'utf8');
-      const sanitized = sanitizeObservationPayload(raw, 2000);
-
-      // Parse reflect_id from frontmatter or filename
-      const reflectId = path.basename(filePath, '.md');
-      const evidenceId = `evd-reflect-${sha256Truncated(filePath, 12)}`;
-
-      items.push({
-        evidence_id: evidenceId,
-        evidence_type: 'reflect',
-        reflect_id: reflectId,
-        project,
-        project_id: '',
-        created_at: '',
-        pattern_summary: sanitized,
-        supporting_sessions: [],
-        support_count: 0,
-        source_ref: {
-          store: 'reflect',
-          path_hash: sha256Truncated(filePath, 16),
-          content_hash: sha256Truncated(raw, 16),
-        },
-      });
-    } catch {
-      // skip unreadable files
-    }
-  }
-
-  return { items, scanned, selected: items.length };
-}
-
-// ---------------------------------------------------------------------------
-// Read recent recalls (at most MAX_RECALLS) → RecallEvidenceItem[]
-// ---------------------------------------------------------------------------
-
-function readRecentRecalls(homeDir, project) {
-  const recallDir = path.join(getRecallsDir(homeDir), project);
-  if (!fs.existsSync(recallDir)) return { items: [], scanned: 0, selected: 0 };
-
-  const allFiles = walkFilesByMtime(recallDir, /^recall-.*\.md$/);
-  const scanned = allFiles.length;
-  const selected = allFiles.slice(0, MAX_RECALLS);
-
-  const items = [];
-  for (const { path: filePath } of selected) {
-    try {
-      const raw = fs.readFileSync(filePath, 'utf8');
-      const sanitized = sanitizeObservationPayload(raw, 2000);
-
-      const recallId = path.basename(filePath, '.md');
-      const evidenceId = `evd-recall-${sha256Truncated(filePath, 12)}`;
-
-      items.push({
-        evidence_id: evidenceId,
-        evidence_type: 'recall',
-        recall_id: recallId,
-        project,
-        project_id: '',
-        created_at: '',
-        user_authored: true,
-        summary: sanitized,
-        source_ref: {
-          store: 'recall',
-          path_hash: sha256Truncated(filePath, 16),
-          content_hash: sha256Truncated(raw, 16),
-        },
-      });
-    } catch {
-      // skip unreadable files
-    }
-  }
-
-  return { items, scanned, selected: items.length };
-}
+const readRecentDiaries = (homeDir, project) => readRecentEvidence('diary', homeDir, project);
+const readRecentReflects = (homeDir, project) => readRecentEvidence('reflect', homeDir, project);
+const readRecentRecalls = (homeDir, project) => readRecentEvidence('recall', homeDir, project);
 
 // ---------------------------------------------------------------------------
 // Build evidence items from observation records

--- a/scripts/lib/learning-curator/lifecycle.js
+++ b/scripts/lib/learning-curator/lifecycle.js
@@ -42,6 +42,21 @@ const LIFECYCLE_STATUS = Object.freeze({
 
 const LIFECYCLE_STATUSES = Object.freeze(Object.values(LIFECYCLE_STATUS));
 
+// Statuses a NEW candidate may be created with (insertion-time, not from an action transition).
+// `pending_review` is the default for fresh proposals; `superseded` is reserved for the
+// "we ingested a duplicate of an existing candidate" path in proposal-ingestor — see spec
+// layer-5 line 583 ("If a candidate is replaced, use relationship metadata and, when
+// appropriate, the `superseded` lifecycle status."). All other statuses are reachable only
+// via applyTransition() from a prior status.
+const INSERTION_STATUSES = Object.freeze([
+  LIFECYCLE_STATUS.PENDING_REVIEW,
+  LIFECYCLE_STATUS.SUPERSEDED,
+]);
+
+function isLegalInsertionStatus(status) {
+  return INSERTION_STATUSES.includes(status);
+}
+
 // Canonical action set (Layer 5 spec — Action × Status matrix columns).
 // DEACTIVATE added in Slice G (Layer 8 extension).
 const LIFECYCLE_ACTION = Object.freeze({
@@ -135,8 +150,10 @@ function applyTransition(currentStatus, action) {
 module.exports = {
   isLegalAction,
   applyTransition,
+  isLegalInsertionStatus,
   LIFECYCLE_STATUS,
   LIFECYCLE_STATUSES,
+  INSERTION_STATUSES,
   LIFECYCLE_ACTION,
   ACTIONS,
   MATRIX,

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -26,8 +26,12 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
-const { appendCandidate, rejectProposal } = require('./queue-writer');
-const { computeEvidenceQuality, VALIDATOR_VERSION } = require('./schema');
+const { appendCandidate, rejectProposal, readCurrentCandidates } = require('./queue-writer');
+const {
+  computeEvidenceQuality,
+  VALIDATOR_VERSION,
+  EVIDENCE_QUALITY_RULE_VERSION,
+} = require('./schema');
 const { SANITIZER_POLICY_VERSION } = require('../sanitize-observation');
 const { atomicWriteFile, sha256Truncated } = require('../utils');
 
@@ -155,7 +159,7 @@ function buildCandidateRecord(proposal, batchManifest, now) {
     evidence,
     evidence_quality: evidenceQuality,
     evidence_quality_metadata: {
-      rule_version: SANITIZER_POLICY_VERSION,
+      rule_version: EVIDENCE_QUALITY_RULE_VERSION,
       basis: {
         project_obs_count: projectObsCount,
       },
@@ -178,17 +182,32 @@ function buildCandidateRecord(proposal, batchManifest, now) {
       activation_claim_scan: { status: 'passed' },
       file_write_claim_scan: { status: 'passed' },
     },
-    dedupe: {
-      dedupe_key: sha256Truncated(
-        `${scope.project_id}|${proposal.artifact_type}|${proposal.name}`,
-        16,
-      ),
-      dedupe_basis: {
-        artifact_type: proposal.artifact_type,
-        name: proposal.name,
-        scope_project_id: scope.project_id,
-      },
-    },
+  };
+
+  // Compute canonical dedupe_basis per Layer 5 spec (layer-5-candidate-queue-lifecycle.md)
+  const normalizedName = (proposal.name || '').toLowerCase().replace(/\s+/g, '-');
+  const normalizedTrigger =
+    typeof proposal.trigger === 'string' ? proposal.trigger.toLowerCase().trim() : undefined;
+  const normalizedBodyHash = sha256Truncated(proposal.body || '', 12);
+
+  const dedupeBasis = {
+    scope_kind: scope.kind,
+    artifact_type: proposal.artifact_type,
+    normalized_name: normalizedName,
+    normalized_body_hash: normalizedBodyHash,
+  };
+  if (scope.kind === 'project' && scope.project_id) {
+    dedupeBasis.project_id = scope.project_id;
+  }
+  if (normalizedTrigger !== undefined) {
+    dedupeBasis.normalized_trigger = normalizedTrigger;
+  }
+
+  const dedupeKey = sha256Truncated(JSON.stringify(dedupeBasis), 12);
+
+  record.dedupe = {
+    dedupe_key: dedupeKey,
+    dedupe_basis: dedupeBasis,
   };
 
   return record;
@@ -372,6 +391,25 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
   };
   const linesBefore = countQueueLines();
 
+  // Build a body-hash → candidate_id index from existing non-terminal candidates
+  // for superseded dedupe detection. Read once before the loop.
+  const existingByBodyHash = {};
+  const NON_TERMINAL_STATUSES = ['pending_review', 'needs_more_evidence'];
+  try {
+    const existingCandidates = readCurrentCandidates();
+    for (const [cid, c] of Object.entries(existingCandidates)) {
+      const status = c.lifecycle && c.lifecycle.status;
+      if (!NON_TERMINAL_STATUSES.includes(status)) continue;
+      const bodyHash =
+        c.dedupe && c.dedupe.dedupe_basis && c.dedupe.dedupe_basis.normalized_body_hash;
+      if (bodyHash) {
+        existingByBodyHash[bodyHash] = cid;
+      }
+    }
+  } catch {
+    // If queue is unreadable, skip dedup check — do not block ingestion
+  }
+
   // Process each proposal. Rejection paths (missing evidence refs, record-build
   // failure) write to rejections.jsonl; appendCandidate writes to queue.jsonl on
   // pass or rejections.jsonl on schema/safety fail. Counts computed from the
@@ -427,6 +465,27 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
         source,
       );
       continue;
+    }
+
+    // Check for semantic duplicate via normalized_body_hash.
+    // Per spec: if a matching non-terminal candidate exists, mark new candidate superseded.
+    const bodyHash =
+      record.dedupe &&
+      record.dedupe.dedupe_basis &&
+      record.dedupe.dedupe_basis.normalized_body_hash;
+    const existingCandidateId = bodyHash ? existingByBodyHash[bodyHash] : undefined;
+    if (existingCandidateId) {
+      record.lifecycle = {
+        status: 'superseded',
+        status_changed_at: now.toISOString(),
+      };
+      record.dedupe = {
+        ...record.dedupe,
+        duplicate_of: existingCandidateId,
+      };
+    } else if (bodyHash) {
+      // Register in local index so a second proposal in the same batch also dedupes
+      existingByBodyHash[bodyHash] = record.candidate_id;
     }
 
     appendCandidate(record);

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -32,6 +32,7 @@ const {
   VALIDATOR_VERSION,
   EVIDENCE_QUALITY_RULE_VERSION,
 } = require('./schema');
+const { isLegalInsertionStatus, LIFECYCLE_STATUS } = require('./lifecycle');
 const { SANITIZER_POLICY_VERSION } = require('../sanitize-observation');
 const { atomicWriteFile, sha256Truncated } = require('../utils');
 
@@ -398,10 +399,9 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
   try {
     const existingCandidates = readCurrentCandidates();
     for (const [cid, c] of Object.entries(existingCandidates)) {
-      const status = c.lifecycle && c.lifecycle.status;
+      const status = c.lifecycle?.status;
       if (!NON_TERMINAL_STATUSES.includes(status)) continue;
-      const bodyHash =
-        c.dedupe && c.dedupe.dedupe_basis && c.dedupe.dedupe_basis.normalized_body_hash;
+      const bodyHash = c.dedupe?.dedupe_basis?.normalized_body_hash;
       if (bodyHash) {
         existingByBodyHash[bodyHash] = cid;
       }
@@ -467,16 +467,20 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
       continue;
     }
 
-    // Check for semantic duplicate via normalized_body_hash.
-    // Per spec: if a matching non-terminal candidate exists, mark new candidate superseded.
-    const bodyHash =
-      record.dedupe &&
-      record.dedupe.dedupe_basis &&
-      record.dedupe.dedupe_basis.normalized_body_hash;
+    // Semantic dedupe via normalized_body_hash. Per Layer 5 spec line 583, when a
+    // duplicate is detected the NEW candidate is created with `superseded` status —
+    // this is an insertion-time status assignment, not an action transition through
+    // lifecycle.applyTransition. INSERTION_STATUSES gates this contract; any other
+    // status reached at insertion time is a bug.
+    const bodyHash = record.dedupe?.dedupe_basis?.normalized_body_hash;
     const existingCandidateId = bodyHash ? existingByBodyHash[bodyHash] : undefined;
     if (existingCandidateId) {
+      const supersededStatus = LIFECYCLE_STATUS.SUPERSEDED;
+      if (!isLegalInsertionStatus(supersededStatus)) {
+        throw new Error(`proposal-ingestor: "${supersededStatus}" is not a legal insertion status`);
+      }
       record.lifecycle = {
-        status: 'superseded',
+        status: supersededStatus,
         status_changed_at: now.toISOString(),
       };
       record.dedupe = {
@@ -484,7 +488,6 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
         duplicate_of: existingCandidateId,
       };
     } else if (bodyHash) {
-      // Register in local index so a second proposal in the same batch also dedupes
       existingByBodyHash[bodyHash] = record.candidate_id;
     }
 

--- a/scripts/lib/learning-curator/schema.js
+++ b/scripts/lib/learning-curator/schema.js
@@ -526,9 +526,18 @@ const REJECTION_CODES = Object.freeze([
   'policy_violation',
 ]);
 
+// ---------------------------------------------------------------------------
+// Evidence quality formula version (independent from sanitizer policy version)
+// ---------------------------------------------------------------------------
+
+// This version string identifies the evidence-quality FORMULA (project_obs_count).
+// It is NOT the same namespace as safety.sanitizer_policy_version.
+const EVIDENCE_QUALITY_RULE_VERSION = 'v1-project_obs_count';
+
 module.exports = {
   validateCandidateV1,
   computeEvidenceQuality,
   REJECTION_CODES,
   VALIDATOR_VERSION,
+  EVIDENCE_QUALITY_RULE_VERSION,
 };

--- a/scripts/lib/operation-record-writer.js
+++ b/scripts/lib/operation-record-writer.js
@@ -1,0 +1,165 @@
+/**
+ * operation-record-writer.js — Layer 3 operation record writer.
+ *
+ * Single helper for reflect/recall operation records. The records share
+ * structure (frontmatter + markdown body, atomic write to a per-project dir)
+ * and differ only in the field set the operation emits.
+ *
+ * Operation records are distinct from instinct files (instinct-writer.js):
+ * they track that a /reflect or /recall session happened, not the learned
+ * instincts themselves. Keeping the storage roots separate prevents
+ * provenance loops with Layer 8 activated instincts.
+ */
+
+const path = require('node:path');
+const os = require('node:os');
+
+const { atomicWriteFile } = require('./utils');
+
+// Map operation kind → directory name under ~/.arcforge/.
+// reflect → reflections (not "reflects") matches the spec storage path.
+const KIND_DIRS = { reflect: 'reflections', recall: 'recalls' };
+
+/**
+ * Serialize a YAML frontmatter list field, or emit `[]` when empty.
+ * Note: relies on existing project convention (hand-rolled YAML, not js-yaml).
+ * Callers should not pass values containing `\n` or unescaped `:` characters.
+ */
+function serializeListField(name, values) {
+  if (!Array.isArray(values) || values.length === 0) return `${name}: []`;
+  const items = values.map((v) => `  - ${v}`).join('\n');
+  return `${name}:\n${items}`;
+}
+
+/**
+ * Common writer used by saveReflectionRecord and saveRecallRecord.
+ * @param {object} opts
+ * @param {'reflect'|'recall'} opts.kind
+ * @param {string} opts.id
+ * @param {string} opts.project
+ * @param {string} opts.project_id
+ * @param {string} opts.session
+ * @param {string} opts.created_at
+ * @param {string} opts.source            — 'reflection' or 'manual'
+ * @param {string} opts.summary
+ * @param {Array<[string, string|string[]]>} opts.extraFields — kind-specific frontmatter
+ *        Each entry is [fieldName, value]. Arrays render as YAML lists; strings as scalars.
+ * @param {string} [opts.homeDir]         — test override
+ */
+function writeOperationRecord({
+  kind,
+  id,
+  project,
+  project_id,
+  session,
+  created_at,
+  source,
+  summary,
+  extraFields = [],
+  homeDir: homeOverride,
+}) {
+  if (typeof id !== 'string' || !id.trim()) {
+    throw new Error(`writeOperationRecord: id must be a non-empty string`);
+  }
+  if (typeof project !== 'string' || !project.trim()) {
+    throw new Error(`writeOperationRecord: project must be a non-empty string`);
+  }
+
+  const homeDir = homeOverride || os.homedir();
+  const dirName = KIND_DIRS[kind];
+  if (!dirName) throw new Error(`writeOperationRecord: unknown kind "${kind}"`);
+  const dir = path.join(homeDir, '.arcforge', dirName, project);
+  const filePath = path.join(dir, `${id}.md`);
+
+  const idFieldName = `${kind}_id`;
+  const titleVerb = kind === 'reflect' ? 'Reflection' : 'Recall';
+
+  const extraLines = extraFields.map(([name, value]) =>
+    Array.isArray(value) ? serializeListField(name, value) : `${name}: ${value ?? ''}`,
+  );
+
+  const content = [
+    '---',
+    `${idFieldName}: ${id}`,
+    `project: ${project}`,
+    `project_id: ${project_id || ''}`,
+    `session: ${session || ''}`,
+    `created_at: ${created_at || new Date().toISOString()}`,
+    `source: ${source}`,
+    ...extraLines,
+    '---',
+    '',
+    `# ${titleVerb}: ${id}`,
+    '',
+    summary || '',
+    '',
+  ].join('\n');
+
+  atomicWriteFile(filePath, content);
+}
+
+/**
+ * Write a reflection operation record to
+ * ~/.arcforge/reflections/<project>/<reflect_id>.md.
+ */
+function saveReflectionRecord({
+  reflect_id,
+  project,
+  project_id,
+  session,
+  created_at,
+  source_diary_ids,
+  summary,
+  homeDir,
+}) {
+  writeOperationRecord({
+    kind: 'reflect',
+    id: reflect_id,
+    project,
+    project_id,
+    session,
+    created_at,
+    source: 'reflection',
+    summary,
+    extraFields: [['source_diary_ids', source_diary_ids]],
+    homeDir,
+  });
+}
+
+/**
+ * Write a recall operation record to
+ * ~/.arcforge/recalls/<project>/<recall_id>.md.
+ */
+function saveRecallRecord({
+  recall_id,
+  project,
+  project_id,
+  session,
+  created_at,
+  recall_query,
+  returned_instinct_ids,
+  summary,
+  homeDir,
+}) {
+  writeOperationRecord({
+    kind: 'recall',
+    id: recall_id,
+    project,
+    project_id,
+    session,
+    created_at,
+    source: 'manual',
+    summary,
+    extraFields: [
+      ['recall_query', recall_query || ''],
+      ['returned_instinct_ids', returned_instinct_ids],
+    ],
+    homeDir,
+  });
+}
+
+module.exports = {
+  writeOperationRecord,
+  saveReflectionRecord,
+  saveRecallRecord,
+};

--- a/scripts/lib/recall-record-writer.js
+++ b/scripts/lib/recall-record-writer.js
@@ -1,0 +1,80 @@
+/**
+ * recall-record-writer.js — Layer 3 recall operation record writer.
+ *
+ * Exports:
+ *   saveRecallRecord(options) — write a recall operation record to
+ *     ~/.arcforge/recalls/<project>/<recall_id>.md
+ *
+ * Recall is a query operation, not a candidate-proposing operation.
+ * The record captures that a /recall query happened and what instincts
+ * were returned. This is separate from instinct-writer.js to prevent
+ * provenance loops with Layer 8 activated instincts.
+ */
+
+const path = require('node:path');
+const os = require('node:os');
+
+const { atomicWriteFile } = require('./utils');
+
+/**
+ * Write a recall operation record.
+ *
+ * @param {object} options
+ * @param {string} options.recall_id              — record ID
+ * @param {string} options.project                — project slug
+ * @param {string} options.project_id             — stable project hash
+ * @param {string} options.session                — session ID
+ * @param {string} options.created_at             — ISO 8601 timestamp
+ * @param {string} options.recall_query           — the query string used
+ * @param {string[]} options.returned_instinct_ids — instinct IDs returned by the query
+ * @param {string} options.summary                — one-paragraph summary of the recall
+ * @param {string} [options.homeDir]              — override HOME (tests use this)
+ */
+function saveRecallRecord({
+  recall_id,
+  project,
+  project_id,
+  session,
+  created_at,
+  recall_query,
+  returned_instinct_ids,
+  summary,
+  homeDir: homeOverride,
+}) {
+  if (typeof recall_id !== 'string' || !recall_id.trim()) {
+    throw new Error('saveRecallRecord: recall_id must be a non-empty string');
+  }
+  if (typeof project !== 'string' || !project.trim()) {
+    throw new Error('saveRecallRecord: project must be a non-empty string');
+  }
+
+  const homeDir = homeOverride || os.homedir();
+  const dir = path.join(homeDir, '.arcforge', 'recalls', project);
+  const filePath = path.join(dir, `${recall_id}.md`);
+
+  const instinctList = Array.isArray(returned_instinct_ids)
+    ? returned_instinct_ids.map((id) => `  - ${id}`).join('\n')
+    : '';
+
+  const content = [
+    '---',
+    `recall_id: ${recall_id}`,
+    `project: ${project}`,
+    `project_id: ${project_id || ''}`,
+    `session: ${session || ''}`,
+    `created_at: ${created_at || new Date().toISOString()}`,
+    `source: manual`,
+    `recall_query: ${recall_query || ''}`,
+    instinctList ? `returned_instinct_ids:\n${instinctList}` : 'returned_instinct_ids: []',
+    '---',
+    '',
+    `# Recall: ${recall_id}`,
+    '',
+    summary || '',
+    '',
+  ].join('\n');
+
+  atomicWriteFile(filePath, content);
+}
+
+module.exports = { saveRecallRecord };

--- a/scripts/lib/reflect-record-writer.js
+++ b/scripts/lib/reflect-record-writer.js
@@ -1,0 +1,77 @@
+/**
+ * reflect-record-writer.js — Layer 3 reflection operation record writer.
+ *
+ * Exports:
+ *   saveReflectionRecord(options) — write a reflection operation record to
+ *     ~/.arcforge/reflections/<project>/<reflect_id>.md
+ *
+ * This is distinct from the instinct file written by instinct-writer.js.
+ * Operation records track that a /reflect session happened; instinct files
+ * record individual learned instincts. Keeping paths separate prevents
+ * provenance loops with Layer 8 activated instincts.
+ */
+
+const path = require('node:path');
+const os = require('node:os');
+
+const { atomicWriteFile } = require('./utils');
+
+/**
+ * Write a reflection operation record.
+ *
+ * @param {object} options
+ * @param {string} options.reflect_id    — record ID, e.g. reflect-<ISO date>-<8 hex>
+ * @param {string} options.project       — project slug
+ * @param {string} options.project_id    — stable project hash
+ * @param {string} options.session       — session ID
+ * @param {string} options.created_at    — ISO 8601 timestamp
+ * @param {string[]} options.source_diary_ids — diary files scanned during reflect
+ * @param {string} options.summary       — one-paragraph summary of the reflection
+ * @param {string} [options.homeDir]     — override HOME (tests use this)
+ */
+function saveReflectionRecord({
+  reflect_id,
+  project,
+  project_id,
+  session,
+  created_at,
+  source_diary_ids,
+  summary,
+  homeDir: homeOverride,
+}) {
+  if (typeof reflect_id !== 'string' || !reflect_id.trim()) {
+    throw new Error('saveReflectionRecord: reflect_id must be a non-empty string');
+  }
+  if (typeof project !== 'string' || !project.trim()) {
+    throw new Error('saveReflectionRecord: project must be a non-empty string');
+  }
+
+  const homeDir = homeOverride || os.homedir();
+  const dir = path.join(homeDir, '.arcforge', 'reflections', project);
+  const filePath = path.join(dir, `${reflect_id}.md`);
+
+  const diaryList = Array.isArray(source_diary_ids)
+    ? source_diary_ids.map((d) => `  - ${d}`).join('\n')
+    : '';
+
+  const content = [
+    '---',
+    `reflect_id: ${reflect_id}`,
+    `project: ${project}`,
+    `project_id: ${project_id || ''}`,
+    `session: ${session || ''}`,
+    `created_at: ${created_at || new Date().toISOString()}`,
+    `source: reflection`,
+    diaryList ? `source_diary_ids:\n${diaryList}` : 'source_diary_ids: []',
+    '---',
+    '',
+    `# Reflection: ${reflect_id}`,
+    '',
+    summary || '',
+    '',
+  ].join('\n');
+
+  atomicWriteFile(filePath, content);
+}
+
+module.exports = { saveReflectionRecord };

--- a/skills/arc-observing/scripts/observer-prompt.md
+++ b/skills/arc-observing/scripts/observer-prompt.md
@@ -31,11 +31,19 @@ Do NOT propose `skill`, `command`, `agent`, or `claude_md_addition`. Those artif
 
 The following evidence items are the ONLY evidence you may cite. Each item has an `evidence_id` — use only those IDs in your `evidence_refs`.
 
+Evidence comes in four types:
+- **observation** — individual tool call events captured from Claude Code sessions
+- **diary** — bounded session diary summaries
+- **reflect** — cross-session reflection patterns from past `/reflect` operations
+- **recall** — manually captured insights from past `/recall` operations
+
+Every item in the batch below has an `evidence_id`. You MUST use those IDs when citing evidence in `evidence_refs`.
+
 {{EVIDENCE_ITEMS}}
 
 ## Recent Diary Reflections
 
-The following are recent session diary summaries for this project. Use these as supporting context, but they do not have `evidence_id`s and cannot be cited in `evidence_refs`.
+The following are recent session diary summaries for this project. These items also appear in the Evidence Batch above with `evidence_type: "diary"` and have `evidence_id`s — you CAN cite them in `evidence_refs` using their `evidence_id`.
 
 {{DIARY_CONTEXT}}
 
@@ -72,7 +80,7 @@ Respond with a single JSON object matching the `CandidateProposalPayload` schema
       "body_source": "llm_curator",
       "evidence_refs": [
         {
-          "evidence_id": "<must be one of the evidence_ids in the batch above>",
+          "evidence_id": "<must be one of the evidence_ids in the batch above — all 4 evidence types are citable>",
           "evidence_type": "<observation|diary|reflect|recall>",
           "relevance": "<brief reason why this evidence supports the proposal>"
         }

--- a/skills/arc-recalling/scripts/recall.js
+++ b/skills/arc-recalling/scripts/recall.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 /**
- * Recall CLI — save, check-duplicate
+ * Recall CLI — save, check-duplicate, save-record
  *
  * Manual instinct creation from user session context.
  */
 
 const { saveInstinct, checkInstinctDuplicate } = require('../../../scripts/lib/instinct-writer');
+const { saveRecallRecord } = require('../../../scripts/lib/recall-record-writer');
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -51,6 +52,36 @@ function cmdSave(flags) {
   }
 }
 
+function cmdSaveRecord(flags) {
+  const { project, session, summary } = flags;
+  const recallId = flags['recall-id'];
+  const query = flags['query'] || flags['recall-query'];
+  const homeDir = flags['home-dir'];
+  const returnedIds = flags['instinct-ids'];
+
+  if (!project || !recallId) {
+    console.error('Error: Missing required arguments');
+    console.log('Usage: recall.js save-record --project X --recall-id Y [--session Z] [--query "..."] [--summary "..."] [--instinct-ids "a,b,c"] [--home-dir DIR]');
+    process.exit(1);
+  }
+
+  const returnedInstinctIds = returnedIds ? returnedIds.split(',').filter(Boolean) : [];
+
+  saveRecallRecord({
+    recall_id: recallId,
+    project,
+    project_id: flags['project-id'] || '',
+    session: session || '',
+    created_at: new Date().toISOString(),
+    recall_query: query || '',
+    returned_instinct_ids: returnedInstinctIds,
+    summary: summary || '',
+    homeDir,
+  });
+
+  console.log(`✓ Saved recall record: ${recallId}`);
+}
+
 function cmdCheckDuplicate(flags) {
   const { id, project } = flags;
 
@@ -71,6 +102,9 @@ function main() {
       break;
     case 'check-duplicate':
       cmdCheckDuplicate(flags);
+      break;
+    case 'save-record':
+      cmdSaveRecord(flags);
       break;
     default:
       console.log('Recall CLI — Manual instinct creation\n');
@@ -94,7 +128,8 @@ function main() {
 module.exports = {
   parseArgs,
   cmdSave,
-  cmdCheckDuplicate
+  cmdCheckDuplicate,
+  cmdSaveRecord,
 };
 
 if (require.main === module) {

--- a/skills/arc-recalling/scripts/recall.js
+++ b/skills/arc-recalling/scripts/recall.js
@@ -6,7 +6,7 @@
  */
 
 const { saveInstinct, checkInstinctDuplicate } = require('../../../scripts/lib/instinct-writer');
-const { saveRecallRecord } = require('../../../scripts/lib/recall-record-writer');
+const { saveRecallRecord } = require('../../../scripts/lib/operation-record-writer');
 
 function parseArgs(argv) {
   const args = argv.slice(2);

--- a/skills/arc-reflecting/scripts/reflect.js
+++ b/skills/arc-reflecting/scripts/reflect.js
@@ -13,6 +13,7 @@ const {
 } = require('../../../scripts/lib/session-utils');
 const { saveInstinct } = require('../../../scripts/lib/instinct-writer');
 const { REFLECT_MAX_CONFIDENCE } = require('../../../scripts/lib/confidence');
+const { saveReflectionRecord } = require('../../../scripts/lib/reflect-record-writer');
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -80,6 +81,34 @@ function cmdAutoCheck(flags) {
   console.log(`${status}|${strategy}|${diaries.length}`);
 }
 
+function cmdSaveRecord(flags) {
+  const { project, session, summary } = flags;
+  const reflectId = flags['reflect-id'];
+  const diariesArg = flags['diaries'];
+  const homeDir = flags['home-dir'];
+
+  if (!project || !reflectId) {
+    console.error('Error: Missing required arguments');
+    console.log('Usage: reflect.js save-record --project X --reflect-id Y [--session Z] [--diaries "a,b,c"] [--summary "..."] [--home-dir DIR]');
+    process.exit(1);
+  }
+
+  const sourceDiaryIds = diariesArg ? diariesArg.split(',').filter(Boolean) : [];
+
+  saveReflectionRecord({
+    reflect_id: reflectId,
+    project,
+    project_id: flags['project-id'] || '',
+    session: session || '',
+    created_at: new Date().toISOString(),
+    source_diary_ids: sourceDiaryIds,
+    summary: summary || '',
+    homeDir,
+  });
+
+  console.log(`✓ Saved reflection record: ${reflectId}`);
+}
+
 function cmdSaveInstinct(flags) {
   const { project, id, trigger, action, domain, evidence } = flags;
   const evidenceCount = parseInt(flags['evidence-count'], 10) || 1;
@@ -128,8 +157,11 @@ function main() {
     case 'save-instinct':
       cmdSaveInstinct(flags);
       break;
+    case 'save-record':
+      cmdSaveRecord(flags);
+      break;
     default:
-      console.log('Usage: reflect.js <strategy|scan|update-log|auto-check|save-instinct> --project X [--strategy Y] [--diaries "a,b,c"] [--reflection Z]');
+      console.log('Usage: reflect.js <strategy|scan|update-log|auto-check|save-instinct|save-record> --project X [--strategy Y] [--diaries "a,b,c"] [--reflection Z]');
       process.exit(1);
   }
 }
@@ -141,7 +173,8 @@ module.exports = {
   cmdScan,
   cmdUpdateLog,
   cmdAutoCheck,
-  cmdSaveInstinct
+  cmdSaveInstinct,
+  cmdSaveRecord,
 };
 
 if (require.main === module) {

--- a/skills/arc-reflecting/scripts/reflect.js
+++ b/skills/arc-reflecting/scripts/reflect.js
@@ -13,7 +13,7 @@ const {
 } = require('../../../scripts/lib/session-utils');
 const { saveInstinct } = require('../../../scripts/lib/instinct-writer');
 const { REFLECT_MAX_CONFIDENCE } = require('../../../scripts/lib/confidence');
-const { saveReflectionRecord } = require('../../../scripts/lib/reflect-record-writer');
+const { saveReflectionRecord } = require('../../../scripts/lib/operation-record-writer');
 
 function parseArgs(argv) {
   const args = argv.slice(2);

--- a/tests/scripts/learning-curator-batch-assembler.test.js
+++ b/tests/scripts/learning-curator-batch-assembler.test.js
@@ -275,3 +275,173 @@ describe('assembleBatch — return value shape', () => {
     expect(result.project).toBe(project);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Criterion 2: typed evidence — DiaryEvidenceItem, ReflectEvidenceItem,
+// RecallEvidenceItem — and source_windows with diaries/reflects/recalls keys.
+// ---------------------------------------------------------------------------
+
+function seedReflections(project, items) {
+  const reflDir = path.join(tmpDir, '.arcforge', 'reflections', project);
+  fs.mkdirSync(reflDir, { recursive: true });
+  for (const item of items) {
+    const content = [
+      '---',
+      `reflect_id: ${item.reflect_id}`,
+      `project: ${project}`,
+      `project_id: proj_abc123456789ab`,
+      `session: session-xyz`,
+      `created_at: ${item.created_at || '2026-05-22T01:00:00.000Z'}`,
+      `source: reflection`,
+      'source_diary_ids: []',
+      '---',
+      '',
+      `# Reflection`,
+      '',
+      item.summary || 'No summary.',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(reflDir, `${item.reflect_id}.md`), content, 'utf8');
+  }
+}
+
+function seedRecalls(project, items) {
+  const recallDir = path.join(tmpDir, '.arcforge', 'recalls', project);
+  fs.mkdirSync(recallDir, { recursive: true });
+  for (const item of items) {
+    const content = [
+      '---',
+      `recall_id: ${item.recall_id}`,
+      `project: ${project}`,
+      `project_id: proj_abc123456789ab`,
+      `session: session-xyz`,
+      `created_at: ${item.created_at || '2026-05-22T01:00:00.000Z'}`,
+      `source: manual`,
+      `recall_query: ${item.recall_query || ''}`,
+      'returned_instinct_ids: []',
+      '---',
+      '',
+      `# Recall`,
+      '',
+      item.summary || 'No summary.',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(recallDir, `${item.recall_id}.md`), content, 'utf8');
+  }
+}
+
+describe('assembleBatch — typed evidence (criterion 2)', () => {
+  test('manifest source_windows has diaries, reflects, recalls keys', () => {
+    const { assembleBatch } = getAssembler();
+    const project = 'typed-evidence-project';
+    seedObservations(project, [makeObservation({ project })]);
+    seedDiaries(project, ['# Diary\nSession summary about grep.']);
+    seedReflections(project, [
+      {
+        reflect_id: 'reflect-20260522T010000Z-aabbccdd',
+        summary: 'Grep pattern found in 3 sessions.',
+      },
+    ]);
+    seedRecalls(project, [
+      {
+        recall_id: 'recall-20260522T010000Z-11223344',
+        recall_query: 'grep',
+        summary: 'Retrieved grep instinct.',
+      },
+    ]);
+
+    const result = assembleBatch({ project });
+    const manifest = JSON.parse(fs.readFileSync(result.manifest_path, 'utf8'));
+
+    expect(manifest.source_windows.diaries).toBeDefined();
+    expect(typeof manifest.source_windows.diaries.records_scanned).toBe('number');
+    expect(typeof manifest.source_windows.diaries.records_selected).toBe('number');
+
+    expect(manifest.source_windows.reflects).toBeDefined();
+    expect(typeof manifest.source_windows.reflects.records_scanned).toBe('number');
+    expect(typeof manifest.source_windows.reflects.records_selected).toBe('number');
+
+    expect(manifest.source_windows.recalls).toBeDefined();
+    expect(typeof manifest.source_windows.recalls.records_scanned).toBe('number');
+    expect(typeof manifest.source_windows.recalls.records_selected).toBe('number');
+  });
+
+  test('manifest evidence_ids includes diary, reflect, recall evidence IDs', () => {
+    const { assembleBatch } = getAssembler();
+    const project = 'typed-evidence-ids-project';
+    seedObservations(project, [makeObservation({ project })]);
+    seedDiaries(project, ['# Diary\nSession content.']);
+    seedReflections(project, [
+      {
+        reflect_id: 'reflect-20260522T010000Z-aabbccdd',
+        summary: 'Reflect summary.',
+      },
+    ]);
+    seedRecalls(project, [
+      {
+        recall_id: 'recall-20260522T010000Z-11223344',
+        recall_query: 'query',
+        summary: 'Recall summary.',
+      },
+    ]);
+
+    const result = assembleBatch({ project });
+    const manifest = JSON.parse(fs.readFileSync(result.manifest_path, 'utf8'));
+
+    // evidence_ids should include items with diary/reflect/recall prefixes
+    const ids = manifest.evidence_ids || [];
+    const hasDiary = ids.some((id) => id.includes('diary'));
+    const hasReflect = ids.some((id) => id.includes('reflect'));
+    const hasRecall = ids.some((id) => id.includes('recall'));
+
+    expect(hasDiary).toBe(true);
+    expect(hasReflect).toBe(true);
+    expect(hasRecall).toBe(true);
+  });
+
+  test('MAX_REFLECTS and MAX_RECALLS are non-zero (default 10)', () => {
+    // This is tested by verifying that reflection/recall files are actually read.
+    // If MAX_REFLECTS were 0, no reflect items would appear.
+    const { assembleBatch } = getAssembler();
+    const project = 'nonzero-max-project';
+    seedObservations(project, [makeObservation({ project })]);
+    seedReflections(project, [
+      {
+        reflect_id: 'reflect-20260522T010000Z-00000001',
+        summary: 'First reflection.',
+      },
+    ]);
+
+    const result = assembleBatch({ project });
+    const manifest = JSON.parse(fs.readFileSync(result.manifest_path, 'utf8'));
+
+    // With non-zero MAX_REFLECTS, reflects.records_selected should be 1
+    expect(manifest.source_windows.reflects.records_selected).toBe(1);
+  });
+
+  test('diary items include evidence_id with diary prefix and evidence_type diary', () => {
+    const { assembleBatch } = getAssembler();
+    const project = 'diary-evidence-type-project';
+    seedObservations(project, [makeObservation({ project })]);
+    seedDiaries(project, ['# Diary\nGrep usage observed.']);
+
+    const result = assembleBatch({ project });
+    const manifest = JSON.parse(fs.readFileSync(result.manifest_path, 'utf8'));
+
+    const ids = manifest.evidence_ids || [];
+    expect(ids.some((id) => id.includes('diary'))).toBe(true);
+  });
+
+  test('diary content still surfaces in rendered prompt after typed refactor', () => {
+    const { assembleBatch } = getAssembler();
+    const project = 'diary-prompt-project';
+    seedObservations(project, [makeObservation({ project })]);
+    seedDiaries(project, ['# Diary\nUser uses grep extensively for code search.']);
+
+    const result = assembleBatch({ project });
+    const promptContent = fs.readFileSync(result.prompt_path, 'utf8');
+
+    // The diary summary must appear in the prompt
+    expect(promptContent).toContain('grep extensively');
+  });
+});

--- a/tests/scripts/learning-curator-proposal-ingestor.test.js
+++ b/tests/scripts/learning-curator-proposal-ingestor.test.js
@@ -465,7 +465,6 @@ describe('ingestProposal — missing batch manifest', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
 // Criterion #2 — evidence_ref_omitted_upstream (PR-B Layer 5 Blocker #2)
 // ---------------------------------------------------------------------------
 
@@ -555,5 +554,107 @@ describe('ingestProposal — evidence_ref_omitted_upstream', () => {
 
     expect(result.accepted).toBe(1);
     expect(result.rejected).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 4: canonical dedupe_basis + superseded lifecycle
+// ---------------------------------------------------------------------------
+
+describe('ingestProposal — dedupe: second candidate with same body superseded (criterion 4)', () => {
+  test('two proposals with same normalized_body_hash: second gets lifecycle_status superseded', () => {
+    const { ingestProposal } = getIngestor();
+    const { manifest, batchId } = makeBatchManifest();
+
+    // First proposal
+    const payload1 = makeValidProposalPayload(batchId, manifest.batch_hash);
+    payload1.proposals[0].name = 'grep-before-edit';
+    payload1.proposals[0].body =
+      'When editing files, first grep for existing patterns to avoid duplication';
+    const responsePath1 = makeResponseFile(payload1);
+    ingestProposal({ batchId, responseFile: responsePath1 });
+
+    // Second proposal with SAME body (and same artifact_type + project scope)
+    // Must be a different response file to avoid idempotency short-circuit
+    const payload2 = makeValidProposalPayload(batchId, manifest.batch_hash);
+    payload2.proposals[0].name = 'grep-before-edit-v2'; // different name
+    payload2.proposals[0].body =
+      'When editing files, first grep for existing patterns to avoid duplication'; // SAME body
+    const responsePath2 = makeResponseFile(payload2);
+    ingestProposal({ batchId, responseFile: responsePath2 });
+
+    // Both candidates should appear in queue
+    const candidates = readCurrentCandidates();
+    const vals = Object.values(candidates);
+    expect(vals.length).toBe(2);
+
+    // One must be pending_review, the other superseded
+    const statuses = vals.map((c) => c.lifecycle.status);
+    expect(statuses).toContain('pending_review');
+    expect(statuses).toContain('superseded');
+
+    // The superseded one must have dedupe.duplicate_of pointing to the first
+    const superseded = vals.find((c) => c.lifecycle.status === 'superseded');
+    expect(superseded).toBeDefined();
+    expect(typeof superseded.dedupe.duplicate_of).toBe('string');
+    expect(superseded.dedupe.duplicate_of.length).toBeGreaterThan(0);
+  });
+
+  test('canonical dedupe_basis shape on accepted candidate', () => {
+    const { ingestProposal } = getIngestor();
+    const { manifest, batchId } = makeBatchManifest();
+    const payload = makeValidProposalPayload(batchId, manifest.batch_hash);
+    const responsePath = makeResponseFile(payload);
+
+    ingestProposal({ batchId, responseFile: responsePath });
+
+    const candidates = readCurrentCandidates();
+    const candidate = Object.values(candidates)[0];
+    const basis = candidate.dedupe.dedupe_basis;
+
+    expect(basis).toBeDefined();
+    expect(['project', 'global']).toContain(basis.scope_kind);
+    expect(typeof basis.artifact_type).toBe('string');
+    expect(typeof basis.normalized_name).toBe('string');
+    expect(typeof basis.normalized_body_hash).toBe('string');
+    expect(basis.normalized_body_hash.length).toBeGreaterThan(0);
+
+    // dedupe_key must be sha256[:12] of canonical JSON of basis
+    expect(candidate.dedupe.dedupe_key).toMatch(/^[a-f0-9]{12}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 5: rule_version namespace split
+// evidence_quality_metadata.rule_version and safety.sanitizer_policy_version
+// must be different strings on a single candidate record.
+// ---------------------------------------------------------------------------
+
+describe('ingestProposal — rule_version namespace split (criterion 5)', () => {
+  test('evidence_quality_metadata.rule_version differs from safety.sanitizer_policy_version', () => {
+    const { ingestProposal } = getIngestor();
+    const { manifest, batchId } = makeBatchManifest();
+    const payload = makeValidProposalPayload(batchId, manifest.batch_hash);
+    const responsePath = makeResponseFile(payload);
+
+    ingestProposal({ batchId, responseFile: responsePath });
+
+    const candidates = readCurrentCandidates();
+    const vals = Object.values(candidates);
+    expect(vals.length).toBe(1);
+
+    const candidate = vals[0];
+    const eqmRuleVersion = candidate.evidence_quality_metadata.rule_version;
+    const sanitizerVersion = candidate.safety.sanitizer_policy_version;
+
+    // Both fields must be present
+    expect(typeof eqmRuleVersion).toBe('string');
+    expect(typeof sanitizerVersion).toBe('string');
+
+    // They must be DIFFERENT (two independent namespaces)
+    expect(eqmRuleVersion).not.toBe(sanitizerVersion);
+
+    // evidence_quality_metadata.rule_version must be the formula version
+    expect(eqmRuleVersion).toBe('v1-project_obs_count');
   });
 });

--- a/tests/scripts/recall-record-writer.test.js
+++ b/tests/scripts/recall-record-writer.test.js
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 function getWriter() {
-  return require('../../scripts/lib/recall-record-writer');
+  return require('../../scripts/lib/operation-record-writer');
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scripts/recall-record-writer.test.js
+++ b/tests/scripts/recall-record-writer.test.js
@@ -1,0 +1,147 @@
+// tests/scripts/recall-record-writer.test.js
+//
+// Criterion 1: recall-record-writer.js saves operation records to
+// ~/.arcforge/recalls/<project>/<recall_id>.md with atomic write.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-recall-record-test-'));
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.resetModules();
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+function getWriter() {
+  return require('../../scripts/lib/recall-record-writer');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('saveRecallRecord — basic write', () => {
+  test('writes file at ~/.arcforge/recalls/<project>/<recall_id>.md', () => {
+    const { saveRecallRecord } = getWriter();
+    const recallId = 'recall-20260522T010000Z-abcd1234';
+    saveRecallRecord({
+      recall_id: recallId,
+      project: 'test-project',
+      project_id: 'proj_abc123456789ab',
+      session: 'session-abc',
+      created_at: '2026-05-22T01:00:00.000Z',
+      recall_query: 'grep patterns',
+      returned_instinct_ids: ['grep-before-edit', 'search-first'],
+      summary: 'Recalled grep instincts for this session.',
+      homeDir: tmpDir,
+    });
+
+    const expectedPath = path.join(
+      tmpDir,
+      '.arcforge',
+      'recalls',
+      'test-project',
+      `${recallId}.md`,
+    );
+    expect(fs.existsSync(expectedPath)).toBe(true);
+  });
+
+  test('file contains YAML frontmatter with required fields', () => {
+    const { saveRecallRecord } = getWriter();
+    const recallId = 'recall-20260522T010000Z-abcd1234';
+    saveRecallRecord({
+      recall_id: recallId,
+      project: 'test-project',
+      project_id: 'proj_abc123456789ab',
+      session: 'session-abc',
+      created_at: '2026-05-22T01:00:00.000Z',
+      recall_query: 'grep patterns',
+      returned_instinct_ids: ['grep-before-edit'],
+      summary: 'Found relevant grep instinct.',
+      homeDir: tmpDir,
+    });
+
+    const filePath = path.join(tmpDir, '.arcforge', 'recalls', 'test-project', `${recallId}.md`);
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain(`recall_id: ${recallId}`);
+    expect(content).toContain('project: test-project');
+    expect(content).toContain('project_id: proj_abc123456789ab');
+    expect(content).toContain('session: session-abc');
+    expect(content).toContain('created_at: ');
+    expect(content).toContain('source: manual');
+  });
+
+  test('file body contains summary', () => {
+    const { saveRecallRecord } = getWriter();
+    const recallId = 'recall-20260522T010000Z-abcd1234';
+    saveRecallRecord({
+      recall_id: recallId,
+      project: 'myproject',
+      project_id: 'proj_xyz',
+      session: 'session-1',
+      created_at: '2026-05-22T01:00:00.000Z',
+      recall_query: 'test query',
+      returned_instinct_ids: [],
+      summary: 'No instincts matched the query.',
+      homeDir: tmpDir,
+    });
+
+    const filePath = path.join(tmpDir, '.arcforge', 'recalls', 'myproject', `${recallId}.md`);
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toContain('No instincts matched the query.');
+  });
+
+  test('writes atomically — tmp file cleaned up after write', () => {
+    const { saveRecallRecord } = getWriter();
+    const recallId = 'recall-20260522T010000Z-ef567890';
+    saveRecallRecord({
+      recall_id: recallId,
+      project: 'atomic-project',
+      project_id: 'proj_atomic',
+      session: 'session-x',
+      created_at: '2026-05-22T01:00:00.000Z',
+      recall_query: 'atomic',
+      returned_instinct_ids: [],
+      summary: 'Atomic write test.',
+      homeDir: tmpDir,
+    });
+
+    const filePath = path.join(tmpDir, '.arcforge', 'recalls', 'atomic-project', `${recallId}.md`);
+    const tmpFilePath = `${filePath}.tmp`;
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.existsSync(tmpFilePath)).toBe(false);
+  });
+
+  test('creates parent directories recursively', () => {
+    const { saveRecallRecord } = getWriter();
+    const recallId = 'recall-20260522T010000Z-11223344';
+    saveRecallRecord({
+      recall_id: recallId,
+      project: 'brand-new-recall-project',
+      project_id: 'proj_new',
+      session: 'session-y',
+      created_at: '2026-05-22T01:00:00.000Z',
+      recall_query: 'new query',
+      returned_instinct_ids: [],
+      summary: 'First recall in project.',
+      homeDir: tmpDir,
+    });
+
+    const dir = path.join(tmpDir, '.arcforge', 'recalls', 'brand-new-recall-project');
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+});

--- a/tests/scripts/recall.test.js
+++ b/tests/scripts/recall.test.js
@@ -1,0 +1,109 @@
+// tests/scripts/recall.test.js
+//
+// Criterion 1: recall.js save-record command emits a recall operation record.
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const scriptPath = path.join(__dirname, '../../skills/arc-recalling/scripts/recall.js');
+
+describe('recall.js CLI', () => {
+  describe('check-duplicate command', () => {
+    it('exits with error when missing arguments', () => {
+      expect(() => {
+        execFileSync('node', [scriptPath, 'check-duplicate'], {
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        });
+      }).toThrow();
+    });
+  });
+
+  describe('usage', () => {
+    it('shows usage when no command given', () => {
+      try {
+        execFileSync('node', [scriptPath], { encoding: 'utf-8', stdio: 'pipe' });
+      } catch (err) {
+        expect(err.stdout.toString()).toContain('recall');
+        expect(err.status).toBe(1);
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 1: save-record command emits a recall operation record
+// ---------------------------------------------------------------------------
+
+describe('recall.js save-record command (criterion 1)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-recall-op-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('saves a recall operation record to ~/.arcforge/recalls/<project>/', () => {
+    const recallId = 'recall-20260522T010000Z-abcd1234';
+    execFileSync(
+      'node',
+      [
+        scriptPath,
+        'save-record',
+        '--project',
+        'test-project',
+        '--recall-id',
+        recallId,
+        '--session',
+        'session-abc',
+        '--query',
+        'grep patterns',
+        '--summary',
+        'Found grep instinct',
+        '--home-dir',
+        tmpDir,
+      ],
+      { encoding: 'utf-8' },
+    );
+
+    const expectedPath = path.join(
+      tmpDir,
+      '.arcforge',
+      'recalls',
+      'test-project',
+      `${recallId}.md`,
+    );
+    expect(fs.existsSync(expectedPath)).toBe(true);
+
+    const content = fs.readFileSync(expectedPath, 'utf-8');
+    expect(content).toContain(`recall_id: ${recallId}`);
+    expect(content).toContain('Found grep instinct');
+  });
+
+  it('exits with error when missing required --project', () => {
+    expect(() => {
+      execFileSync('node', [scriptPath, 'save-record', '--recall-id', 'recall-x'], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+    }).toThrow();
+  });
+
+  it('exits with error when missing required --recall-id', () => {
+    expect(() => {
+      execFileSync('node', [scriptPath, 'save-record', '--project', 'test-project'], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+    }).toThrow();
+  });
+});

--- a/tests/scripts/reflect-record-writer.test.js
+++ b/tests/scripts/reflect-record-writer.test.js
@@ -1,0 +1,158 @@
+// tests/scripts/reflect-record-writer.test.js
+//
+// Criterion 1: reflect-record-writer.js saves operation records to
+// ~/.arcforge/reflections/<project>/<reflect_id>.md with atomic write.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-reflect-record-test-'));
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.resetModules();
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+function getWriter() {
+  return require('../../scripts/lib/reflect-record-writer');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('saveReflectionRecord — basic write', () => {
+  test('writes file at ~/.arcforge/reflections/<project>/<reflect_id>.md', () => {
+    const { saveReflectionRecord } = getWriter();
+    const reflectId = 'reflect-20260522T010000Z-abcd1234';
+    saveReflectionRecord({
+      reflect_id: reflectId,
+      project: 'test-project',
+      project_id: 'proj_abc123456789ab',
+      session: 'session-abc',
+      created_at: '2026-05-22T01:00:00.000Z',
+      source_diary_ids: ['diary-1.md', 'diary-2.md'],
+      summary: 'Reflected on two sessions and found grep pattern.',
+      homeDir: tmpDir,
+    });
+
+    const expectedPath = path.join(
+      tmpDir,
+      '.arcforge',
+      'reflections',
+      'test-project',
+      `${reflectId}.md`,
+    );
+    expect(fs.existsSync(expectedPath)).toBe(true);
+  });
+
+  test('file contains YAML frontmatter with required fields', () => {
+    const { saveReflectionRecord } = getWriter();
+    const reflectId = 'reflect-20260522T010000Z-abcd1234';
+    saveReflectionRecord({
+      reflect_id: reflectId,
+      project: 'test-project',
+      project_id: 'proj_abc123456789ab',
+      session: 'session-abc',
+      created_at: '2026-05-22T01:00:00.000Z',
+      source_diary_ids: ['diary-1.md', 'diary-2.md'],
+      summary: 'Pattern found: grep first.',
+      homeDir: tmpDir,
+    });
+
+    const filePath = path.join(
+      tmpDir,
+      '.arcforge',
+      'reflections',
+      'test-project',
+      `${reflectId}.md`,
+    );
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    // Must begin with YAML frontmatter
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain(`reflect_id: ${reflectId}`);
+    expect(content).toContain('project: test-project');
+    expect(content).toContain('project_id: proj_abc123456789ab');
+    expect(content).toContain('session: session-abc');
+    expect(content).toContain('created_at: ');
+    expect(content).toContain('source: reflection');
+  });
+
+  test('file body contains summary', () => {
+    const { saveReflectionRecord } = getWriter();
+    const reflectId = 'reflect-20260522T010000Z-abcd1234';
+    saveReflectionRecord({
+      reflect_id: reflectId,
+      project: 'myproject',
+      project_id: 'proj_xyz',
+      session: 'session-1',
+      created_at: '2026-05-22T01:00:00.000Z',
+      source_diary_ids: [],
+      summary: 'User always runs grep before editing files.',
+      homeDir: tmpDir,
+    });
+
+    const filePath = path.join(tmpDir, '.arcforge', 'reflections', 'myproject', `${reflectId}.md`);
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toContain('User always runs grep before editing files.');
+  });
+
+  test('writes atomically — no partial file on crash', () => {
+    // Atomic write means file is either fully present or absent.
+    // We verify the .tmp file is cleaned up after write.
+    const { saveReflectionRecord } = getWriter();
+    const reflectId = 'reflect-20260522T010000Z-ef567890';
+    saveReflectionRecord({
+      reflect_id: reflectId,
+      project: 'atomic-project',
+      project_id: 'proj_atomic',
+      session: 'session-x',
+      created_at: '2026-05-22T01:00:00.000Z',
+      source_diary_ids: [],
+      summary: 'Atomic write test.',
+      homeDir: tmpDir,
+    });
+
+    const filePath = path.join(
+      tmpDir,
+      '.arcforge',
+      'reflections',
+      'atomic-project',
+      `${reflectId}.md`,
+    );
+    const tmpFilePath = `${filePath}.tmp`;
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.existsSync(tmpFilePath)).toBe(false);
+  });
+
+  test('creates parent directories recursively', () => {
+    const { saveReflectionRecord } = getWriter();
+    const reflectId = 'reflect-20260522T010000Z-11223344';
+    // Project with slashes-free name — just verify dir creation
+    saveReflectionRecord({
+      reflect_id: reflectId,
+      project: 'brand-new-project',
+      project_id: 'proj_new',
+      session: 'session-y',
+      created_at: '2026-05-22T01:00:00.000Z',
+      source_diary_ids: [],
+      summary: 'New project reflection.',
+      homeDir: tmpDir,
+    });
+
+    const dir = path.join(tmpDir, '.arcforge', 'reflections', 'brand-new-project');
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+});

--- a/tests/scripts/reflect-record-writer.test.js
+++ b/tests/scripts/reflect-record-writer.test.js
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 function getWriter() {
-  return require('../../scripts/lib/reflect-record-writer');
+  return require('../../scripts/lib/operation-record-writer');
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scripts/reflect.test.js
+++ b/tests/scripts/reflect.test.js
@@ -1,9 +1,9 @@
 // tests/scripts/reflect.test.js
 
 const { execFileSync } = require('node:child_process');
-const _fs = require('node:fs');
+const fs = require('node:fs');
 const path = require('node:path');
-const _os = require('node:os');
+const os = require('node:os');
 
 describe('reflect.js CLI', () => {
   const scriptPath = path.join(__dirname, '../../skills/arc-reflecting/scripts/reflect.js');
@@ -56,5 +56,82 @@ describe('reflect.js CLI', () => {
         expect(err.status).toBe(1);
       }
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 1: save-record command emits a reflection operation record
+// ---------------------------------------------------------------------------
+
+describe('reflect.js save-record command (criterion 1)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-reflect-op-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  const scriptPath = path.join(__dirname, '../../skills/arc-reflecting/scripts/reflect.js');
+
+  it('saves a reflection operation record to ~/.arcforge/reflections/<project>/', () => {
+    const reflectId = 'reflect-20260522T010000Z-abcd1234';
+    execFileSync(
+      'node',
+      [
+        scriptPath,
+        'save-record',
+        '--project',
+        'test-project',
+        '--reflect-id',
+        reflectId,
+        '--session',
+        'session-abc',
+        '--diaries',
+        'diary-1.md,diary-2.md',
+        '--summary',
+        'Grep pattern found',
+        '--home-dir',
+        tmpDir,
+      ],
+      { encoding: 'utf-8' },
+    );
+
+    const expectedPath = path.join(
+      tmpDir,
+      '.arcforge',
+      'reflections',
+      'test-project',
+      `${reflectId}.md`,
+    );
+    expect(fs.existsSync(expectedPath)).toBe(true);
+
+    const content = fs.readFileSync(expectedPath, 'utf-8');
+    expect(content).toContain(`reflect_id: ${reflectId}`);
+    expect(content).toContain('Grep pattern found');
+  });
+
+  it('exits with error when missing required --project', () => {
+    expect(() => {
+      execFileSync('node', [scriptPath, 'save-record', '--reflect-id', 'reflect-x'], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+    }).toThrow();
+  });
+
+  it('exits with error when missing required --reflect-id', () => {
+    expect(() => {
+      execFileSync('node', [scriptPath, 'save-record', '--project', 'test-project'], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+    }).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

PR-C of the 2026-05-22 spec realignment plan. Brings Layer 3 from 1 evidence type to 4 typed evidence types, adds Layer 5 canonical dedupe, splits rule_version namespaces, and introduces operation record storage paths (separated from instinct activation surface).

## Changes

**Reflect/Recall operation record storage paths (§1.1 in plan)**
- New \`scripts/lib/operation-record-writer.js\` exports \`saveReflectionRecord\` + \`saveRecallRecord\` — atomic write to \`~/.arcforge/reflections/<project>/<reflect_id>.md\` and \`~/.arcforge/recalls/<project>/<recall_id>.md\`. Consolidated from two near-duplicate writers (one shared core, two thin wrappers).
- \`/reflect\` and \`/recall\` skills emit operation records via new \`save-record\` subcommand. Existing \`saveInstinct()\` paths unchanged (additive — no migration).
- Separating storage from \`~/.arcforge/instincts/\` prevents Layer 8 activated instincts from looping back as Layer 3 evidence.

**Layer 3 typed evidence (4 types)**
- \`batch-assembler.js\`: single \`readRecentEvidence(kind, ...)\` helper driven by \`EVIDENCE_KIND_CONFIG\`, emitting \`DiaryEvidenceItem\` / \`ReflectEvidenceItem\` / \`RecallEvidenceItem\` per spec lines 147-228. \`readRecentDiaries/Reflects/Recalls\` are thin aliases for callers.
- Manifest \`source_windows\` gains \`diaries\`, \`reflects\`, \`recalls\` blocks each with \`records_scanned\` + \`records_selected\`.
- \`max_reflections\` and \`max_recalls\` no longer hard-coded to 0.

**Layer 4 prompt updated**
- \`observer-prompt.md\`: candidate evidence_refs may now cite all 4 evidence types via \`evidence_id\`. Removed the "diaries cannot be cited" restriction.

**Layer 5 canonical \`dedupe_basis\`**
- \`proposal-ingestor.js\` computes canonical \`dedupe_basis\` (scope_kind, project_id?, artifact_type, normalized_name, normalized_trigger?, normalized_body_hash) per spec lines 574-587.
- Duplicate detected by \`normalized_body_hash\` → new candidate inserted with \`lifecycle.status: 'superseded'\` and \`dedupe.duplicate_of: <existing_id>\`.
- Gated by new \`lifecycle.isLegalInsertionStatus()\`: only \`pending_review\` (default) and \`superseded\` (dedupe path) are valid at insertion time; all other statuses must transition via \`applyTransition\`.

**Layer 5 rule_version namespace split**
- \`safety.sanitizer_policy_version\` uses \`SANITIZER_POLICY_VERSION\` (sanitizer module version).
- \`evidence_quality_metadata.rule_version\` uses new \`EVIDENCE_QUALITY_RULE_VERSION = 'v1-project_obs_count'\` (evidence-quality formula version).
- Two distinct namespaces, never share a value.

## Tests added

- \`tests/scripts/reflect-record-writer.test.js\`: 5 new tests for reflect operation record shape.
- \`tests/scripts/recall-record-writer.test.js\`: 5 new tests for recall operation record shape.
- \`tests/scripts/reflect.test.js\` + \`tests/scripts/recall.test.js\`: CLI save-record subcommand tests.
- \`tests/scripts/learning-curator-batch-assembler.test.js\`: 5 new tests covering typed evidence emission for all 3 sources + source_windows manifest fields.
- \`tests/scripts/learning-curator-proposal-ingestor.test.js\`: 3 new tests (canonical dedupe_basis x2, rule_version namespace split x1).

## Test plan

- [x] \`npm run test:scripts\` — 1773 passed, 0 failed
- [x] \`npm run test:hooks\` — 213 passed
- [x] \`npm run test:node\` — 7 passed
- [x] \`npm run test:skills\` — 546 passed, 12 pre-existing failures (orphan test deleted by PR #46)
- [x] \`npm run lint\` — clean
- [x] Round-trip: fake fixture with diary/reflect/recall files → manifest contains all 3 source_windows + 3 evidence_type values in evidence_items.
- [x] Dedupe: two candidates with same normalized_body_hash → second is \`superseded\` with \`duplicate_of\` set.

## Risk

Medium-high. Behavior changes on batch shape (new typed evidence items) and operation record write paths (\`/reflect\` and \`/recall\` now write to new dirs in addition to existing \`saveInstinct()\` behavior). Forward-compatible because:
- Layer 5 validator accepts the new fields additively.
- Operation record dirs are new — no migration of existing instinct files.
- Reflect/recall CLI \`save-record\` subcommand is additive; existing flows untouched.

## Stacking

This PR is based on \`feat/learning-curator-pivot\`. PR-B (#48) also targets that branch and touches \`proposal-ingestor.js\` (safety metadata block). After PR-B merges, this PR will need a rebase that integrates PR-B's full safety block with PR-C's dedupe_basis additions. Conflict is mechanical (two additive sets of fields on the same record), no behavior conflict.

## Follow-up PRs

- PR-D: Layer 6 dashboard upgrade (wire model, request envelope, detail view)

Per the parent plan at \`/Users/gregho/.claude/plans/read-documents-below-docs-plans-2026-05-spicy-conway.md\`.