### PR TITLE
fix(learning): PR-E — Layer 5 validator + ingestor hardening (3 drifts, 7 rejection codes)

### DIFF
--- a/scripts/lib/learning-curator/batch-assembler.js
+++ b/scripts/lib/learning-curator/batch-assembler.js
@@ -610,6 +610,10 @@ function assembleBatch({ project, homeDir: homeOverride } = {}) {
     evidence_status_by_id: Object.fromEntries(
       evidenceItems.map((e) => [e.evidence_id, e.evidence_status]),
     ),
+    // evidence_type_by_id: needed by ingest-proposal for evidence_type_mismatch check
+    evidence_type_by_id: Object.fromEntries(
+      evidenceItems.map((e) => [e.evidence_id, e.evidence_type]),
+    ),
   };
 
   // Atomic writes (sibling tmp + rename) prevent truncated files on crash —

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -280,19 +280,20 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
   }
 
   // Load batch manifest (needed for evidence_id validation and project context).
-  // A missing manifest is a hard error — source_batch_hash is required (string) in
-  // CuratorRunManifest; we cannot construct a valid run record without it.
+  // Per Layer 5 spec L244, a missing manifest is a rejection (not a hard throw):
+  // the run_id is derivable from the response hash, so we can still write an audit record.
   const batchManifest = loadBatchManifest(batchId, homeDir);
   if (!batchManifest) {
-    throw new Error(
-      `ingestProposal: batch manifest not found for batch_id "${batchId}". ` +
-        'Run assemble-batch first.',
-    );
+    const detail = `batch manifest not found for batch_id "${batchId}" — run assemble-batch first`;
+    const source = { source_type: 'layer4_llm_curator', batch_id: batchId };
+    rejectProposal([{ code: 'source_manifest_missing', detail }], source);
+    return { run_id: null, parse_status: 'source_manifest_missing', accepted: 0, rejected: 1 };
   }
   const validEvidenceIds = new Set(
     Array.isArray(batchManifest.evidence_ids) ? batchManifest.evidence_ids : [],
   );
   const evidenceStatusById = batchManifest.evidence_status_by_id || {};
+  const evidenceTypeById = batchManifest.evidence_type_by_id || {};
 
   // Base run manifest fields
   const runManifest = {
@@ -369,6 +370,25 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
     runManifest.parse_status = 'empty';
     persistRunManifest(runManifest, homeDir);
     return { run_id: runId, parse_status: 'empty', accepted: 0, rejected: 0 };
+  }
+
+  // Verify batch_hash in payload matches loaded manifest — detects stale or misrouted responses.
+  const payloadBatchHash = payload.source?.batch_hash;
+  if (payloadBatchHash !== undefined && payloadBatchHash !== batchManifest.batch_hash) {
+    const source = { source_type: 'layer4_llm_curator', batch_id: batchId };
+    rejectProposal(
+      [
+        {
+          code: 'source_hash_mismatch',
+          detail: `expected batch_hash "${batchManifest.batch_hash}", got "${payloadBatchHash}"`,
+        },
+      ],
+      source,
+    );
+    runManifest.parse_status = 'source_hash_mismatch';
+    runManifest.rejected_count = 1;
+    persistRunManifest(runManifest, homeDir);
+    return { run_id: runId, parse_status: 'source_hash_mismatch', accepted: 0, rejected: 1 };
   }
 
   runManifest.proposal_count = proposals.length;
@@ -452,6 +472,27 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
         })),
         source,
       );
+      continue;
+    }
+
+    // Check for evidence_type mismatches: proposal's claimed type must match batch's actual type
+    const typeMismatchReasons = [];
+    if (Array.isArray(proposal.evidence_refs)) {
+      for (let i = 0; i < proposal.evidence_refs.length; i++) {
+        const ref = proposal.evidence_refs[i];
+        const actualType = evidenceTypeById[ref.evidence_id];
+        if (actualType !== undefined && ref.evidence_type !== actualType) {
+          typeMismatchReasons.push({
+            code: 'evidence_type_mismatch',
+            field_path: `evidence_refs[${i}]`,
+            detail: `evidence_id "${ref.evidence_id}" has type "${actualType}" in batch but proposal claims "${ref.evidence_type}"`,
+          });
+        }
+      }
+    }
+    if (typeMismatchReasons.length > 0) {
+      const source = { source_type: 'layer4_llm_curator', batch_id: batchId };
+      rejectProposal(typeMismatchReasons, source);
       continue;
     }
 

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -12,7 +12,9 @@
  * Per Layer 4 spec (layer-4-llm-curator-analysis.md):
  * - CuratorRunManifest persisted for every attempted run (even failures)
  * - raw_prompt_saved: false, raw_response_saved: false (default off)
- * - parse_status: "parsed" | "empty" | "malformed_json" | "non_object"
+ * - parse_status (open enum of run outcomes):
+ *     "parsed" | "empty" | "malformed_json" | "non_object" |
+ *     "transport_error" | "source_hash_mismatch" | "source_manifest_missing"
  *
  * Idempotency: run_id is derived deterministically from (batch_id, response_hash,
  * prompt_policy_version). If the same run_id manifest already exists, the prior
@@ -373,6 +375,8 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
   }
 
   // Verify batch_hash in payload matches loaded manifest — detects stale or misrouted responses.
+  // Ordered after the empty-proposals guard because an empty payload is inert (no record reaches
+  // the queue) regardless of hash; the hash check is only material when there's something to admit.
   const payloadBatchHash = payload.source?.batch_hash;
   if (payloadBatchHash !== undefined && payloadBatchHash !== batchManifest.batch_hash) {
     const source = { source_type: 'layer4_llm_curator', batch_id: batchId };

--- a/scripts/lib/learning-curator/schema.js
+++ b/scripts/lib/learning-curator/schema.js
@@ -63,6 +63,13 @@ const FIELD_LIMITS = {
 };
 
 // ---------------------------------------------------------------------------
+// Evidence count bounds (pin to prompt's 2-5)
+// ---------------------------------------------------------------------------
+
+const MIN_EVIDENCE_REFS = 2;
+const MAX_EVIDENCE_REFS = 5;
+
+// ---------------------------------------------------------------------------
 // Evidence quality formula (v1) — project_obs_count only
 // ---------------------------------------------------------------------------
 
@@ -190,7 +197,7 @@ function validateCandidateV1(record) {
     // missing
   } else if (!ARTIFACT_TYPES.includes(record.artifact_type)) {
     add(
-      'schema_invalid',
+      'artifact_type_not_allowed',
       'artifact_type',
       `artifact_type "${record.artifact_type}" is not allowed`,
     );
@@ -206,7 +213,7 @@ function validateCandidateV1(record) {
     } else {
       if (!['project', 'global'].includes(scope.kind)) {
         add(
-          'schema_invalid',
+          'scope_not_allowed',
           'scope.kind',
           `scope.kind "${scope.kind}" must be "project" or "global"`,
         );
@@ -302,6 +309,19 @@ function validateCandidateV1(record) {
   } else if (!isArray(record.evidence)) {
     add('schema_invalid', 'evidence', 'evidence must be an array');
   } else {
+    if (record.evidence.length < MIN_EVIDENCE_REFS) {
+      add(
+        'too_few_evidence_refs',
+        'evidence',
+        `evidence must have at least ${MIN_EVIDENCE_REFS} entries (got ${record.evidence.length})`,
+      );
+    } else if (record.evidence.length > MAX_EVIDENCE_REFS) {
+      add(
+        'too_many_evidence_refs',
+        'evidence',
+        `evidence must have at most ${MAX_EVIDENCE_REFS} entries (got ${record.evidence.length})`,
+      );
+    }
     for (let i = 0; i < record.evidence.length; i++) {
       const ev = record.evidence[i];
       if (!isObject(ev)) {
@@ -540,4 +560,6 @@ module.exports = {
   REJECTION_CODES,
   VALIDATOR_VERSION,
   EVIDENCE_QUALITY_RULE_VERSION,
+  MIN_EVIDENCE_REFS,
+  MAX_EVIDENCE_REFS,
 };

--- a/skills/arc-observing/tests/run-tests.sh
+++ b/skills/arc-observing/tests/run-tests.sh
@@ -412,16 +412,65 @@ done
 
 # Slice E.2b: daemon calls claude with `--output-format json --json-schema ...`,
 # so the response file is a CLI envelope whose .structured_output holds the payload.
-# The stub mimics that envelope shape — proposal-ingestor.js extracts structured_output.
-STUB_PAYLOAD='{"schema_version":1,"source":{"layer":4,"curator":"llm","run_id":"curator_run_20260521T030000Z_aabbccddee11","created_at":"2026-05-21T03:00:00.000Z","batch_id":"STUB_BATCH","batch_hash":"STUB_HASH","prompt_policy_version":"v1","output_schema_version":1},"proposals":[{"proposal_index":0,"artifact_type":"instinct","proposed_scope":{"kind":"project","project_id":"proj_abc123456789ab"},"name":"e2-test-instinct","summary":"Test instinct from E2 stub","rationale":"Observed in E2 test fixture","domain":"workflow","body":"When in E2 test, always write tests first.","body_source":"llm_curator","evidence_refs":[],"llm_confidence":"medium","risk_notes":[],"uncertainty_notes":[],"recommended_review_action":"review"}]}'
-STUB_ENVELOPE='{"type":"result","subtype":"success","is_error":false,"api_error_status":null,"duration_ms":100,"result":"stub success","structured_output":'$STUB_PAYLOAD'}'
-
-# Stub claude that emits the CLI envelope (matches --output-format json + --json-schema)
+# The stub reads the latest batch manifest to get the real batch_hash and evidence_ids,
+# then emits a valid CandidateProposalPayload with ≥2 evidence_refs (MIN_EVIDENCE_REFS=2).
 cat > "${STUB_BIN_G3}/claude" << STUB_EOF
 #!/usr/bin/env bash
-# Consume stdin (prompt file piped in), emit the known envelope
+# Consume stdin (prompt file piped in)
 cat > /dev/null
-printf '%s\n' '$STUB_ENVELOPE'
+# Find the most recent batch manifest in TEST_HOME_G3
+BATCHES_DIR="${TEST_HOME_G3}/.arcforge/learning/curator-batches"
+MANIFEST_FILE=\$(ls -t "\${BATCHES_DIR}"/*.manifest.json 2>/dev/null | head -1)
+if [ -z "\$MANIFEST_FILE" ]; then
+  # Fallback: emit empty proposals (ingestor will write empty parse_status)
+  printf '{"type":"result","subtype":"success","is_error":false,"duration_ms":100,"result":"stub","structured_output":{"schema_version":1,"source":{"layer":4,"curator":"llm","run_id":"stub_run","created_at":"2026-05-21T03:00:00.000Z","prompt_policy_version":"v1","output_schema_version":1},"proposals":[]}}\n'
+  exit 0
+fi
+# Extract batch_id, batch_hash, and first 2 evidence_ids from manifest via node
+node -e "
+  const m = JSON.parse(require('fs').readFileSync('\${MANIFEST_FILE}','utf8'));
+  const ids = (m.evidence_ids || []).slice(0,2);
+  const typeById = m.evidence_type_by_id || {};
+  const refs = ids.map((id,i) => ({
+    evidence_id: id,
+    evidence_type: typeById[id] || 'observation',
+    relevance: 'E2 test evidence ref ' + i
+  }));
+  const payload = {
+    schema_version: 1,
+    source: {
+      layer: 4, curator: 'llm',
+      run_id: 'curator_run_e2_stub_00000000',
+      created_at: '2026-05-21T03:00:00.000Z',
+      batch_id: m.batch_id,
+      batch_hash: m.batch_hash,
+      prompt_policy_version: 'v1',
+      output_schema_version: 1
+    },
+    proposals: refs.length >= 2 ? [{
+      proposal_index: 0,
+      artifact_type: 'instinct',
+      proposed_scope: { kind: 'project', project_id: m.scope && m.scope.project_id || 'proj_abc123456789ab' },
+      name: 'e2-test-instinct',
+      summary: 'Test instinct from E2 stub',
+      rationale: 'Observed in E2 test fixture',
+      domain: 'workflow',
+      body: 'When in E2 test, always write tests first.',
+      body_source: 'llm_curator',
+      evidence_refs: refs,
+      llm_confidence: 'medium',
+      risk_notes: [],
+      uncertainty_notes: [],
+      recommended_review_action: 'review'
+    }] : []
+  };
+  const envelope = {
+    type: 'result', subtype: 'success', is_error: false,
+    api_error_status: null, duration_ms: 100,
+    result: 'stub success', structured_output: payload
+  };
+  process.stdout.write(JSON.stringify(envelope) + '\n');
+"
 STUB_EOF
 chmod +x "${STUB_BIN_G3}/claude"
 

--- a/tests/scripts/learning-curator-proposal-ingestor.test.js
+++ b/tests/scripts/learning-curator-proposal-ingestor.test.js
@@ -454,14 +454,22 @@ describe('ingestProposal — non_object', () => {
 // ---------------------------------------------------------------------------
 
 describe('ingestProposal — missing batch manifest', () => {
-  test('throws when batch manifest does not exist for given batch_id', () => {
+  test('missing batch manifest produces rejection (not throw) with parse_status source_manifest_missing', () => {
     const { ingestProposal } = getIngestor();
     // Do NOT call makeBatchManifest — no manifest on disk
     const responsePath = makeResponseFile({ proposals: [] });
 
-    expect(() =>
-      ingestProposal({ batchId: 'batch_nonexistent_000000000000', responseFile: responsePath }),
-    ).toThrow(/batch manifest not found/i);
+    // Must not throw — per Layer 5 spec L244: missing manifest is a rejection
+    let result;
+    expect(() => {
+      result = ingestProposal({
+        batchId: 'batch_nonexistent_000000000000',
+        responseFile: responsePath,
+      });
+    }).not.toThrow();
+
+    expect(result.parse_status).toBe('source_manifest_missing');
+    expect(result.accepted).toBe(0);
   });
 });
 
@@ -738,5 +746,202 @@ describe('recordRunFailure — writes failure manifest', () => {
     });
     // Both runs produce same run_id (same batchId+parseStatus+timestamp-second)
     expect(r1.run_id).toBe(r2.run_id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 6: source_manifest_missing as REJECTION, not THROW (PR-E Drift #4)
+// ---------------------------------------------------------------------------
+
+describe('ingestProposal — source_manifest_missing rejection (not throw)', () => {
+  test('missing batch manifest produces rejection record, does not throw', () => {
+    const { ingestProposal } = getIngestor();
+    // Do NOT call makeBatchManifest — no manifest on disk
+    const responsePath = makeResponseFile({ proposals: [] });
+
+    // Must not throw
+    let result;
+    expect(() => {
+      result = ingestProposal({
+        batchId: 'batch_nonexistent_000000000000',
+        responseFile: responsePath,
+      });
+    }).not.toThrow();
+
+    // Should return a failure shape (not parsed)
+    expect(result).toBeDefined();
+    expect(result.parse_status).toBe('source_manifest_missing');
+    expect(result.accepted).toBe(0);
+    expect(result.rejected).toBe(1);
+  });
+
+  test('rejection record with code source_manifest_missing is written to rejections.jsonl', () => {
+    const { ingestProposal } = getIngestor();
+    const responsePath = makeResponseFile({ proposals: [] });
+
+    ingestProposal({ batchId: 'batch_nonexistent_000000000000', responseFile: responsePath });
+
+    const rejections = readRejections();
+    expect(rejections.length).toBe(1);
+    const reasons = rejections[0].reasons || [];
+    expect(reasons.some((r) => r.code === 'source_manifest_missing')).toBe(true);
+  });
+
+  test('queue.jsonl gets nothing when manifest is missing', () => {
+    const { ingestProposal } = getIngestor();
+    const responsePath = makeResponseFile({ proposals: [] });
+
+    ingestProposal({ batchId: 'batch_nonexistent_000000000000', responseFile: responsePath });
+
+    const candidates = readCurrentCandidates();
+    expect(Object.keys(candidates).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 5: source_hash_mismatch (PR-E Drift #3)
+// ---------------------------------------------------------------------------
+
+describe('ingestProposal — source_hash_mismatch', () => {
+  test('mismatched batch_hash in payload produces rejection with source_hash_mismatch', () => {
+    const { ingestProposal } = getIngestor();
+    const { batchId } = makeBatchManifest();
+    // Payload has the WRONG batch_hash
+    const payload = makeValidProposalPayload(batchId, 'wronghash000000000000');
+    const responsePath = makeResponseFile(payload);
+
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.accepted).toBe(0);
+    expect(result.rejected).toBeGreaterThanOrEqual(1);
+
+    const rejections = readRejections();
+    expect(rejections.length).toBeGreaterThanOrEqual(1);
+    const reasons = rejections[0].reasons || [];
+    expect(reasons.some((r) => r.code === 'source_hash_mismatch')).toBe(true);
+    const mismatchReason = reasons.find((r) => r.code === 'source_hash_mismatch');
+    expect(mismatchReason.detail).toMatch(/a1b2c3d4e5f6/); // expected hash from manifest
+  });
+
+  test('correct batch_hash passes without hash mismatch rejection', () => {
+    const { ingestProposal } = getIngestor();
+    const { manifest, batchId } = makeBatchManifest();
+    const payload = makeValidProposalPayload(batchId, manifest.batch_hash);
+    const responsePath = makeResponseFile(payload);
+
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.accepted).toBe(1);
+    expect(result.rejected).toBe(0);
+
+    const rejections = readRejections();
+    expect(rejections.length).toBe(0);
+  });
+
+  test('hash mismatch stops all proposal processing (queue gets nothing)', () => {
+    const { ingestProposal } = getIngestor();
+    const { batchId } = makeBatchManifest();
+    const payload = makeValidProposalPayload(batchId, 'stale_hash_00000000000');
+    const responsePath = makeResponseFile(payload);
+
+    ingestProposal({ batchId, responseFile: responsePath });
+
+    const candidates = readCurrentCandidates();
+    expect(Object.keys(candidates).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 4: evidence_type_mismatch (PR-E Drift #2c)
+// ---------------------------------------------------------------------------
+
+describe('ingestProposal — evidence_type_mismatch', () => {
+  test('proposal citing diary evidence_id with wrong evidence_type is rejected', () => {
+    const { ingestProposal } = getIngestor();
+    // Batch has a diary item as ev_diary_001
+    const { manifest, batchId } = makeBatchManifest({
+      evidence_ids: ['ev_diary_001', 'ev_obs_001'],
+      evidence_status_by_id: {
+        ev_diary_001: 'present',
+        ev_obs_001: 'present',
+      },
+      evidence_type_by_id: {
+        ev_diary_001: 'diary',
+        ev_obs_001: 'observation',
+      },
+    });
+
+    const payload = {
+      schema_version: 1,
+      source: {
+        layer: 4,
+        curator: 'llm',
+        run_id: 'curator_run_type_mismatch_test',
+        created_at: '2026-05-21T01:00:00.000Z',
+        batch_id: batchId,
+        batch_hash: manifest.batch_hash,
+        prompt_policy_version: 'v1',
+        output_schema_version: 1,
+      },
+      proposals: [
+        {
+          proposal_index: 0,
+          artifact_type: 'instinct',
+          proposed_scope: { kind: 'project', project_id: 'proj_abc123456789ab' },
+          name: 'test-instinct',
+          summary: 'A test instinct.',
+          rationale: 'Observed pattern.',
+          domain: 'workflow',
+          body: 'Always test your code.',
+          body_source: 'llm_curator',
+          // Claims diary evidence as 'observation' — type mismatch!
+          evidence_refs: [
+            {
+              evidence_id: 'ev_diary_001',
+              evidence_type: 'observation', // WRONG — batch has this as 'diary'
+              relevance: 'direct',
+            },
+            {
+              evidence_id: 'ev_obs_001',
+              evidence_type: 'observation', // correct
+              relevance: 'supporting',
+            },
+          ],
+          llm_confidence: 'medium',
+          risk_notes: [],
+          uncertainty_notes: [],
+          recommended_review_action: 'review',
+        },
+      ],
+    };
+
+    const responsePath = makeResponseFile(payload);
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.accepted).toBe(0);
+    expect(result.rejected).toBeGreaterThanOrEqual(1);
+
+    const rejections = readRejections();
+    expect(rejections.length).toBeGreaterThanOrEqual(1);
+    const reasons = rejections[0].reasons || [];
+    expect(reasons.some((r) => r.code === 'evidence_type_mismatch')).toBe(true);
+    const mismatchReason = reasons.find((r) => r.code === 'evidence_type_mismatch');
+    expect(mismatchReason.field_path).toMatch(/evidence_refs\[0\]/);
+  });
+
+  test('correct evidence_type for all refs passes without type mismatch', () => {
+    const { ingestProposal } = getIngestor();
+    const { manifest, batchId } = makeBatchManifest({
+      evidence_ids: ['ev_001', 'ev_002'],
+      evidence_status_by_id: { ev_001: 'present', ev_002: 'present' },
+      evidence_type_by_id: { ev_001: 'observation', ev_002: 'observation' },
+    });
+
+    const payload = makeValidProposalPayload(batchId, manifest.batch_hash);
+    const responsePath = makeResponseFile(payload);
+    const result = ingestProposal({ batchId, responseFile: responsePath });
+
+    expect(result.accepted).toBe(1);
+    expect(result.rejected).toBe(0);
   });
 });

--- a/tests/scripts/learning-curator-queue-writer.test.js
+++ b/tests/scripts/learning-curator-queue-writer.test.js
@@ -69,6 +69,12 @@ function makeValidRecord(overrides = {}) {
         relevance: 'User repeatedly used grep before editing files',
         summary: 'Observed grep-first pattern 5 times across 3 sessions',
       },
+      {
+        evidence_id: 'ev_def456',
+        evidence_type: 'observation',
+        relevance: 'Second observation supporting the pattern',
+        summary: 'Confirmed grep-first pattern in another session',
+      },
     ],
     evidence_quality: 'medium',
     evidence_quality_metadata: {
@@ -337,6 +343,11 @@ appendCandidate({
     evidence_type: 'observation',
     relevance: 'r',
     summary: 's',
+  }, {
+    evidence_id: 'e2',
+    evidence_type: 'observation',
+    relevance: 'r2',
+    summary: 's2',
   }],
   evidence_quality: 'low',
   evidence_quality_metadata: {

--- a/tests/scripts/learning-curator-schema.test.js
+++ b/tests/scripts/learning-curator-schema.test.js
@@ -4,6 +4,8 @@ const {
   validateCandidateV1,
   REJECTION_CODES,
   VALIDATOR_VERSION,
+  MIN_EVIDENCE_REFS,
+  MAX_EVIDENCE_REFS,
 } = require('../../scripts/lib/learning-curator/schema');
 
 // ---------------------------------------------------------------------------
@@ -35,7 +37,7 @@ function makeRecord(overrides = {}) {
     domain: 'workflow',
     body: 'When editing files, first grep for existing patterns to avoid duplication',
     body_source: 'llm_curator',
-    evidence: [makeEvidence()],
+    evidence: [makeEvidence(), makeEvidence({ evidence_id: 'ev_def456' })],
     evidence_quality: 'medium',
     evidence_quality_metadata: {
       rule_version: 'v1',
@@ -270,7 +272,7 @@ describe('validateCandidateV1 — enum violations', () => {
     const r = makeRecord({ artifact_type: 'bot' });
     const res = validateCandidateV1(r);
     expect(res.ok).toBe(false);
-    expect(res.reasons.some((r) => r.code === 'schema_invalid')).toBe(true);
+    expect(res.reasons.some((r) => r.code === 'artifact_type_not_allowed')).toBe(true);
   });
 
   it('rejects unknown body_source', () => {
@@ -297,6 +299,107 @@ describe('validateCandidateV1 — enum violations', () => {
     const r = makeRecord({ scope: { kind: 'team' } });
     const res = validateCandidateV1(r);
     expect(res.ok).toBe(false);
+    expect(res.reasons.some((r) => r.code === 'scope_not_allowed')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion #1 — artifact_type_not_allowed (PR-E Drift #2a)
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — artifact_type_not_allowed', () => {
+  it('accepts valid artifact_type "instinct"', () => {
+    const r = makeRecord({ artifact_type: 'instinct' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts valid artifact_type "skill"', () => {
+    const r = makeRecord({ artifact_type: 'skill' });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('rejects bad artifact_type with code artifact_type_not_allowed, NOT schema_invalid', () => {
+    const r = makeRecord({ artifact_type: 'fake_type' });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    const codes = res.reasons.map((r) => r.code);
+    expect(codes).toContain('artifact_type_not_allowed');
+    expect(codes).not.toContain('schema_invalid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion #2 — scope_not_allowed (PR-E Drift #2b)
+// ---------------------------------------------------------------------------
+
+describe('validateCandidateV1 — scope_not_allowed', () => {
+  it('accepts scope.kind "project"', () => {
+    const r = makeRecord({ scope: { kind: 'project', project: 'myproj', project_id: 'p_123' } });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts scope.kind "global"', () => {
+    const r = makeRecord({ scope: { kind: 'global' } });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('rejects bad scope.kind with code scope_not_allowed, NOT schema_invalid', () => {
+    const r = makeRecord({ scope: { kind: 'invalid' } });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    const codes = res.reasons.map((r) => r.code);
+    expect(codes).toContain('scope_not_allowed');
+    expect(codes).not.toContain('schema_invalid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion #3 — too_few_evidence_refs + too_many_evidence_refs (PR-E Drift #2d/e)
+// ---------------------------------------------------------------------------
+
+describe('MIN_EVIDENCE_REFS / MAX_EVIDENCE_REFS constants', () => {
+  it('MIN_EVIDENCE_REFS is exported and equals 2', () => {
+    expect(MIN_EVIDENCE_REFS).toBe(2);
+  });
+
+  it('MAX_EVIDENCE_REFS is exported and equals 5', () => {
+    expect(MAX_EVIDENCE_REFS).toBe(5);
+  });
+});
+
+describe('validateCandidateV1 — evidence count enforcement', () => {
+  function makeEvidenceArray(n) {
+    return Array.from({ length: n }, (_, i) => makeEvidence({ evidence_id: `ev_test_${i}` }));
+  }
+
+  it('accepts exactly 2 evidence refs (MIN)', () => {
+    const r = makeRecord({ evidence: makeEvidenceArray(2) });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('accepts exactly 5 evidence refs (MAX)', () => {
+    const r = makeRecord({ evidence: makeEvidenceArray(5) });
+    expect(validateCandidateV1(r).ok).toBe(true);
+  });
+
+  it('rejects 1 evidence ref with code too_few_evidence_refs', () => {
+    const r = makeRecord({ evidence: makeEvidenceArray(1) });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    const codes = res.reasons.map((r) => r.code);
+    expect(codes).toContain('too_few_evidence_refs');
+    const reason = res.reasons.find((r) => r.code === 'too_few_evidence_refs');
+    expect(reason.field_path).toBe('evidence');
+  });
+
+  it('rejects 6 evidence refs with code too_many_evidence_refs', () => {
+    const r = makeRecord({ evidence: makeEvidenceArray(6) });
+    const res = validateCandidateV1(r);
+    expect(res.ok).toBe(false);
+    const codes = res.reasons.map((r) => r.code);
+    expect(codes).toContain('too_many_evidence_refs');
+    const reason = res.reasons.find((r) => r.code === 'too_many_evidence_refs');
+    expect(reason.field_path).toBe('evidence');
   });
 });
 
@@ -489,10 +592,10 @@ describe('validateCandidateV1 — rejection reason codes', () => {
     expect(res.reasons.some((r) => r.code === 'field_too_long')).toBe(true);
   });
 
-  it('emits schema_invalid for unknown artifact_type', () => {
+  it('emits artifact_type_not_allowed for unknown artifact_type', () => {
     const r = makeRecord({ artifact_type: 'unknown' });
     const res = validateCandidateV1(r);
-    expect(res.reasons.some((r) => r.code === 'schema_invalid')).toBe(true);
+    expect(res.reasons.some((r) => r.code === 'artifact_type_not_allowed')).toBe(true);
   });
 });
 

--- a/tests/scripts/learning-dashboard.test.js
+++ b/tests/scripts/learning-dashboard.test.js
@@ -16,6 +16,26 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 
 // ---------------------------------------------------------------------------
+// Helper — write a candidate event directly to queue.jsonl, bypassing
+// schema validation (for testing edge-case states like empty evidence).
+// ---------------------------------------------------------------------------
+
+function writeDirectlyToQueue(record) {
+  const queuePath = path.join(os.homedir(), '.arcforge', 'learning', 'candidates', 'queue.jsonl');
+  fs.mkdirSync(path.dirname(queuePath), { recursive: true });
+  const event = {
+    schema_version: 1,
+    event_id: `evt_direct_${crypto.randomBytes(4).toString('hex')}`,
+    ts: new Date().toISOString(),
+    candidate_id: record.candidate_id,
+    event_type: 'candidate.created',
+    actor: { layer: 5, actor_type: 'validator' },
+    record,
+  };
+  fs.appendFileSync(queuePath, `${JSON.stringify(event)}\n`, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
 // Helpers — build a valid Candidate v1 record
 // ---------------------------------------------------------------------------
 
@@ -38,6 +58,12 @@ function makeCandidateRecord(overrides = {}) {
         evidence_type: 'observation',
         relevance: 'Direct observation of Edit → Bash pattern.',
         summary: 'Edit then Bash seen in session A.',
+      },
+      {
+        evidence_id: 'ev-002',
+        evidence_type: 'observation',
+        relevance: 'Second observation confirming the pattern.',
+        summary: 'Edit then Bash seen in session B.',
       },
     ],
     evidence_quality: 'low',
@@ -1498,8 +1524,9 @@ describe('PR-D Criterion 5 — detail view evidence_summaries / llm_assessment /
   });
 
   it('evidence_summaries is empty array when candidate has no evidence', () => {
+    // Write directly to queue bypassing schema validation (0 evidence is below MIN_EVIDENCE_REFS)
     const record = makeCandidateRecord({ evidence: [] });
-    appendCandidate(record);
+    writeDirectlyToQueue(record);
 
     const detail = sanitizeDashboardDetail(record.candidate_id);
     expect(detail.evidence_summaries).toEqual([]);
@@ -1567,6 +1594,12 @@ describe('PR-D Criterion 5 — detail view evidence_summaries / llm_assessment /
           evidence_type: 'observation',
           relevance: 'test relevance',
           summary: `API_KEY=${secretKey} was used in the session`,
+        },
+        {
+          evidence_id: 'ev-sec2',
+          evidence_type: 'observation',
+          relevance: 'second evidence',
+          summary: 'Clean evidence entry',
         },
       ],
     });


### PR DESCRIPTION
## Summary

PR-E of the 2026-05-22 re-audit drift fixes. Closes 3 Layer 5 drifts (Drift #2/#3/#4) by enforcing 7 previously-dead rejection codes and tightening the proposal validation path.

## Drifts closed

**Drift #2 — 7 dead rejection codes now emit**:
- \`artifact_type_not_allowed\` (was \`schema_invalid\`) — schema.js
- \`scope_not_allowed\` (was \`schema_invalid\`) — schema.js
- \`evidence_type_mismatch\` — new check in proposal-ingestor.js (uses new \`evidence_type_by_id\` manifest map)
- \`too_few_evidence_refs\` (MIN=2 pinned to prompt) — schema.js
- \`too_many_evidence_refs\` (MAX=5 pinned to prompt) — schema.js
- \`source_manifest_missing\` — proposal-ingestor.js (now rejection, not throw)
- \`source_hash_mismatch\` — proposal-ingestor.js (new round-trip check)

**Drift #3 — batch_hash round-trip cross-check**:
- After loading manifest by batch_id, validator compares \`payload.source.batch_hash === manifest.batch_hash\`. Mismatch → reject with \`source_hash_mismatch\`. Detects stale or misrouted LLM responses.

**Drift #4 — missing batch manifest is a rejection, not a throw**:
- Previously: \`throw new Error('batch manifest not found...')\` — daemon saw fatal error, no rejection record persisted.
- Now: rejection record written with code \`source_manifest_missing\`. Daemon can continue normally; audit trail intact.

## Constants pinned

- \`MIN_EVIDENCE_REFS = 2\` (matches prompt instruction)
- \`MAX_EVIDENCE_REFS = 5\` (matches prompt instruction)

Per user decision: validator + prompt co-evolve. Future prompt changes that adjust these bounds will require validator update — by design.

## parse_status enum expansion

Added \`source_hash_mismatch\` and \`source_manifest_missing\` to the open-enum (joining pre-existing \`transport_error\` from earlier work). Top-of-file docstring updated to reflect the full union.

## Manifest shape additions

\`batch-assembler.js\` now persists \`evidence_type_by_id\` map alongside the existing \`evidence_ids[]\` and \`evidence_status_by_id\`. Used by the new \`evidence_type_mismatch\` check at ingest time.

## Tests added

- \`learning-curator-schema.test.js\`: \`artifact_type_not_allowed\`, \`scope_not_allowed\`, \`too_few_evidence_refs\`, \`too_many_evidence_refs\` rejection codes.
- \`learning-curator-proposal-ingestor.test.js\`: \`evidence_type_mismatch\`, \`source_hash_mismatch\`, \`source_manifest_missing\` rejections (no longer throws).
- \`learning-curator-batch-assembler.test.js\`: \`evidence_type_by_id\` map appears in manifest.
- \`learning-dashboard.test.js\`: fixture \`makeCandidateRecord\` updated to 2 evidence items (was 1) since MIN=2 enforced.

## Test plan

- [x] \`npm run test:scripts\` — 1847 tests pass
- [x] \`npm run test:hooks\` — 213 pass
- [x] \`npm run test:node\` — 7 pass
- [x] \`npm run test:skills\` — 546 pass
- [x] \`npm run lint\` — clean
- [x] E2-G3 shell daemon test stub rewritten dynamically (reads actual manifest to satisfy hash + MIN_EVIDENCE_REFS)

## Risk

Medium. Adds validator strictness on candidate insertion. Forward-compatible: existing accepted candidates stay valid; the new checks block additional malformed cases that previously slipped through as generic \`schema_invalid\` (or threw on missing manifest). No existing acceptance path narrows further than the spec.

## Stacking

Based on \`feat/learning-curator-pivot\`. Independent of PR #51 (eval scenarios) — neither file overlap.

PR-F (Layer 4 daemon failure manifest) is the next planned PR — depends on this one because Drift #1's daemon failure-write path coheres with Drift #4's rejection-on-missing-manifest behavior.

Per the parent plan at \`/Users/gregho/.claude/plans/swift-forging-axolotl.md\`.