### PR TITLE
feat(learning): PR-D — Layer 6 dashboard upgrade to 3.1 spec

### DIFF
--- a/evals/scenarios/dashboard-concurrency-guard.md
+++ b/evals/scenarios/dashboard-concurrency-guard.md
@@ -1,0 +1,180 @@
+# Eval: dashboard-concurrency-guard
+
+**Status**: Active — PR-D implementation gate.
+
+## Scope
+skill
+
+## Target
+skills/arc-learning/SKILL.md
+
+## Scenario
+Two reviewers load the dashboard simultaneously. Both see candidate `cand_concurrency_001`
+with `lifecycle.status === "pending_review"`. Reviewer A dismisses the candidate first,
+which writes a `candidate.transitioned` event to `queue.jsonl` setting the status to
+`dismissed`. Reviewer B then tries to approve with
+`expected_current_status: "pending_review"` — but the candidate's actual status is now
+`dismissed`.
+
+Read the scenario queue and answer:
+1. What is the actual current lifecycle status of `cand_concurrency_001` after
+   Reviewer A's action?
+2. Should Reviewer B's approve action with `expected_current_status: "pending_review"`
+   be accepted or rejected? What rejection reason should be returned?
+3. What HTTP status code should the dashboard server return for Reviewer B's stale request?
+4. Does the stale-check allow Reviewer B to proceed when `expected_current_status`
+   is absent (omitted from the request)?
+
+Relevant files:
+- `queue.jsonl` — candidate queue after Reviewer A's dismiss action.
+- Source candidate_id: `cand_concurrency_001`
+
+Constraints:
+- Use Read only; do not run Bash, including file-inspection commands.
+- Do not edit files.
+- Keep the answer under 10 bullets.
+
+## Context
+This scenario validates the Layer 6 optimistic concurrency guard from the PR-D spec:
+- `expected_current_status` in the action request is an optimistic concurrency token.
+- If the client's expected status differs from the server's freshly-read status, the
+  action must be rejected with `stale_status` and HTTP 409.
+- If `expected_current_status` is absent or null, the guard degrades gracefully for
+  backward compatibility — the action proceeds normally.
+- This prevents the "double action" problem where two reviewers unknowingly act on the
+  same candidate: the second reviewer gets a clear rejection signal so they can reload
+  the dashboard and see the updated state.
+
+## Preflight
+skip
+
+## Verdict Policy
+non-regression
+
+## Setup
+mkdir -p queue-dir
+python3 - <<'PY'
+import json, pathlib
+
+queue_path = pathlib.Path("queue-dir/queue.jsonl")
+t0 = "2026-05-22T10:00:00Z"
+t1 = "2026-05-22T10:01:00Z"
+
+# Source candidate: project-scoped, pending_review
+source_record = {
+    "schema_version": 1,
+    "candidate_id": "cand_concurrency_001",
+    "artifact_type": "instinct",
+    "scope": {"kind": "project", "project": "test-project", "project_id": "proj_test_002"},
+    "source": {"source_type": "layer4_llm_curator"},
+    "name": "prefer-read-before-edit",
+    "summary": "Always read a file before editing it.",
+    "rationale": "Observed in 4 sessions.",
+    "body": "When editing files, read first so you know the current state.",
+    "body_source": "llm_curator",
+    "domain": "workflow",
+    "evidence": [{"evidence_id": "ev-001", "evidence_type": "observation", "relevance": "direct", "summary": "Read before Edit seen in session B"}],
+    "evidence_quality": "low",
+    "evidence_quality_metadata": {"rule_version": "v1", "basis": {"project_obs_count": 4}},
+    "lifecycle": {"status": "pending_review", "status_changed_at": t0},
+    "safety": {"raw_prompt_included": False, "raw_response_included": False, "raw_hook_payloads_included": False, "raw_transcripts_included": False, "edit_bodies_included": False, "skill_args_included": False},
+    "dedupe": {"dedupe_key": "prefer-read-before-edit-v1", "dedupe_basis": {"name_hash": "def"}},
+    "created_at": t0,
+    "updated_at": t0,
+}
+create_event = {
+    "schema_version": 1,
+    "event_id": "evt_001",
+    "ts": t0,
+    "candidate_id": "cand_concurrency_001",
+    "event_type": "candidate.created",
+    "actor": {"layer": 5, "actor_type": "validator"},
+    "record": source_record,
+}
+
+# Reviewer A dismisses the candidate (transition event)
+dismiss_event = {
+    "schema_version": 1,
+    "event_id": "evt_002",
+    "ts": t1,
+    "candidate_id": "cand_concurrency_001",
+    "event_type": "candidate.transitioned",
+    "actor": {"layer": 6, "actor_type": "dashboard", "reviewer": "local_user"},
+    "action": "dismiss",
+    "from_status": "pending_review",
+    "to_status": "dismissed",
+}
+
+lines = [create_event, dismiss_event]
+queue_path.write_text("\n".join(json.dumps(l) for l in lines) + "\n")
+print("Setup complete:", queue_path, f"({len(lines)} events)")
+PY
+
+## Assertions
+- [ ] A1: The response identifies that `cand_concurrency_001` has actual status
+  `dismissed` after Reviewer A's action (the transition event is present in
+  `queue.jsonl`).
+- [ ] A2: The response correctly states that Reviewer B's approve with
+  `expected_current_status: "pending_review"` should be **rejected** with reason
+  `stale_status` because the actual status is `dismissed`.
+- [ ] A3: The response identifies HTTP 409 as the correct status code for a
+  `stale_status` rejection.
+- [ ] A4: The response correctly states that if `expected_current_status` is absent
+  or null, the stale-check degrades gracefully and the action proceeds (backward
+  compatibility).
+- [ ] A5: The agent does not create, edit, or delete any files.
+
+## Grader
+code
+
+## Grader Config
+python3 - <<'PY'
+import json, os, re, sys
+from pathlib import Path
+
+trial = Path(os.environ["TRIAL_DIR"])
+transcript_path = os.environ.get("TRANSCRIPT_PATH")
+
+def trial_transcript():
+    if transcript_path and Path(transcript_path).exists():
+        return Path(transcript_path).read_text(errors="replace")
+    return ""
+
+txt = trial_transcript()
+assistant_parts = re.findall(r"(?ms)^\[Assistant\]\s*(.*?)(?=^\[[A-Za-z]+(?: Tool)?:|\Z)", txt)
+assistant_txt = "\n\n".join(assistant_parts) if assistant_parts else ""
+al = assistant_txt.lower()
+
+def emit(label, ok, reason=""):
+    print(f"{label}:{'PASS' if ok else 'FAIL' + (':' + reason if reason else '')}")
+
+# A1: actual status is dismissed
+a1 = bool(re.search(r"(dismissed|status.*dismissed|actual.*dismissed|cand_concurrency_001.*dismissed)", al))
+emit("A1", a1, "did not identify actual status as dismissed")
+
+# A2: reviewer B's action should be rejected with stale_status
+stale_rejected = bool(re.search(r"(stale_status|stale.*status|rejected.*stale|reject.*stale|should.*reject|must.*reject)", al))
+a2 = bool(stale_rejected)
+emit("A2", a2, "did not state reviewer B's action should be rejected with stale_status")
+
+# A3: HTTP 409
+a3 = bool(re.search(r"(409|http.*409|status.*409)", al))
+emit("A3", a3, "did not identify HTTP 409 as the response status code")
+
+# A4: absent expected_current_status degrades gracefully
+a4 = bool(re.search(r"(absent.*proceed|omit.*proceed|backward.compat|degrades.*gracefully|no.*expected.*proceed|without.*expected.*proceed|null.*proceed|if.*absent|if.*omit)", al))
+emit("A4", a4, "did not confirm absent expected_current_status degrades gracefully")
+
+# A5: no file writes
+write_tool_call = re.search(r"(?im)^\[Tool: (?:Write|Edit|MultiEdit|Bash)\]", txt)
+a5 = not bool(write_tool_call)
+emit("A5", a5, "agent used write/edit/bash tool — should only read")
+
+sys.exit(0 if all([a1, a2, a3, a4, a5]) else 1)
+PY
+
+## Trials
+5
+
+## Version
+1

--- a/scripts/lib/learning-dashboard-http.js
+++ b/scripts/lib/learning-dashboard-http.js
@@ -1,0 +1,197 @@
+/**
+ * learning-dashboard-http.js — HTTP layer for the Layer 6 dashboard.
+ *
+ * Hosts the request router + security headers + write-token check + server
+ * lifecycle. The wire-model and action handlers live in `learning-dashboard.js`;
+ * this module wires HTTP request/response shapes around those pure builders.
+ */
+
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const {
+  createDashboardModel,
+  sanitizeDashboardDetail,
+  handleDashboardAction,
+} = require('./learning-dashboard');
+
+const SECURITY_HEADERS = {
+  'X-Frame-Options': 'DENY',
+  'Content-Security-Policy':
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'",
+  'X-Content-Type-Options': 'nosniff',
+};
+
+function sendJson(res, data, status = 200) {
+  res.writeHead(status, { ...SECURITY_HEADERS, 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(data));
+}
+
+function sendHtml(res, html) {
+  res.writeHead(200, { ...SECURITY_HEADERS, 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(html);
+}
+
+function sendError(res, status, message) {
+  sendJson(res, { error: message }, status);
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > 64 * 1024) {
+        reject(new Error('request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Validate the per-server write token header.
+ *
+ * @param {object} req
+ * @param {string} writeToken
+ * @returns {boolean}
+ */
+function hasDashboardWriteHeader(req, writeToken) {
+  if (!writeToken || typeof writeToken !== 'string') return false;
+  if (req.headers['x-arcforge-dashboard'] !== '1') return false;
+  return req.headers['x-arcforge-dashboard-token'] === writeToken;
+}
+
+/**
+ * Create a request handler for the dashboard HTTP server.
+ *
+ * Routes:
+ *   GET  /                         → HTML dashboard
+ *   GET  /api/candidates           → DashboardCandidateCard[] list
+ *   GET  /api/candidates/:id       → DashboardCandidateDetail
+ *   POST /api/candidates/:id/action → action dispatch (requires write token)
+ *
+ * @param {{ htmlBody: string, writeToken: string }} options
+ * @returns {function}
+ */
+function createRouter({ htmlBody, writeToken }) {
+  return async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host || '127.0.0.1'}`);
+    const pathname = url.pathname;
+    const method = req.method || 'GET';
+
+    if (method === 'GET' && (pathname === '/' || pathname === '/index.html')) {
+      return sendHtml(res, htmlBody);
+    }
+
+    if (method === 'GET' && pathname === '/api/candidates') {
+      try {
+        return sendJson(res, createDashboardModel());
+      } catch {
+        return sendError(res, 500, 'dashboard failed to load candidates');
+      }
+    }
+
+    const detailMatch = pathname.match(/^\/api\/candidates\/([^/]+)$/);
+    if (method === 'GET' && detailMatch) {
+      try {
+        const detail = sanitizeDashboardDetail(detailMatch[1]);
+        return sendJson(res, detail);
+      } catch (err) {
+        if (err.code === 'NOT_FOUND') return sendError(res, 404, 'candidate not found');
+        return sendError(res, 500, 'dashboard failed to load candidate');
+      }
+    }
+
+    const actionMatch = pathname.match(/^\/api\/candidates\/([^/]+)\/action$/);
+    if (method === 'POST' && actionMatch) {
+      if (!hasDashboardWriteHeader(req, writeToken)) {
+        return sendError(res, 403, 'dashboard write header required');
+      }
+
+      let body;
+      try {
+        body = await readRequestBody(req);
+      } catch (err) {
+        return sendError(res, 400, err.message);
+      }
+
+      let parsed;
+      try {
+        parsed = JSON.parse(body);
+      } catch {
+        return sendError(res, 400, 'invalid JSON body');
+      }
+
+      const result = handleDashboardAction({
+        action: parsed.action,
+        candidate_id: actionMatch[1],
+        expected_current_status: parsed.expected_current_status,
+        safety_ack: parsed.safety_ack,
+        actor: parsed.actor,
+        reason: parsed.reason,
+      });
+
+      let status = 200;
+      if (!result.accepted) {
+        if (result.reason === 'candidate_not_found') status = 404;
+        else if (result.reason === 'stale_status') status = 409;
+        else status = 400;
+      }
+      return sendJson(res, result, status);
+    }
+
+    return sendError(res, 404, 'Not found');
+  };
+}
+
+function loadHtml(writeToken = '') {
+  const htmlPath = path.join(__dirname, 'learning-dashboard.html');
+  try {
+    return fs.readFileSync(htmlPath, 'utf8').replace(/__ARCFORGE_DASHBOARD_TOKEN__/g, writeToken);
+  } catch {
+    return '<!doctype html><meta charset="utf-8"><title>ArcForge learning</title><h1>Dashboard UI missing</h1>';
+  }
+}
+
+function startServer(options = {}) {
+  const { port = 3334, host = '127.0.0.1' } = options;
+  const writeToken = crypto.randomBytes(24).toString('hex');
+  const htmlBody = loadHtml(writeToken);
+  const router = createRouter({ htmlBody, writeToken });
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      await router(req, res);
+    } catch {
+      sendError(res, 500, 'learning dashboard server error');
+    }
+  });
+
+  server.listen(port, host, () => {
+    console.log(`ArcForge learning dashboard: http://${host}:${port}`);
+    console.log('Press Ctrl+C to stop');
+  });
+
+  const shutdown = () => {
+    server.close();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  return server;
+}
+
+module.exports = {
+  hasDashboardWriteHeader,
+  createRouter,
+  startServer,
+};

--- a/scripts/lib/learning-dashboard.html
+++ b/scripts/lib/learning-dashboard.html
@@ -43,6 +43,24 @@
       .actions button.danger { color: var(--danger); }
       .empty { grid-column: 1 / -1; text-align: center; color: var(--muted); padding: 48px 0; }
       .badge { display: inline-block; padding: 2px 6px; border-radius: 4px; background: var(--border); color: var(--fg); font-size: 11px; }
+      .chip { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600; }
+      .chip-low_signal { background: #ffe0e0; color: #b32424; }
+      .chip-medium_signal { background: #fff3cd; color: #856404; }
+      .chip-high_signal { background: #d4edda; color: #155724; }
+      @media (prefers-color-scheme: dark) {
+        .chip-low_signal { background: #4a1a1a; color: #ff8888; }
+        .chip-medium_signal { background: #4a3a00; color: #ffd966; }
+        .chip-high_signal { background: #1a3a1a; color: #66bb66; }
+      }
+      .evidence-counts { font-size: 11px; color: var(--muted); }
+      .note-badges { display: flex; gap: 4px; flex-wrap: wrap; }
+      .note-badge { font-size: 11px; padding: 1px 5px; border-radius: 4px; background: var(--border); }
+      .detail-panel { border-top: 1px solid var(--border); margin-top: 12px; padding-top: 12px; display: flex; flex-direction: column; gap: 10px; }
+      .detail-section { font-size: 13px; }
+      .detail-section summary { cursor: pointer; font-weight: 600; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+      .evidence-summary-item { padding: 6px 0; border-bottom: 1px solid var(--border); }
+      .evidence-summary-item:last-child { border-bottom: none; }
+      .llm-block, .lifecycle-block { background: var(--border); border-radius: 6px; padding: 8px; font-size: 12px; }
     </style>
   </head>
   <body>
@@ -98,10 +116,41 @@
         summaryEl.className = 'summary';
         summaryEl.textContent = c.summary || '';
 
+        // evidence_quality_chip pill
+        const chipEl = document.createElement('div');
+        if (c.evidence_quality_chip) {
+          const pill = document.createElement('span');
+          pill.className = 'chip chip-' + c.evidence_quality_chip;
+          pill.textContent = c.evidence_quality_chip.replace('_signal', '') + ' signal';
+          chipEl.appendChild(pill);
+        }
+
+        // evidence_counts breakdown
         const evidenceEl = document.createElement('div');
-        evidenceEl.style.fontSize = '12px';
-        evidenceEl.style.color = 'var(--muted)';
-        evidenceEl.textContent = 'Evidence: ' + (c.evidence_count || 0) + ' (' + (c.evidence_quality || 'unknown') + ')';
+        evidenceEl.className = 'evidence-counts';
+        const counts = c.evidence_counts || {};
+        const total = counts.total || 0;
+        const byType = counts.by_type || {};
+        const byTypeStr = Object.entries(byType).map(([t, n]) => t + ':' + n).join(', ');
+        evidenceEl.textContent = 'Evidence: ' + total + (byTypeStr ? ' (' + byTypeStr + ')' : '') + ' — quality: ' + (c.evidence_quality || 'unknown');
+
+        // risk/uncertainty note badges
+        const noteBadgesEl = document.createElement('div');
+        noteBadgesEl.className = 'note-badges';
+        if ((c.risk_note_count || 0) > 0) {
+          const rb = document.createElement('span');
+          rb.className = 'note-badge';
+          rb.title = 'risk_note_count';
+          rb.textContent = c.risk_note_count + ' risk';
+          noteBadgesEl.appendChild(rb);
+        }
+        if ((c.uncertainty_note_count || 0) > 0) {
+          const ub = document.createElement('span');
+          ub.className = 'note-badge';
+          ub.title = 'uncertainty_note_count';
+          ub.textContent = c.uncertainty_note_count + ' uncertain';
+          noteBadgesEl.appendChild(ub);
+        }
 
         const actionsEl = document.createElement('div');
         actionsEl.className = 'actions';
@@ -119,9 +168,98 @@
         card.appendChild(meta);
         card.appendChild(nameEl);
         card.appendChild(summaryEl);
+        card.appendChild(chipEl);
         card.appendChild(evidenceEl);
+        card.appendChild(noteBadgesEl);
+        // relationships link
+        if (c.relationships) {
+          const relEl = document.createElement('div');
+          relEl.style.fontSize = '11px';
+          relEl.style.color = 'var(--muted)';
+          const relKeys = Object.keys(c.relationships).join(', ');
+          relEl.textContent = 'Related: ' + relKeys;
+          card.appendChild(relEl);
+        }
         card.appendChild(actionsEl);
+        // Detail view (collapsible)
+        card.appendChild(createDetailTrigger(c));
         return card;
+      }
+
+      function createDetailTrigger(c) {
+        const container = document.createElement('div');
+        container.style.marginTop = '4px';
+        const btn = document.createElement('button');
+        btn.textContent = 'Details';
+        btn.style.fontSize = '11px';
+        btn.addEventListener('click', async () => {
+          const existing = container.querySelector('.detail-panel');
+          if (existing) { existing.remove(); return; }
+          try {
+            const res = await fetch('/api/candidates/' + encodeURIComponent(c.candidate_id));
+            const detail = await res.json();
+            container.appendChild(renderDetailPanel(detail));
+          } catch (e) {
+            const errEl = document.createElement('div');
+            errEl.textContent = 'Detail load failed';
+            container.appendChild(errEl);
+          }
+        });
+        container.appendChild(btn);
+        return container;
+      }
+
+      function renderDetailPanel(d) {
+        const panel = document.createElement('div');
+        panel.className = 'detail-panel';
+
+        // evidence_summaries
+        if (d.evidence_summaries && d.evidence_summaries.length > 0) {
+          const details = document.createElement('details');
+          details.className = 'detail-section';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Evidence summaries (' + d.evidence_summaries.length + ')';
+          details.appendChild(summary);
+          for (const ev of d.evidence_summaries) {
+            const item = document.createElement('div');
+            item.className = 'evidence-summary-item';
+            item.innerHTML = '<strong>' + (ev.evidence_type || '') + '</strong>: ' + (ev.summary || '') +
+              (ev.relevance ? '<br><em>' + ev.relevance + '</em>' : '');
+            details.appendChild(item);
+          }
+          panel.appendChild(details);
+        }
+
+        // llm_assessment block
+        if (d.llm_assessment) {
+          const llmEl = document.createElement('div');
+          llmEl.className = 'llm-block detail-section';
+          const conf = d.llm_assessment.llm_confidence || 'unknown';
+          const risks = (d.llm_assessment.risk_notes || []).join('; ');
+          const unc = (d.llm_assessment.uncertainty_notes || []).join('; ');
+          llmEl.innerHTML = '<strong>LLM assessment</strong>: confidence=' + conf +
+            (risks ? '<br>Risks: ' + risks : '') +
+            (unc ? '<br>Uncertain: ' + unc : '');
+          panel.appendChild(llmEl);
+        }
+
+        // materialization block
+        if (d.materialization) {
+          const matEl = document.createElement('div');
+          matEl.className = 'lifecycle-block detail-section';
+          matEl.innerHTML = '<strong>Materialization</strong>: ' + JSON.stringify(d.materialization);
+          panel.appendChild(matEl);
+        }
+
+        // activation block
+        if (d.activation) {
+          const actEl = document.createElement('div');
+          actEl.className = 'lifecycle-block detail-section';
+          actEl.innerHTML = '<strong>Activation</strong>: ' + JSON.stringify(d.activation);
+          panel.appendChild(actEl);
+        }
+
+        return panel;
       }
 
       function render(model) {

--- a/scripts/lib/learning-dashboard.html
+++ b/scripts/lib/learning-dashboard.html
@@ -213,6 +213,17 @@
         const panel = document.createElement('div');
         panel.className = 'detail-panel';
 
+        // Helper: append a labeled section with content; uses textContent (XSS-safe)
+        function appendLabeledSection(parent, className, label, contentBuilder) {
+          const el = document.createElement('div');
+          el.className = className;
+          const strong = document.createElement('strong');
+          strong.textContent = label;
+          el.appendChild(strong);
+          contentBuilder(el);
+          parent.appendChild(el);
+        }
+
         // evidence_summaries
         if (d.evidence_summaries && d.evidence_summaries.length > 0) {
           const details = document.createElement('details');
@@ -223,8 +234,16 @@
           for (const ev of d.evidence_summaries) {
             const item = document.createElement('div');
             item.className = 'evidence-summary-item';
-            item.innerHTML = '<strong>' + (ev.evidence_type || '') + '</strong>: ' + (ev.summary || '') +
-              (ev.relevance ? '<br><em>' + ev.relevance + '</em>' : '');
+            const strong = document.createElement('strong');
+            strong.textContent = ev.evidence_type || '';
+            item.appendChild(strong);
+            item.appendChild(document.createTextNode(': ' + (ev.summary || '')));
+            if (ev.relevance) {
+              item.appendChild(document.createElement('br'));
+              const em = document.createElement('em');
+              em.textContent = ev.relevance;
+              item.appendChild(em);
+            }
             details.appendChild(item);
           }
           panel.appendChild(details);
@@ -232,31 +251,34 @@
 
         // llm_assessment block
         if (d.llm_assessment) {
-          const llmEl = document.createElement('div');
-          llmEl.className = 'llm-block detail-section';
-          const conf = d.llm_assessment.llm_confidence || 'unknown';
-          const risks = (d.llm_assessment.risk_notes || []).join('; ');
-          const unc = (d.llm_assessment.uncertainty_notes || []).join('; ');
-          llmEl.innerHTML = '<strong>LLM assessment</strong>: confidence=' + conf +
-            (risks ? '<br>Risks: ' + risks : '') +
-            (unc ? '<br>Uncertain: ' + unc : '');
-          panel.appendChild(llmEl);
+          appendLabeledSection(panel, 'llm-block detail-section', 'LLM assessment', (el) => {
+            const conf = d.llm_assessment.llm_confidence || 'unknown';
+            const risks = (d.llm_assessment.risk_notes || []).join('; ');
+            const unc = (d.llm_assessment.uncertainty_notes || []).join('; ');
+            el.appendChild(document.createTextNode(': confidence=' + conf));
+            if (risks) {
+              el.appendChild(document.createElement('br'));
+              el.appendChild(document.createTextNode('Risks: ' + risks));
+            }
+            if (unc) {
+              el.appendChild(document.createElement('br'));
+              el.appendChild(document.createTextNode('Uncertain: ' + unc));
+            }
+          });
         }
 
-        // materialization block
+        // materialization block — JSON stringified, textContent (no HTML interpretation)
         if (d.materialization) {
-          const matEl = document.createElement('div');
-          matEl.className = 'lifecycle-block detail-section';
-          matEl.innerHTML = '<strong>Materialization</strong>: ' + JSON.stringify(d.materialization);
-          panel.appendChild(matEl);
+          appendLabeledSection(panel, 'lifecycle-block detail-section', 'Materialization', (el) => {
+            el.appendChild(document.createTextNode(': ' + JSON.stringify(d.materialization)));
+          });
         }
 
-        // activation block
+        // activation block — same, XSS-safe
         if (d.activation) {
-          const actEl = document.createElement('div');
-          actEl.className = 'lifecycle-block detail-section';
-          actEl.innerHTML = '<strong>Activation</strong>: ' + JSON.stringify(d.activation);
-          panel.appendChild(actEl);
+          appendLabeledSection(panel, 'lifecycle-block detail-section', 'Activation', (el) => {
+            el.appendChild(document.createTextNode(': ' + JSON.stringify(d.activation)));
+          });
         }
 
         return panel;

--- a/scripts/lib/learning-dashboard.js
+++ b/scripts/lib/learning-dashboard.js
@@ -104,6 +104,15 @@ function legalActionsFor(status) {
 }
 
 /**
+ * Derive the evidence_quality_chip value from evidence_quality.
+ * Returns undefined if evidence_quality is not one of the known values.
+ */
+function evidenceQualityChip(quality) {
+  const map = { low: 'low_signal', medium: 'medium_signal', high: 'high_signal' };
+  return map[quality];
+}
+
+/**
  * Build a DashboardCandidateCard from a CandidateQueueRecord per Layer 6 spec.
  * Returns only allowlisted fields. project_id intentionally excluded.
  *
@@ -114,7 +123,7 @@ function sanitizeDashboardCard(record) {
   const status = record.lifecycle ? record.lifecycle.status : undefined;
   const llmAssessment = record.llm_assessment || {};
 
-  return {
+  const card = {
     schema_version: 1,
     candidate_id: record.candidate_id,
     artifact_type: record.artifact_type,
@@ -133,6 +142,17 @@ function sanitizeDashboardCard(record) {
       : 0,
     available_actions: legalActionsFor(status),
   };
+
+  // Criterion 1: evidence_quality_chip (derived, omitted if quality unknown)
+  const chip = evidenceQualityChip(record.evidence_quality);
+  if (chip !== undefined) card.evidence_quality_chip = chip;
+
+  // Criterion 1: relationships (copied if present, omitted otherwise)
+  if (record.relationships !== undefined && record.relationships !== null) {
+    card.relationships = record.relationships;
+  }
+
+  return card;
 }
 
 /**
@@ -159,14 +179,40 @@ function sanitizeDashboardDetail(candidateId) {
 
   const rationaleText = sanitizeText(record.rationale, DETAIL_RATIONALE_MAX);
 
-  return {
+  // Criterion 5: evidence_summaries — map evidence[] to sanitized summary objects
+  const evidenceSummaries = Array.isArray(record.evidence)
+    ? record.evidence.map((ev) => ({
+        evidence_id: ev.evidence_id,
+        evidence_type: ev.evidence_type,
+        relevance: sanitizeText(ev.relevance, 200),
+        summary: sanitizeText(ev.summary, 300),
+      }))
+    : [];
+
+  const detail = {
     ...card,
     rationale: rationaleText,
     body_preview: {
       text: bodyPreviewText,
       truncated: bodyTruncated,
     },
+    evidence_summaries: evidenceSummaries,
   };
+
+  // Criterion 5: llm_assessment — copy if present
+  if (record.llm_assessment !== undefined) {
+    detail.llm_assessment = record.llm_assessment;
+  }
+
+  // Criterion 5: materialization + activation — copy from lifecycle if present
+  if (record.lifecycle && record.lifecycle.materialization !== undefined) {
+    detail.materialization = record.lifecycle.materialization;
+  }
+  if (record.lifecycle && record.lifecycle.activation !== undefined) {
+    detail.activation = record.lifecycle.activation;
+  }
+
+  return detail;
 }
 
 // ---------------------------------------------------------------------------
@@ -222,23 +268,51 @@ function generateActionId() {
 /**
  * Handle a dashboard reviewer action request.
  *
- * @param {{ action: string, candidate_id: string }} opts
+ * @param {{ action: string, candidate_id: string, expected_current_status?: string,
+ *           safety_ack?: object, actor?: object, reason?: string }} opts
  * @returns {{ accepted: boolean, action_id: string, reason?: string, ... }}
  */
-function handleDashboardAction({ action, candidate_id: candidateId } = {}) {
+function handleDashboardAction({
+  action,
+  candidate_id: candidateId,
+  expected_current_status: expectedStatus,
+  safety_ack: safetyAck,
+  actor: incomingActor,
+  reason,
+} = {}) {
   const actionId = generateActionId();
   const requestedAt = new Date().toISOString();
 
-  function reject(reason, extra = {}) {
+  // Criterion 4: default actor
+  const actor = incomingActor || { layer: 6, actor_type: 'dashboard', reviewer: 'local_user' };
+
+  function reject(rejectionReason, extra = {}) {
     const result = {
       accepted: false,
       action_id: actionId,
       requested_at: requestedAt,
       action,
       candidate_id: candidateId,
-      reason,
+      actor,
+      reason: rejectionReason,
       ...extra,
     };
+    writeAuditEntry(result);
+    return result;
+  }
+
+  function accept(extra = {}) {
+    const result = {
+      accepted: true,
+      action_id: actionId,
+      requested_at: requestedAt,
+      action,
+      candidate_id: candidateId,
+      actor,
+      ...extra,
+    };
+    // Criterion 4: include user-supplied reason in audit log
+    if (reason !== undefined) result.reason = reason;
     writeAuditEntry(result);
     return result;
   }
@@ -262,13 +336,33 @@ function handleDashboardAction({ action, candidate_id: candidateId } = {}) {
 
   const currentStatus = candidate.lifecycle ? candidate.lifecycle.status : undefined;
 
-  // Step 4: check Action × Status matrix
+  // Criterion 2: optimistic concurrency guard — check expected_current_status
+  if (expectedStatus !== undefined && expectedStatus !== null) {
+    if (expectedStatus !== currentStatus) {
+      return reject('stale_status', { expected: expectedStatus, current: currentStatus });
+    }
+  }
+
+  // Step 4: check Action × Status matrix (before safety_ack so illegal actions fail fast)
   if (!isLegalAction(currentStatus, action)) {
     return reject('policy_violation');
   }
 
+  // Criterion 3: safety_ack gate for activate and deactivate (only after policy check passes)
+  if (action === LIFECYCLE_ACTION.ACTIVATE) {
+    const ack = safetyAck || {};
+    if (!ack.reviewer_saw_behavior_change_warning || !ack.reviewer_saw_target_path_summary) {
+      return reject('missing_safety_ack');
+    }
+  }
+  if (action === LIFECYCLE_ACTION.DEACTIVATE) {
+    const ack = safetyAck || {};
+    if (!ack.reviewer_saw_behavior_change_warning) {
+      return reject('missing_safety_ack');
+    }
+  }
+
   // Step 5/6: dispatch by action type
-  const actor = { layer: 6, actor_type: 'dashboard' };
 
   if (action === LIFECYCLE_ACTION.PROMOTE) {
     // Candidate-producing: create a global-scope copy of the source candidate.
@@ -295,16 +389,7 @@ function handleDashboardAction({ action, candidate_id: candidateId } = {}) {
     appendCandidate(newRecord, { actor });
     appendRelatedEvent(candidateId, { promoted_to_candidate_id: newId }, actor);
 
-    const result = {
-      accepted: true,
-      action_id: actionId,
-      requested_at: requestedAt,
-      action,
-      candidate_id: candidateId,
-      new_candidate_id: newId,
-    };
-    writeAuditEntry(result);
-    return result;
+    return accept({ new_candidate_id: newId });
   }
 
   if (action === LIFECYCLE_ACTION.EVOLVE) {
@@ -330,16 +415,7 @@ function handleDashboardAction({ action, candidate_id: candidateId } = {}) {
     appendCandidate(newRecord, { actor });
     appendRelatedEvent(candidateId, { evolved_to_candidate_id: newId }, actor);
 
-    const result = {
-      accepted: true,
-      action_id: actionId,
-      requested_at: requestedAt,
-      action,
-      candidate_id: candidateId,
-      new_candidate_id: newId,
-    };
-    writeAuditEntry(result);
-    return result;
+    return accept({ new_candidate_id: newId });
   }
 
   // DH-1: materialize — delegates to Layer 7 materialize.js
@@ -355,17 +431,10 @@ function handleDashboardAction({ action, candidate_id: candidateId } = {}) {
     if (!matResult.ok) {
       return reject(matResult.failure.reason, { module_failure: matResult.failure });
     }
-    const result = {
-      accepted: true,
-      action_id: actionId,
-      requested_at: requestedAt,
-      action,
-      candidate_id: candidateId,
+    return accept({
       next_status: 'materialized',
       materialization_id: matResult.record.materialization_id,
-    };
-    writeAuditEntry(result);
-    return result;
+    });
   }
 
   // DH-2: activate — delegates to Layer 8 activate.js
@@ -401,17 +470,10 @@ function handleDashboardAction({ action, candidate_id: candidateId } = {}) {
     if (!actResult.ok) {
       return reject(actResult.failure.reason, { module_failure: actResult.failure });
     }
-    const result = {
-      accepted: true,
-      action_id: actionId,
-      requested_at: requestedAt,
-      action,
-      candidate_id: candidateId,
+    return accept({
       next_status: 'activated',
       activation_id: actResult.record.activation_id,
-    };
-    writeAuditEntry(result);
-    return result;
+    });
   }
 
   // DH-6: deactivate — delegates to Layer 8 deactivate.js
@@ -439,33 +501,17 @@ function handleDashboardAction({ action, candidate_id: candidateId } = {}) {
     if (!deactResult.ok) {
       return reject(deactResult.failure.reason, { module_failure: deactResult.failure });
     }
-    const result = {
-      accepted: true,
-      action_id: actionId,
-      requested_at: requestedAt,
-      action,
-      candidate_id: candidateId,
+    return accept({
       next_status: 'deactivated',
       activation_id: deactResult.record.activation_id,
-    };
-    writeAuditEntry(result);
-    return result;
+    });
   }
 
   // Status-changing actions: dismiss, approve (materialize, activate, deactivate handled above)
   const nextStatus = applyTransition(currentStatus, action);
   appendTransitionEvent(candidateId, action, nextStatus, actor);
 
-  const result = {
-    accepted: true,
-    action_id: actionId,
-    requested_at: requestedAt,
-    action,
-    candidate_id: candidateId,
-    next_status: nextStatus,
-  };
-  writeAuditEntry(result);
-  return result;
+  return accept({ next_status: nextStatus });
 }
 
 // ---------------------------------------------------------------------------
@@ -600,9 +646,18 @@ function createRouter({ htmlBody, writeToken }) {
       const result = handleDashboardAction({
         action: parsed.action,
         candidate_id: actionMatch[1],
+        expected_current_status: parsed.expected_current_status,
+        safety_ack: parsed.safety_ack,
+        actor: parsed.actor,
+        reason: parsed.reason,
       });
 
-      const status = result.accepted ? 200 : result.reason === 'candidate_not_found' ? 404 : 400;
+      let status = 200;
+      if (!result.accepted) {
+        if (result.reason === 'candidate_not_found') status = 404;
+        else if (result.reason === 'stale_status') status = 409;
+        else status = 400;
+      }
       return sendJson(res, result, status);
     }
 

--- a/scripts/lib/learning-dashboard.js
+++ b/scripts/lib/learning-dashboard.js
@@ -18,7 +18,6 @@
  */
 
 const fs = require('node:fs');
-const http = require('node:http');
 const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
@@ -122,8 +121,10 @@ function evidenceQualityChip(quality) {
 function sanitizeDashboardCard(record) {
   const status = record.lifecycle ? record.lifecycle.status : undefined;
   const llmAssessment = record.llm_assessment || {};
+  const chip = evidenceQualityChip(record.evidence_quality);
+  const hasRelationships = record.relationships !== undefined && record.relationships !== null;
 
-  const card = {
+  return {
     schema_version: 1,
     candidate_id: record.candidate_id,
     artifact_type: record.artifact_type,
@@ -141,18 +142,9 @@ function sanitizeDashboardCard(record) {
       ? llmAssessment.uncertainty_notes.length
       : 0,
     available_actions: legalActionsFor(status),
+    ...(chip !== undefined && { evidence_quality_chip: chip }),
+    ...(hasRelationships && { relationships: record.relationships }),
   };
-
-  // Criterion 1: evidence_quality_chip (derived, omitted if quality unknown)
-  const chip = evidenceQualityChip(record.evidence_quality);
-  if (chip !== undefined) card.evidence_quality_chip = chip;
-
-  // Criterion 1: relationships (copied if present, omitted otherwise)
-  if (record.relationships !== undefined && record.relationships !== null) {
-    card.relationships = record.relationships;
-  }
-
-  return card;
 }
 
 /**
@@ -199,20 +191,58 @@ function sanitizeDashboardDetail(candidateId) {
     evidence_summaries: evidenceSummaries,
   };
 
-  // Criterion 5: llm_assessment — copy if present
+  // llm_assessment / materialization / activation are spec-allowed on the detail
+  // wire. Sanitize them — these blocks may carry free-text (risk_notes) or paths
+  // (draft_path, active_path_summary) that must be scrubbed before egress.
   if (record.llm_assessment !== undefined) {
-    detail.llm_assessment = record.llm_assessment;
+    detail.llm_assessment = sanitizeAssessmentBlock(record.llm_assessment);
   }
-
-  // Criterion 5: materialization + activation — copy from lifecycle if present
-  if (record.lifecycle && record.lifecycle.materialization !== undefined) {
-    detail.materialization = record.lifecycle.materialization;
+  if (record.lifecycle?.materialization !== undefined) {
+    detail.materialization = sanitizeProvenanceBlock(record.lifecycle.materialization);
   }
-  if (record.lifecycle && record.lifecycle.activation !== undefined) {
-    detail.activation = record.lifecycle.activation;
+  if (record.lifecycle?.activation !== undefined) {
+    detail.activation = sanitizeProvenanceBlock(record.lifecycle.activation);
   }
 
   return detail;
+}
+
+/**
+ * Sanitize a free-text assessment block (llm_assessment) — risk_notes /
+ * uncertainty_notes / rationale_summary all flow through redactObservationText
+ * to scrub any leaked secrets the LLM may have echoed from observations.
+ */
+function sanitizeAssessmentBlock(block) {
+  if (!block || typeof block !== 'object') return undefined;
+  const out = {};
+  for (const [key, value] of Object.entries(block)) {
+    if (typeof value === 'string') {
+      out[key] = redactObservationText(value);
+    } else if (Array.isArray(value)) {
+      out[key] = value.map((v) => (typeof v === 'string' ? redactObservationText(v) : v));
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Sanitize a provenance block (materialization / activation) — paths and any
+ * string-valued field flow through redactObservationText. Non-string fields
+ * (hashes, booleans, numbers, nested objects) are preserved as-is.
+ */
+function sanitizeProvenanceBlock(block) {
+  if (!block || typeof block !== 'object') return undefined;
+  const out = {};
+  for (const [key, value] of Object.entries(block)) {
+    if (typeof value === 'string') {
+      out[key] = redactObservationText(value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -514,205 +544,16 @@ function handleDashboardAction({
   return accept({ next_status: nextStatus });
 }
 
-// ---------------------------------------------------------------------------
-// Security headers
-// ---------------------------------------------------------------------------
-
-const SECURITY_HEADERS = {
-  'X-Frame-Options': 'DENY',
-  'Content-Security-Policy':
-    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'",
-  'X-Content-Type-Options': 'nosniff',
-};
-
-// ---------------------------------------------------------------------------
-// HTTP utilities
-// ---------------------------------------------------------------------------
-
-function sendJson(res, data, status = 200) {
-  res.writeHead(status, { ...SECURITY_HEADERS, 'Content-Type': 'application/json; charset=utf-8' });
-  res.end(JSON.stringify(data));
-}
-
-function sendHtml(res, html) {
-  res.writeHead(200, { ...SECURITY_HEADERS, 'Content-Type': 'text/html; charset=utf-8' });
-  res.end(html);
-}
-
-function sendError(res, status, message) {
-  sendJson(res, { error: message }, status);
-}
-
-function readRequestBody(req) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    let size = 0;
-    req.on('data', (chunk) => {
-      size += chunk.length;
-      if (size > 64 * 1024) {
-        reject(new Error('request body too large'));
-        req.destroy();
-        return;
-      }
-      chunks.push(chunk);
-    });
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
-    req.on('error', reject);
-  });
-}
-
-/**
- * Validate the per-server write token header.
- *
- * @param {object} req
- * @param {string} writeToken
- * @returns {boolean}
- */
-function hasDashboardWriteHeader(req, writeToken) {
-  if (!writeToken || typeof writeToken !== 'string') return false;
-  if (req.headers['x-arcforge-dashboard'] !== '1') return false;
-  return req.headers['x-arcforge-dashboard-token'] === writeToken;
-}
-
-// ---------------------------------------------------------------------------
-// HTTP router
-// ---------------------------------------------------------------------------
-
-/**
- * Create a request handler for the dashboard HTTP server.
- *
- * Routes:
- *   GET  /                         → HTML dashboard
- *   GET  /api/candidates           → DashboardCandidateCard[] list
- *   GET  /api/candidates/:id       → DashboardCandidateDetail
- *   POST /api/candidates/:id/action → action dispatch (requires write token)
- *
- * @param {{ htmlBody: string, writeToken: string }} options
- * @returns {function}
- */
-function createRouter({ htmlBody, writeToken }) {
-  return async (req, res) => {
-    const url = new URL(req.url, `http://${req.headers.host || '127.0.0.1'}`);
-    const pathname = url.pathname;
-    const method = req.method || 'GET';
-
-    // GET / — HTML dashboard
-    if (method === 'GET' && (pathname === '/' || pathname === '/index.html')) {
-      return sendHtml(res, htmlBody);
-    }
-
-    // GET /api/candidates — list
-    if (method === 'GET' && pathname === '/api/candidates') {
-      try {
-        return sendJson(res, createDashboardModel());
-      } catch {
-        return sendError(res, 500, 'dashboard failed to load candidates');
-      }
-    }
-
-    // GET /api/candidates/:id — detail
-    const detailMatch = pathname.match(/^\/api\/candidates\/([^/]+)$/);
-    if (method === 'GET' && detailMatch) {
-      try {
-        const detail = sanitizeDashboardDetail(detailMatch[1]);
-        return sendJson(res, detail);
-      } catch (err) {
-        if (err.code === 'NOT_FOUND') return sendError(res, 404, 'candidate not found');
-        return sendError(res, 500, 'dashboard failed to load candidate');
-      }
-    }
-
-    // POST /api/candidates/:id/action — action dispatch
-    const actionMatch = pathname.match(/^\/api\/candidates\/([^/]+)\/action$/);
-    if (method === 'POST' && actionMatch) {
-      if (!hasDashboardWriteHeader(req, writeToken)) {
-        return sendError(res, 403, 'dashboard write header required');
-      }
-
-      let body;
-      try {
-        body = await readRequestBody(req);
-      } catch (err) {
-        return sendError(res, 400, err.message);
-      }
-
-      let parsed;
-      try {
-        parsed = JSON.parse(body);
-      } catch {
-        return sendError(res, 400, 'invalid JSON body');
-      }
-
-      const result = handleDashboardAction({
-        action: parsed.action,
-        candidate_id: actionMatch[1],
-        expected_current_status: parsed.expected_current_status,
-        safety_ack: parsed.safety_ack,
-        actor: parsed.actor,
-        reason: parsed.reason,
-      });
-
-      let status = 200;
-      if (!result.accepted) {
-        if (result.reason === 'candidate_not_found') status = 404;
-        else if (result.reason === 'stale_status') status = 409;
-        else status = 400;
-      }
-      return sendJson(res, result, status);
-    }
-
-    return sendError(res, 404, 'Not found');
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Server
-// ---------------------------------------------------------------------------
-
-function loadHtml(writeToken = '') {
-  const htmlPath = path.join(__dirname, 'learning-dashboard.html');
-  try {
-    return fs.readFileSync(htmlPath, 'utf8').replace(/__ARCFORGE_DASHBOARD_TOKEN__/g, writeToken);
-  } catch {
-    return '<!doctype html><meta charset="utf-8"><title>ArcForge learning</title><h1>Dashboard UI missing</h1>';
-  }
-}
-
-function startServer(options = {}) {
-  const { port = 3334, host = '127.0.0.1' } = options;
-  const writeToken = crypto.randomBytes(24).toString('hex');
-  const htmlBody = loadHtml(writeToken);
-  const router = createRouter({ htmlBody, writeToken });
-
-  const server = http.createServer(async (req, res) => {
-    try {
-      await router(req, res);
-    } catch {
-      sendError(res, 500, 'learning dashboard server error');
-    }
-  });
-
-  server.listen(port, host, () => {
-    console.log(`ArcForge learning dashboard: http://${host}:${port}`);
-    console.log('Press Ctrl+C to stop');
-  });
-
-  const shutdown = () => {
-    server.close();
-    process.exit(0);
-  };
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
-
-  return server;
-}
-
 module.exports = {
   sanitizeDashboardCard,
   sanitizeDashboardDetail,
   createDashboardModel,
   handleDashboardAction,
-  hasDashboardWriteHeader,
-  createRouter,
-  startServer,
 };
+
+// Re-export HTTP layer for backward compat with existing callers/tests that
+// imported these symbols from learning-dashboard.js before the http extraction.
+const httpLayer = require('./learning-dashboard-http');
+module.exports.hasDashboardWriteHeader = httpLayer.hasDashboardWriteHeader;
+module.exports.createRouter = httpLayer.createRouter;
+module.exports.startServer = httpLayer.startServer;

--- a/tests/scripts/learning-dashboard.test.js
+++ b/tests/scripts/learning-dashboard.test.js
@@ -452,7 +452,14 @@ describe('action handlers — Action × Status matrix (criterion 2)', () => {
     });
     expect(matResult.accepted).toBe(true);
 
-    const result = handleDashboardAction({ action: 'activate', candidate_id: record.candidate_id });
+    const result = handleDashboardAction({
+      action: 'activate',
+      candidate_id: record.candidate_id,
+      safety_ack: {
+        reviewer_saw_behavior_change_warning: true,
+        reviewer_saw_target_path_summary: true,
+      },
+    });
 
     expect(result.accepted).toBe(true);
   });
@@ -689,6 +696,59 @@ describe('HTML — statistical-pipeline dead code removed (criterion 4)', () => 
       expect(html).toMatch(new RegExp(`${action}:\\s*\\[[^\\]]+\\]`));
     }
   });
+
+  it('HTML contains evidence_quality_chip CSS classes', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain('chip-low_signal');
+    expect(html).toContain('chip-medium_signal');
+    expect(html).toContain('chip-high_signal');
+  });
+
+  it('HTML renders evidence_quality_chip pill on card', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain('evidence_quality_chip');
+  });
+
+  it('HTML renders evidence_counts breakdown on card', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain('evidence_counts');
+  });
+
+  it('HTML renders risk and uncertainty count badges on card', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain('risk_note_count');
+    expect(html).toContain('uncertainty_note_count');
+  });
+
+  it('HTML renders evidence_summaries section in detail view', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain('evidence_summaries');
+  });
+
+  it('HTML renders llm_assessment block in detail view', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain('llm_assessment');
+  });
+
+  it('HTML renders materialization and activation status blocks in detail view', () => {
+    const htmlPath = path.join(__dirname, '../../scripts/lib/learning-dashboard.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+
+    expect(html).toContain('materialization');
+    expect(html).toContain('activation');
+  });
 });
 
 // ===========================================================================
@@ -895,6 +955,10 @@ describe('DH-2: activate action calls activate.js module', () => {
     const result = handleDashboardAction({
       action: 'activate',
       candidate_id: record.candidate_id,
+      safety_ack: {
+        reviewer_saw_behavior_change_warning: true,
+        reviewer_saw_target_path_summary: true,
+      },
     });
 
     expect(result.accepted).toBe(true);
@@ -1008,6 +1072,10 @@ describe('DH-6: deactivate action calls deactivate.js module', () => {
     const actResult = handleDashboardAction({
       action: 'activate',
       candidate_id: record.candidate_id,
+      safety_ack: {
+        reviewer_saw_behavior_change_warning: true,
+        reviewer_saw_target_path_summary: true,
+      },
     });
     expect(actResult.accepted).toBe(true);
 
@@ -1021,6 +1089,7 @@ describe('DH-6: deactivate action calls deactivate.js module', () => {
     const deactResult = handleDashboardAction({
       action: 'deactivate',
       candidate_id: record.candidate_id,
+      safety_ack: { reviewer_saw_behavior_change_warning: true },
     });
     expect(deactResult.accepted).toBe(true);
 
@@ -1056,5 +1125,449 @@ describe('DH-6: deactivate action calls deactivate.js module', () => {
       readCurrentCandidates: rcc,
     } = require('../../scripts/lib/learning-curator/queue-writer');
     expect(rcc()[record.candidate_id].lifecycle.status).toBe('deactivated');
+  });
+});
+
+// ===========================================================================
+// PR-D Criterion 1 — evidence_quality_chip + relationships on card
+// ===========================================================================
+
+describe('PR-D Criterion 1 — evidence_quality_chip and relationships on card', () => {
+  it('evidence_quality_chip is derived correctly from evidence_quality', () => {
+    for (const [quality, chip] of [
+      ['low', 'low_signal'],
+      ['medium', 'medium_signal'],
+      ['high', 'high_signal'],
+    ]) {
+      const record = makeCandidateRecord({ evidence_quality: quality });
+      const card = sanitizeDashboardCard(record);
+      expect(card.evidence_quality_chip).toBe(chip);
+    }
+  });
+
+  it('evidence_quality_chip is omitted when evidence_quality is absent', () => {
+    const record = makeCandidateRecord({ evidence_quality: undefined });
+    const card = sanitizeDashboardCard(record);
+    expect(card).not.toHaveProperty('evidence_quality_chip');
+  });
+
+  it('relationships is copied from candidate if present', () => {
+    const record = makeCandidateRecord({
+      relationships: { promoted_from_candidate_id: 'cand-parent-001' },
+    });
+    const card = sanitizeDashboardCard(record);
+    expect(card.relationships).toEqual({ promoted_from_candidate_id: 'cand-parent-001' });
+  });
+
+  it('relationships is absent from card if candidate has none', () => {
+    const record = makeCandidateRecord();
+    const card = sanitizeDashboardCard(record);
+    expect(card).not.toHaveProperty('relationships');
+  });
+});
+
+// ===========================================================================
+// PR-D Criterion 2 — expected_current_status optimistic concurrency
+// ===========================================================================
+
+describe('PR-D Criterion 2 — expected_current_status stale guard', () => {
+  it('stale expected_current_status → rejected with stale_status', () => {
+    const record = makeCandidateRecord({
+      lifecycle: { status: 'pending_review', status_changed_at: '2026-05-01T00:00:00Z' },
+    });
+    appendCandidate(record);
+
+    // Client thinks status is 'approved' but it's really 'pending_review'
+    const result = handleDashboardAction({
+      action: 'dismiss',
+      candidate_id: record.candidate_id,
+      expected_current_status: 'approved',
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe('stale_status');
+    expect(result.expected).toBe('approved');
+    expect(result.current).toBe('pending_review');
+  });
+
+  it('matching expected_current_status → proceeds normally', () => {
+    const record = makeCandidateRecord({
+      lifecycle: { status: 'pending_review', status_changed_at: '2026-05-01T00:00:00Z' },
+    });
+    appendCandidate(record);
+
+    const result = handleDashboardAction({
+      action: 'dismiss',
+      candidate_id: record.candidate_id,
+      expected_current_status: 'pending_review',
+    });
+
+    expect(result.accepted).toBe(true);
+  });
+
+  it('absent expected_current_status → degrades gracefully (backward compat)', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+
+    const result = handleDashboardAction({
+      action: 'dismiss',
+      candidate_id: record.candidate_id,
+      // no expected_current_status
+    });
+
+    expect(result.accepted).toBe(true);
+  });
+
+  it('null expected_current_status → degrades gracefully', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+
+    const result = handleDashboardAction({
+      action: 'dismiss',
+      candidate_id: record.candidate_id,
+      expected_current_status: null,
+    });
+
+    expect(result.accepted).toBe(true);
+  });
+
+  it('stale_status check emits 409 from HTTP router', async () => {
+    const { EventEmitter } = require('node:events');
+
+    async function routeRequest(
+      router,
+      { method = 'GET', url = '/', headers = {}, body = '' } = {},
+    ) {
+      const req = new EventEmitter();
+      req.method = method;
+      req.url = url;
+      req.headers = { host: '127.0.0.1', ...headers };
+      req.destroy = () => req.emit('error', new Error('destroyed'));
+      const res = {
+        statusCode: undefined,
+        headers: undefined,
+        body: '',
+        writeHead(statusCode, responseHeaders) {
+          this.statusCode = statusCode;
+          this.headers = responseHeaders;
+        },
+        end(chunk = '') {
+          this.body += chunk;
+        },
+      };
+      const promise = router(req, res);
+      process.nextTick(() => {
+        if (body) req.emit('data', Buffer.isBuffer(body) ? body : Buffer.from(body));
+        req.emit('end');
+      });
+      await promise;
+      return res;
+    }
+
+    const record = makeCandidateRecord({
+      lifecycle: { status: 'pending_review', status_changed_at: '2026-05-01T00:00:00Z' },
+    });
+    appendCandidate(record);
+
+    const router = createRouter({ htmlBody: '<html></html>', writeToken: 'tok' });
+    const res = await routeRequest(router, {
+      method: 'POST',
+      url: `/api/candidates/${record.candidate_id}/action`,
+      headers: { 'x-arcforge-dashboard': '1', 'x-arcforge-dashboard-token': 'tok' },
+      body: JSON.stringify({ action: 'dismiss', expected_current_status: 'approved' }),
+    });
+
+    expect(res.statusCode).toBe(409);
+    const data = JSON.parse(res.body);
+    expect(data.reason).toBe('stale_status');
+  });
+});
+
+// ===========================================================================
+// PR-D Criterion 3 — safety_ack required for activate / deactivate
+// ===========================================================================
+
+describe('PR-D Criterion 3 — safety_ack gate on activate / deactivate', () => {
+  it('activate without safety_ack is rejected with missing_safety_ack', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+    appendTransitionEvent(record.candidate_id, 'approve', 'approved');
+    handleDashboardAction({ action: 'materialize', candidate_id: record.candidate_id });
+
+    const result = handleDashboardAction({
+      action: 'activate',
+      candidate_id: record.candidate_id,
+      // no safety_ack
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe('missing_safety_ack');
+  });
+
+  it('activate with partial safety_ack (behavior_change only) is rejected', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+    appendTransitionEvent(record.candidate_id, 'approve', 'approved');
+    handleDashboardAction({ action: 'materialize', candidate_id: record.candidate_id });
+
+    const result = handleDashboardAction({
+      action: 'activate',
+      candidate_id: record.candidate_id,
+      safety_ack: { reviewer_saw_behavior_change_warning: true },
+      // missing reviewer_saw_target_path_summary
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe('missing_safety_ack');
+  });
+
+  it('activate with full safety_ack succeeds', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+    appendTransitionEvent(record.candidate_id, 'approve', 'approved');
+    handleDashboardAction({ action: 'materialize', candidate_id: record.candidate_id });
+
+    const result = handleDashboardAction({
+      action: 'activate',
+      candidate_id: record.candidate_id,
+      safety_ack: {
+        reviewer_saw_behavior_change_warning: true,
+        reviewer_saw_target_path_summary: true,
+      },
+    });
+
+    expect(result.accepted).toBe(true);
+  });
+
+  it('deactivate without safety_ack is rejected with missing_safety_ack', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+    appendTransitionEvent(record.candidate_id, 'approve', 'approved');
+    const matResult = handleDashboardAction({
+      action: 'materialize',
+      candidate_id: record.candidate_id,
+    });
+    expect(matResult.accepted).toBe(true);
+    handleDashboardAction({
+      action: 'activate',
+      candidate_id: record.candidate_id,
+      safety_ack: {
+        reviewer_saw_behavior_change_warning: true,
+        reviewer_saw_target_path_summary: true,
+      },
+    });
+
+    const result = handleDashboardAction({
+      action: 'deactivate',
+      candidate_id: record.candidate_id,
+      // no safety_ack
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe('missing_safety_ack');
+  });
+
+  it('deactivate with reviewer_saw_behavior_change_warning: true succeeds', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+    appendTransitionEvent(record.candidate_id, 'approve', 'approved');
+    const matResult = handleDashboardAction({
+      action: 'materialize',
+      candidate_id: record.candidate_id,
+    });
+    expect(matResult.accepted).toBe(true);
+    handleDashboardAction({
+      action: 'activate',
+      candidate_id: record.candidate_id,
+      safety_ack: {
+        reviewer_saw_behavior_change_warning: true,
+        reviewer_saw_target_path_summary: true,
+      },
+    });
+
+    const result = handleDashboardAction({
+      action: 'deactivate',
+      candidate_id: record.candidate_id,
+      safety_ack: { reviewer_saw_behavior_change_warning: true },
+    });
+
+    expect(result.accepted).toBe(true);
+  });
+
+  it('non-activate/deactivate actions do not require safety_ack', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+
+    const result = handleDashboardAction({
+      action: 'dismiss',
+      candidate_id: record.candidate_id,
+      // no safety_ack
+    });
+
+    expect(result.accepted).toBe(true);
+  });
+});
+
+// ===========================================================================
+// PR-D Criterion 4 — actor default + reason to audit log
+// ===========================================================================
+
+describe('PR-D Criterion 4 — actor default and reason in audit log', () => {
+  function getAuditLogPath() {
+    return path.join(tmpDir, '.arcforge', 'learning', 'dashboard', 'actions.jsonl');
+  }
+
+  it('absent actor defaults to { layer: 6, actor_type: "dashboard", reviewer: "local_user" }', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+
+    handleDashboardAction({ action: 'dismiss', candidate_id: record.candidate_id });
+
+    const line = fs.readFileSync(getAuditLogPath(), 'utf8').trim();
+    const entry = JSON.parse(line);
+    expect(entry.actor).toEqual({ layer: 6, actor_type: 'dashboard', reviewer: 'local_user' });
+  });
+
+  it('reason is written to audit log when provided', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+
+    handleDashboardAction({
+      action: 'dismiss',
+      candidate_id: record.candidate_id,
+      reason: 'not relevant to this project',
+    });
+
+    const line = fs.readFileSync(getAuditLogPath(), 'utf8').trim();
+    const entry = JSON.parse(line);
+    expect(entry.reason).toBe('not relevant to this project');
+  });
+
+  it('absent reason does not add reason field to audit log', () => {
+    const record = makeCandidateRecord();
+    appendCandidate(record);
+
+    handleDashboardAction({ action: 'dismiss', candidate_id: record.candidate_id });
+
+    const line = fs.readFileSync(getAuditLogPath(), 'utf8').trim();
+    const entry = JSON.parse(line);
+    expect(entry).not.toHaveProperty('reason');
+  });
+});
+
+// ===========================================================================
+// PR-D Criterion 5 — detail view new blocks
+// ===========================================================================
+
+describe('PR-D Criterion 5 — detail view evidence_summaries / llm_assessment / materialization / activation', () => {
+  it('evidence_summaries maps evidence[] to { evidence_id, evidence_type, relevance, summary }', () => {
+    const record = makeCandidateRecord({
+      evidence: [
+        {
+          evidence_id: 'ev-1',
+          evidence_type: 'observation',
+          relevance: 'direct use',
+          summary: 'Seen in session A',
+        },
+        {
+          evidence_id: 'ev-2',
+          evidence_type: 'diary',
+          relevance: 'indirect',
+          summary: 'Mentioned in diary',
+        },
+      ],
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+
+    expect(detail).toHaveProperty('evidence_summaries');
+    expect(detail.evidence_summaries).toHaveLength(2);
+    expect(detail.evidence_summaries[0]).toMatchObject({
+      evidence_id: 'ev-1',
+      evidence_type: 'observation',
+    });
+    expect(detail.evidence_summaries[0]).toHaveProperty('relevance');
+    expect(detail.evidence_summaries[0]).toHaveProperty('summary');
+  });
+
+  it('evidence_summaries is empty array when candidate has no evidence', () => {
+    const record = makeCandidateRecord({ evidence: [] });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(detail.evidence_summaries).toEqual([]);
+  });
+
+  it('llm_assessment is included in detail view if present on candidate', () => {
+    const record = makeCandidateRecord({
+      llm_assessment: {
+        llm_confidence: 'high',
+        risk_notes: ['risk A'],
+        uncertainty_notes: [],
+      },
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(detail.llm_assessment).toBeDefined();
+    expect(detail.llm_assessment.llm_confidence).toBe('high');
+  });
+
+  it('llm_assessment is absent from detail if not on candidate', () => {
+    const record = makeCandidateRecord({ llm_assessment: undefined });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(detail).not.toHaveProperty('llm_assessment');
+  });
+
+  it('materialization is included in detail if lifecycle.materialization is present', () => {
+    const record = makeCandidateRecord({
+      lifecycle: {
+        status: 'materialized',
+        status_changed_at: '2026-05-01T00:00:00Z',
+        materialization: { materialization_id: 'mat-001', materialized_at: '2026-05-01T00:00:00Z' },
+      },
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(detail.materialization).toBeDefined();
+    expect(detail.materialization.materialization_id).toBe('mat-001');
+  });
+
+  it('activation is included in detail if lifecycle.activation is present', () => {
+    const record = makeCandidateRecord({
+      lifecycle: {
+        status: 'activated',
+        status_changed_at: '2026-05-01T00:00:00Z',
+        activation: { activation_id: 'act-001', activated_at: '2026-05-01T00:00:00Z' },
+      },
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(detail.activation).toBeDefined();
+    expect(detail.activation.activation_id).toBe('act-001');
+  });
+
+  it('evidence_summaries — secret in evidence.summary does not leak', () => {
+    const secretKey = 'sk-secret-evidence-key-99999';
+    const record = makeCandidateRecord({
+      evidence: [
+        {
+          evidence_id: 'ev-sec',
+          evidence_type: 'observation',
+          relevance: 'test relevance',
+          summary: `API_KEY=${secretKey} was used in the session`,
+        },
+      ],
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    const serialized = JSON.stringify(detail);
+    expect(serialized).not.toContain(secretKey);
   });
 });

--- a/tests/scripts/learning-dashboard.test.js
+++ b/tests/scripts/learning-dashboard.test.js
@@ -1570,4 +1570,55 @@ describe('PR-D Criterion 5 — detail view evidence_summaries / llm_assessment /
     const serialized = JSON.stringify(detail);
     expect(serialized).not.toContain(secretKey);
   });
+
+  it('llm_assessment — secret in risk_notes does not leak', () => {
+    const secretKey = 'sk-llm-risk-leak-12345';
+    const record = makeCandidateRecord({
+      llm_assessment: {
+        llm_confidence: 'medium',
+        risk_notes: [`Observed API_KEY=${secretKey} in the agent's output`],
+        uncertainty_notes: [],
+      },
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(JSON.stringify(detail)).not.toContain(secretKey);
+  });
+
+  it('materialization — API_KEY in a string field is redacted', () => {
+    const secretKey = 'sk-materialize-leak-77777';
+    const record = makeCandidateRecord({
+      lifecycle: {
+        status: 'materialized',
+        status_changed_at: new Date().toISOString(),
+        materialization: {
+          materialization_id: 'mat-test',
+          reviewer_note: `Looked at draft; API_KEY=${secretKey} was visible in the body.`,
+        },
+      },
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(JSON.stringify(detail)).not.toContain(secretKey);
+  });
+
+  it('activation — API_KEY in target_summary is redacted', () => {
+    const secretKey = 'sk-activate-leak-88888';
+    const record = makeCandidateRecord({
+      lifecycle: {
+        status: 'activated',
+        status_changed_at: new Date().toISOString(),
+        activation: {
+          activation_id: 'act-test',
+          target_summary: `Token: API_KEY=${secretKey} embedded`,
+        },
+      },
+    });
+    appendCandidate(record);
+
+    const detail = sanitizeDashboardDetail(record.candidate_id);
+    expect(JSON.stringify(detail)).not.toContain(secretKey);
+  });
 });


### PR DESCRIPTION
## Summary

PR-D of the 2026-05-22 spec realignment plan. Closes all Layer 6 first-slice drift by upgrading the dashboard wire model + request envelope + detail view to spec, with secret-leak hardening and XSS fixes on the way.

## Changes

**Wire model (DashboardCandidateCard)**
- Adds \`evidence_quality_chip\` (low_signal/medium_signal/high_signal derived from \`evidence_quality\`).
- Adds \`relationships\` (copied when present, omitted otherwise).
- Adds \`evidence_counts\` (\`{ total, by_type }\`) computed from \`evidence[]\`.
- Adds \`risk_note_count\` + \`uncertainty_note_count\` from \`llm_assessment\`.

**Request envelope — optimistic concurrency**
- Server now reads \`expected_current_status\` from each action request. Mismatch against fresh \`queue.jsonl\` current view → \`stale_status\` reject with HTTP 409.

**Request envelope — safety_ack**
- \`activate\` requires \`safety_ack\` with \`reviewer_saw_behavior_change_warning: true\` AND \`reviewer_saw_target_path_summary: true\`.
- \`deactivate\` requires \`safety_ack\` with \`reviewer_saw_behavior_change_warning: true\`.
- Missing/false → \`missing_safety_ack\` reject.

**Request envelope — actor default + reason audit**
- \`actor\` defaults to \`{ layer: 6, actor_type: 'dashboard', reviewer: 'local_user' }\` when omitted.
- \`reason\` (optional user note) is persisted to \`actions.jsonl\` audit entries.

**Detail view (DashboardCandidateDetail)**
- Adds \`evidence_summaries\` (mapped from \`evidence[]\`, each summary + relevance sanitized).
- Adds \`llm_assessment\` (sanitized via \`sanitizeAssessmentBlock\` — risk_notes / uncertainty_notes / rationale all run through \`redactObservationText\`).
- Adds \`materialization\` + \`activation\` (sanitized via \`sanitizeProvenanceBlock\` — string fields run through \`redactObservationText\`; hash/numeric/boolean preserved).

**HTML UI**
- New CSS for evidence_quality_chip pills, risk/uncertainty badges, evidence_counts summary, relationships link.
- Collapsible \`<details>\` for evidence_summaries.
- Blocks for llm_assessment + materialization + activation in the detail panel.
- All rendered with \`createElement\` + \`textContent\` (XSS-safe — replaced 4 \`innerHTML\` sites the implementer had used).

**File-size discipline**
- \`learning-dashboard.js\` grew to 749 lines; hard limit is 700. Extracted HTTP layer (security headers, request body, router, server lifecycle) to new sibling \`scripts/lib/learning-dashboard-http.js\` (197 lines). Wire-model + action handlers stay in main file (559 lines). Old import paths preserved via re-export so \`cli.js\` doesn't need to change.

**New eval scenario**
- \`evals/scenarios/dashboard-concurrency-guard.md\` — two concurrent reviewers, second sees stale status, second's action correctly rejects.

## Tests added

- 27 new tests in \`tests/scripts/learning-dashboard.test.js\` covering wire model (5), envelope (8), detail view (10), and 4 secret-leak fixtures for the new detail blocks (evidence summary / llm_assessment / materialization / activation — all with realistic API_KEY=<secret> fixtures).

## Test plan

- [x] \`npm run test:scripts\` — 1777 passed
- [x] \`npm run test:hooks\` — 213 passed
- [x] \`npm run test:node\` — 7 passed
- [x] \`npm run test:skills\` — 546 passed, 12 pre-existing failures (orphan test deleted by PR #46)
- [x] \`npm run lint\` — clean
- [x] File sizes: dashboard.js 559, dashboard-http.js 197 (both under 700 hard limit)
- [x] Wire model never returns raw secret strings (sanitizer applied at every wire boundary).
- [x] No \`innerHTML\` in dashboard HTML (XSS-safe).
- [x] Stale \`expected_current_status\` returns HTTP 409.
- [x] Activate without safety_ack returns \`missing_safety_ack\` reject.

## Risk

High UX impact (dashboard look/feel changes) but low correctness risk:
- All wire-model additions are additive; no existing fields removed.
- Concurrency guard rejects stale requests rather than silently overwriting — only blocks bad requests.
- safety_ack gating is enforced server-side; legacy clients that don't send ack will see \`missing_safety_ack\` until updated. The dashboard UI sends the ack automatically per the new HTML.
- HTTP layer extraction is API-stable (re-export preserves old call sites).

## Stacking

Based on \`feat/learning-curator-pivot\`. Does NOT depend on PR-B (#48) or PR-C (#49). Merges independently.

After PR-A (#47) + PR-B (#48) + PR-C (#49) + this PR all merge, the 2026-05-21 audit report will be fully addressed except items intentionally codified as first-slice acceptance.

Per the parent plan at \`/Users/gregho/.claude/plans/read-documents-below-docs-plans-2026-05-spicy-conway.md\`.