### PR TITLE
feat(learning): PR-F — Layer 4 daemon failure manifest (transport_error / timeout)

### DIFF
--- a/scripts/lib/learning-curator/cli.js
+++ b/scripts/lib/learning-curator/cli.js
@@ -22,7 +22,9 @@
 const { assembleBatch } = require('./batch-assembler');
 const { ingestProposal, recordRunFailure } = require('./proposal-ingestor');
 
-const ALLOWED_FAILURE_STATUSES = ['transport_error', 'timeout', 'cli_not_found'];
+// Spec layer-4 §parse_status enum for daemon-side failures.
+// CLI-binary-missing maps to transport_error with detail carrying the reason.
+const ALLOWED_FAILURE_STATUSES = ['transport_error', 'timeout'];
 
 // ---------------------------------------------------------------------------
 // Arg parser — minimal, no external deps
@@ -168,7 +170,7 @@ function cmdHelp() {
       '    Layer 4→5: parse LLM response and ingest proposals into candidate queue.',
       '    Prints JSON: { run_id, parse_status, accepted, rejected }',
       '',
-      '  record-run-failure --batch-id <batch_id> --parse-status <transport_error|timeout|cli_not_found> [--detail <msg>]',
+      '  record-run-failure --batch-id <batch_id> --parse-status <transport_error|timeout> [--detail <msg>]',
       '    Layer 4: write a CuratorRunManifest for a daemon transport failure.',
       '    Prints JSON: { run_id, parse_status, accepted, rejected }',
       '',

--- a/scripts/lib/learning-curator/cli.js
+++ b/scripts/lib/learning-curator/cli.js
@@ -20,7 +20,9 @@
  */
 
 const { assembleBatch } = require('./batch-assembler');
-const { ingestProposal } = require('./proposal-ingestor');
+const { ingestProposal, recordRunFailure } = require('./proposal-ingestor');
+
+const ALLOWED_FAILURE_STATUSES = ['transport_error', 'timeout', 'cli_not_found'];
 
 // ---------------------------------------------------------------------------
 // Arg parser — minimal, no external deps
@@ -113,6 +115,45 @@ function cmdIngestProposal(argv) {
   );
 }
 
+function cmdRecordRunFailure(argv) {
+  const args = parseArgs(argv);
+  const batchId = args['batch-id'];
+  const parseStatus = args['parse-status'];
+  const detail = args.detail || null;
+
+  if (!batchId || typeof batchId !== 'string') {
+    console.error('Error: --batch-id <batch_id> is required for record-run-failure');
+    process.exit(1);
+  }
+  if (!parseStatus || typeof parseStatus !== 'string') {
+    console.error('Error: --parse-status <status> is required for record-run-failure');
+    process.exit(1);
+  }
+  if (!ALLOWED_FAILURE_STATUSES.includes(parseStatus)) {
+    console.error(
+      `Error: --parse-status "${parseStatus}" is not allowed. Allowed values: ${ALLOWED_FAILURE_STATUSES.join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = recordRunFailure({ batchId, parseStatus, detail: detail || undefined });
+  } catch (err) {
+    console.error(`Error: record-run-failure failed: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.log(
+    JSON.stringify({
+      run_id: result.run_id,
+      parse_status: result.parse_status,
+      accepted: result.accepted,
+      rejected: result.rejected,
+    }),
+  );
+}
+
 function cmdHelp() {
   console.log(
     [
@@ -125,6 +166,10 @@ function cmdHelp() {
       '',
       '  ingest-proposal --batch-id <batch_id> --response-file <path>',
       '    Layer 4→5: parse LLM response and ingest proposals into candidate queue.',
+      '    Prints JSON: { run_id, parse_status, accepted, rejected }',
+      '',
+      '  record-run-failure --batch-id <batch_id> --parse-status <transport_error|timeout|cli_not_found> [--detail <msg>]',
+      '    Layer 4: write a CuratorRunManifest for a daemon transport failure.',
       '    Prints JSON: { run_id, parse_status, accepted, rejected }',
       '',
       '  help',
@@ -146,6 +191,9 @@ switch (subcommand) {
     break;
   case 'ingest-proposal':
     cmdIngestProposal(remainingArgs);
+    break;
+  case 'record-run-failure':
+    cmdRecordRunFailure(remainingArgs);
     break;
   case 'help':
   case '--help':

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -512,12 +512,17 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
 // ---------------------------------------------------------------------------
 
 /**
- * Write a minimal CuratorRunManifest for a daemon-side failure
- * (transport_error, timeout, cli_not_found) where no response file exists.
+ * Write a minimal CuratorRunManifest for a daemon-side failure where no
+ * response file exists (claude CLI exited non-zero, watchdog killed it, or
+ * the CLI binary was missing entirely).
+ *
+ * Per Layer 4 spec, parse_status for these paths is exactly one of
+ * `'transport_error'` or `'timeout'`. "CLI not found" maps to transport_error
+ * with the reason carried in `detail`.
  *
  * @param {object} options
  * @param {string} options.batchId
- * @param {string} options.parseStatus — 'transport_error' | 'timeout' | 'cli_not_found'
+ * @param {string} options.parseStatus — 'transport_error' | 'timeout'
  * @param {string} [options.detail]    — free-text reason
  * @param {string} [options.homeDir]   — override home directory (tests)
  * @returns {{ run_id, parse_status, accepted, rejected }}
@@ -548,6 +553,7 @@ function recordRunFailure({ batchId, parseStatus, detail, homeDir: homeOverride 
     detail: detail || null,
     accepted_count: 0,
     rejected_count: 0,
+    proposal_count: 0,
     handed_to_layer5: false,
     prompt_hash: null,
     response_hash: null,

--- a/scripts/lib/learning-curator/proposal-ingestor.js
+++ b/scripts/lib/learning-curator/proposal-ingestor.js
@@ -506,4 +506,58 @@ function ingestProposal({ batchId, responseFile, homeDir: homeOverride, duration
   return { run_id: runId, parse_status: 'parsed', accepted, rejected };
 }
 
-module.exports = { ingestProposal };
+// ---------------------------------------------------------------------------
+// recordRunFailure — Layer 4 spec §10: manifest for every attempted run,
+// including daemon transport failures (no response file available).
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a minimal CuratorRunManifest for a daemon-side failure
+ * (transport_error, timeout, cli_not_found) where no response file exists.
+ *
+ * @param {object} options
+ * @param {string} options.batchId
+ * @param {string} options.parseStatus — 'transport_error' | 'timeout' | 'cli_not_found'
+ * @param {string} [options.detail]    — free-text reason
+ * @param {string} [options.homeDir]   — override home directory (tests)
+ * @returns {{ run_id, parse_status, accepted, rejected }}
+ */
+function recordRunFailure({ batchId, parseStatus, detail, homeDir: homeOverride } = {}) {
+  if (typeof batchId !== 'string' || !batchId.trim()) {
+    throw new Error('recordRunFailure: batchId must be a non-empty string');
+  }
+  if (typeof parseStatus !== 'string' || !parseStatus.trim()) {
+    throw new Error('recordRunFailure: parseStatus must be a non-empty string');
+  }
+
+  const homeDir = homeOverride || os.homedir();
+  const now = new Date();
+  const createdAt = now.toISOString();
+  const ts = compactUtc(now);
+
+  // Deterministic run_id: sha256 of (batchId + parseStatus), same shape as ingestProposal
+  const runIdHash = sha256Truncated(batchId + parseStatus, 12);
+  const runId = `curator_run_${ts}_${runIdHash}`;
+
+  const runManifest = {
+    schema_version: SCHEMA_VERSION,
+    run_id: runId,
+    created_at: createdAt,
+    source_batch_id: batchId,
+    parse_status: parseStatus,
+    detail: detail || null,
+    accepted_count: 0,
+    rejected_count: 0,
+    handed_to_layer5: false,
+    prompt_hash: null,
+    response_hash: null,
+    raw_prompt_saved: false,
+    raw_response_saved: false,
+  };
+
+  persistRunManifest(runManifest, homeDir);
+
+  return { run_id: runId, parse_status: parseStatus, accepted: 0, rejected: 0 };
+}
+
+module.exports = { ingestProposal, recordRunFailure };

--- a/skills/arc-observing/scripts/observer-daemon.sh
+++ b/skills/arc-observing/scripts/observer-daemon.sh
@@ -301,10 +301,12 @@ analyze_project() {
       fi
     else
       log_msg "WARNING: claude CLI not found, skipping analysis"
-      # PR-F: write failure manifest for cli_not_found
+      # PR-F: write failure manifest. CLI-binary-missing is recorded as
+      # transport_error per layer-4 spec parse_status enum; detail carries
+      # the "not found in PATH" specific reason.
       node "$CURATOR_CLI" record-run-failure \
         --batch-id "$batch_id" \
-        --parse-status "cli_not_found" \
+        --parse-status "transport_error" \
         --detail "claude CLI not found in PATH" \
         > /dev/null 2>&1 || true
       return
@@ -425,8 +427,8 @@ daemon_loop() {
 
   # Cleanup lock + transient analyzer files on exit; also remove ANALYZING lock to prevent stale lock after crash.
   # Also clean up any transient curator response files left by an interrupted analysis.
-  trap 'log_msg "Daemon stopping (EXIT)"; rm -f "${INSTINCTS_DIR}/.analyzing.lock" "${INSTINCTS_DIR}/.analyzing.output.tmp" "${INSTINCTS_DIR}"/.curator-response.*.json; remove_lock' EXIT
-  trap 'log_msg "Daemon stopping (signal)"; rm -f "${INSTINCTS_DIR}/.analyzing.lock" "${INSTINCTS_DIR}/.analyzing.output.tmp" "${INSTINCTS_DIR}"/.curator-response.*.json; remove_lock; exit 0' TERM INT
+  trap 'log_msg "Daemon stopping (EXIT)"; rm -f "${INSTINCTS_DIR}/.analyzing.lock" "${INSTINCTS_DIR}/.analyzing.output.tmp" "${INSTINCTS_DIR}"/.curator-response.*.json "${INSTINCTS_DIR}"/.watchdog-fired.*; remove_lock' EXIT
+  trap 'log_msg "Daemon stopping (signal)"; rm -f "${INSTINCTS_DIR}/.analyzing.lock" "${INSTINCTS_DIR}/.analyzing.output.tmp" "${INSTINCTS_DIR}"/.curator-response.*.json "${INSTINCTS_DIR}"/.watchdog-fired.*; remove_lock; exit 0' TERM INT
 
   # SIGUSR1 handler with cooldown
   handle_sigusr1() {

--- a/skills/arc-observing/scripts/observer-daemon.sh
+++ b/skills/arc-observing/scripts/observer-daemon.sh
@@ -232,11 +232,16 @@ analyze_project() {
   local tmp_out="${INSTINCTS_DIR}/.analyzing.output.tmp"
   trap 'rm -f "$tmp_out" "$response_file"' RETURN
 
+  # Marker file: set by watchdog subshell before killing claude.
+  # Lets the outer loop distinguish timeout from plain transport_error.
+  local watchdog_fired_marker="${INSTINCTS_DIR}/.watchdog-fired.${batch_id}"
+
   while [ "$retry_count" -le "$max_retries" ] && [ "$analysis_success" = false ]; do
     if command -v claude &>/dev/null; then
       local exit_code=0
       local claude_pid=""
       local watchdog_pid=""
+      rm -f "$watchdog_fired_marker"
 
       # Pipe prompt file to claude; capture JSON envelope to response_file.
       # --output-format json + --json-schema forces structured output (no
@@ -253,10 +258,13 @@ analyze_project() {
         > "$response_file" 2>"$tmp_out") &
       claude_pid=$!
 
-      # Watchdog: kill claude if it exceeds OBSERVER_DAEMON_WATCHDOG_SECS
+      # Watchdog: kill claude if it exceeds OBSERVER_DAEMON_WATCHDOG_SECS.
+      # Touch watchdog_fired_marker before killing so the outer loop can
+      # distinguish timeout from a plain claude crash (transport_error).
       (sleep "$OBSERVER_DAEMON_WATCHDOG_SECS" && \
         if kill -0 "$claude_pid" 2>/dev/null; then \
           log_msg "WATCHDOG: claude exceeded ${OBSERVER_DAEMON_WATCHDOG_SECS}s — killing (PID ${claude_pid})"; \
+          touch "$watchdog_fired_marker" 2>/dev/null || true; \
           kill "$claude_pid" 2>/dev/null || true; \
         fi) &
       watchdog_pid=$!
@@ -271,6 +279,16 @@ analyze_project() {
         log_msg "Claude analysis completed successfully"
       else
         log_msg "ERROR: claude analysis failed (exit code: ${exit_code})"
+        # If watchdog fired, this attempt counts as a timeout.
+        # Write a failure manifest for this attempt (Layer 4 spec §10).
+        if [ -f "$watchdog_fired_marker" ]; then
+          rm -f "$watchdog_fired_marker"
+          node "$CURATOR_CLI" record-run-failure \
+            --batch-id "$batch_id" \
+            --parse-status "timeout" \
+            --detail "claude CLI exceeded watchdog timeout (${OBSERVER_DAEMON_WATCHDOG_SECS}s)" \
+            > /dev/null 2>&1 || true
+        fi
         retry_count=$((retry_count + 1))
         if [ "$retry_count" -le "$max_retries" ]; then
           log_msg "Retrying analysis (attempt ${retry_count}/${max_retries})..."
@@ -279,6 +297,12 @@ analyze_project() {
       fi
     else
       log_msg "WARNING: claude CLI not found, skipping analysis"
+      # PR-F: write failure manifest for cli_not_found
+      node "$CURATOR_CLI" record-run-failure \
+        --batch-id "$batch_id" \
+        --parse-status "cli_not_found" \
+        --detail "claude CLI not found in PATH" \
+        > /dev/null 2>&1 || true
       return
     fi
   done
@@ -287,6 +311,12 @@ analyze_project() {
     log_msg "ERROR: Analysis failed after ${max_retries} retries for ${project}"
     echo $((fail_count + 1)) > "$fail_count_file"
     rm -f "$response_file"
+    # PR-F: write failure manifest for transport_error (all retries exhausted)
+    node "$CURATOR_CLI" record-run-failure \
+      --batch-id "$batch_id" \
+      --parse-status "transport_error" \
+      --detail "claude CLI exited non-zero after ${max_retries} retries" \
+      > /dev/null 2>&1 || true
     return
   fi
 

--- a/skills/arc-observing/scripts/observer-daemon.sh
+++ b/skills/arc-observing/scripts/observer-daemon.sh
@@ -215,6 +215,7 @@ analyze_project() {
   local analysis_success=false
   local retry_count=0
   local max_retries=1
+  local last_was_timeout=false
   local schema_path="${ARCFORGE_ROOT}/scripts/lib/learning-curator/candidate-proposal-schema.json"
   if [ ! -f "$schema_path" ]; then
     log_msg "ERROR: candidate-proposal-schema.json not found at ${schema_path}"
@@ -288,6 +289,9 @@ analyze_project() {
             --parse-status "timeout" \
             --detail "claude CLI exceeded watchdog timeout (${OBSERVER_DAEMON_WATCHDOG_SECS}s)" \
             > /dev/null 2>&1 || true
+          last_was_timeout=true
+        else
+          last_was_timeout=false
         fi
         retry_count=$((retry_count + 1))
         if [ "$retry_count" -le "$max_retries" ]; then
@@ -311,12 +315,15 @@ analyze_project() {
     log_msg "ERROR: Analysis failed after ${max_retries} retries for ${project}"
     echo $((fail_count + 1)) > "$fail_count_file"
     rm -f "$response_file"
-    # PR-F: write failure manifest for transport_error (all retries exhausted)
-    node "$CURATOR_CLI" record-run-failure \
-      --batch-id "$batch_id" \
-      --parse-status "transport_error" \
-      --detail "claude CLI exited non-zero after ${max_retries} retries" \
-      > /dev/null 2>&1 || true
+    # PR-F: write failure manifest for transport_error only if the last attempt was NOT
+    # a watchdog timeout (timeout attempts already wrote their own manifests).
+    if [ "$last_was_timeout" != true ]; then
+      node "$CURATOR_CLI" record-run-failure \
+        --batch-id "$batch_id" \
+        --parse-status "transport_error" \
+        --detail "claude CLI exited non-zero after ${max_retries} retries" \
+        > /dev/null 2>&1 || true
+    fi
     return
   fi
 

--- a/skills/arc-observing/tests/run-tests.sh
+++ b/skills/arc-observing/tests/run-tests.sh
@@ -219,6 +219,89 @@ else
   ERRORS+=('C4: process killed before stub sleep (elapsed check)')
 fi
 
+# PR-F C4 extension: assert that a failure manifest with parse_status=timeout was written
+C4_RUNS_DIR="${TEST_HOME_C4}/.arcforge/learning/curator-runs"
+C4_TIMEOUT_STATUS=""
+if [ -d "$C4_RUNS_DIR" ]; then
+  C4_TIMEOUT_STATUS=$(find "$C4_RUNS_DIR" -name '*.manifest.json' 2>/dev/null \
+    -exec grep -l '"timeout"' {} \; | head -1 || true)
+fi
+
+if [ -n "$C4_TIMEOUT_STATUS" ]; then
+  echo "  PASS: C4 PR-F: failure manifest with parse_status=timeout was written"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: C4 PR-F: no failure manifest with parse_status=timeout found in ${C4_RUNS_DIR}"
+  FAIL=$((FAIL + 1))
+  ERRORS+=('C4 PR-F: failure manifest with parse_status=timeout was written')
+fi
+
+# ─────────────────────────────────────────────
+# PR-F-T1: transport_error — stub claude exits 1 → failure manifest written
+# Strategy: stub claude exits 1 immediately. Daemon should call record-run-failure
+# and write a manifest with parse_status=transport_error.
+# ─────────────────────────────────────────────
+
+echo ""
+echo "=== PR-F-T1: transport_error failure manifest ==="
+
+ARCFORGE_REPO_ROOT_PRF="$(cd "$(dirname "$0")/../../.." && pwd)"
+TMPDIR_PRF=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_PRF"' EXIT
+TEST_HOME_PRF="${TMPDIR_PRF}/home"
+STUB_BIN_PRF="${TMPDIR_PRF}/bin"
+mkdir -p "$TEST_HOME_PRF" "$STUB_BIN_PRF"
+
+# Stub 'claude' that exits 1 immediately (transport_error)
+cat > "${STUB_BIN_PRF}/claude" << 'STUB_EOF'
+#!/usr/bin/env bash
+exit 1
+STUB_EOF
+chmod +x "${STUB_BIN_PRF}/claude"
+
+# Create a project with enough observations
+PRF_PROJECT="prf-test-proj"
+PRF_OBS_DIR="${TEST_HOME_PRF}/.arcforge/observations/${PRF_PROJECT}"
+mkdir -p "$PRF_OBS_DIR"
+for i in $(seq 1 15); do
+  printf '{"ts":"2026-05-22T01:%02d:00.000Z","event":"tool_start","tool":"Read","session":"s1","project":"%s","project_id":"proj_abc123456789ab","evidence_status":"present","input_summary":"file %d"}\n' \
+    "$i" "$PRF_PROJECT" "$i" >> "${PRF_OBS_DIR}/observations.jsonl"
+done
+
+PRF_RESULT=$(
+  HOME="$TEST_HOME_PRF"
+  ARCFORGE_ROOT="$ARCFORGE_REPO_ROOT_PRF"
+  PATH="${STUB_BIN_PRF}:${PATH}"
+  SCRIPT_DIR="$(dirname "$DAEMON_SCRIPT")"
+  OBSERVER_PROMPT="${SCRIPT_DIR}/observer-prompt.md"
+  OBSERVER_DAEMON_WATCHDOG_SECS=10
+  set +e
+  # shellcheck source=/dev/null
+  source "$DAEMON_SCRIPT" 2>/dev/null
+  mkdir -p "$INSTINCTS_DIR"
+  analyze_project "$PRF_PROJECT" 2>/dev/null || true
+  echo "done"
+) 2>/dev/null
+
+# Assert: failure manifest with parse_status=transport_error was written
+PRF_RUNS_DIR="${TEST_HOME_PRF}/.arcforge/learning/curator-runs"
+PRF_TRANSPORT_MANIFEST=""
+if [ -d "$PRF_RUNS_DIR" ]; then
+  PRF_TRANSPORT_MANIFEST=$(find "$PRF_RUNS_DIR" -name '*.manifest.json' 2>/dev/null \
+    -exec grep -l '"transport_error"' {} \; | head -1 || true)
+fi
+
+if [ -n "$PRF_TRANSPORT_MANIFEST" ]; then
+  echo "  PASS: PR-F-T1: failure manifest with parse_status=transport_error was written"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: PR-F-T1: no failure manifest with parse_status=transport_error found"
+  echo "        Runs dir: ${PRF_RUNS_DIR}"
+  echo "        PRF_RESULT: ${PRF_RESULT}"
+  FAIL=$((FAIL + 1))
+  ERRORS+=('PR-F-T1: failure manifest with parse_status=transport_error was written')
+fi
+
 # ─────────────────────────────────────────────
 # E2-G1: daemon no longer writes to per-project instincts subdir
 # Strategy: the production analysis code must not contain mkdir + write

--- a/skills/arc-observing/tests/run-tests.sh
+++ b/skills/arc-observing/tests/run-tests.sh
@@ -236,6 +236,23 @@ else
   ERRORS+=('C4 PR-F: failure manifest with parse_status=timeout was written')
 fi
 
+# PR-F C4 extension: when all attempts timed out, NO transport_error manifest should be written
+C4_TRANSPORT_STATUS=""
+if [ -d "$C4_RUNS_DIR" ]; then
+  C4_TRANSPORT_STATUS=$(find "$C4_RUNS_DIR" -name '*.manifest.json' 2>/dev/null \
+    -exec grep -l '"transport_error"' {} \; | head -1 || true)
+fi
+
+if [ -z "$C4_TRANSPORT_STATUS" ]; then
+  echo "  PASS: C4 PR-F: no spurious transport_error manifest when all attempts timed out"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: C4 PR-F: spurious transport_error manifest written when all attempts timed out (should be timeout only)"
+  echo "        manifest: ${C4_TRANSPORT_STATUS}"
+  FAIL=$((FAIL + 1))
+  ERRORS+=('C4 PR-F: no spurious transport_error manifest when all attempts timed out')
+fi
+
 # ─────────────────────────────────────────────
 # PR-F-T1: transport_error — stub claude exits 1 → failure manifest written
 # Strategy: stub claude exits 1 immediately. Daemon should call record-run-failure

--- a/tests/scripts/learning-curator-cli.test.js
+++ b/tests/scripts/learning-curator-cli.test.js
@@ -144,3 +144,93 @@ describe('CLI help', () => {
     expect(output.toLowerCase()).toMatch(/usage|subcommand|assemble-batch|ingest-proposal/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// PR-F: record-run-failure subcommand
+// ---------------------------------------------------------------------------
+
+describe('CLI record-run-failure', () => {
+  test('writes manifest file and prints JSON result', () => {
+    const output = runCLI([
+      'record-run-failure',
+      '--batch-id',
+      'batch_test_rf_001',
+      '--parse-status',
+      'transport_error',
+      '--detail',
+      'claude exit 1',
+    ]);
+    const parsed = JSON.parse(output);
+    expect(parsed.run_id).toMatch(/^curator_run_/);
+    expect(parsed.parse_status).toBe('transport_error');
+    expect(parsed.accepted).toBe(0);
+    expect(parsed.rejected).toBe(0);
+
+    // Manifest file must exist
+    const runsDir = path.join(tmpDir, '.arcforge', 'learning', 'curator-runs');
+    const manifestPath = path.join(runsDir, `${parsed.run_id}.manifest.json`);
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(manifest.parse_status).toBe('transport_error');
+  });
+
+  test('timeout parse-status persists correctly', () => {
+    const output = runCLI([
+      'record-run-failure',
+      '--batch-id',
+      'batch_test_rf_002',
+      '--parse-status',
+      'timeout',
+      '--detail',
+      'watchdog killed claude',
+    ]);
+    const parsed = JSON.parse(output);
+    expect(parsed.parse_status).toBe('timeout');
+  });
+
+  test('cli_not_found parse-status persists correctly', () => {
+    const output = runCLI([
+      'record-run-failure',
+      '--batch-id',
+      'batch_test_rf_003',
+      '--parse-status',
+      'cli_not_found',
+    ]);
+    const parsed = JSON.parse(output);
+    expect(parsed.parse_status).toBe('cli_not_found');
+  });
+
+  test('invalid parse-status exits non-zero', () => {
+    const { spawnSync } = require('node:child_process');
+    const result = spawnSync(
+      'node',
+      [
+        CLI_PATH,
+        'record-run-failure',
+        '--batch-id',
+        'batch_test_rf_bad',
+        '--parse-status',
+        'invalid_status',
+      ],
+      {
+        env: { ...process.env, HOME: tmpDir },
+        encoding: 'utf8',
+      },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/parse-status|invalid|allowed/i);
+  });
+
+  test('missing batch-id exits non-zero', () => {
+    const { spawnSync } = require('node:child_process');
+    const result = spawnSync(
+      'node',
+      [CLI_PATH, 'record-run-failure', '--parse-status', 'timeout'],
+      {
+        env: { ...process.env, HOME: tmpDir },
+        encoding: 'utf8',
+      },
+    );
+    expect(result.status).not.toBe(0);
+  });
+});

--- a/tests/scripts/learning-curator-cli.test.js
+++ b/tests/scripts/learning-curator-cli.test.js
@@ -188,16 +188,22 @@ describe('CLI record-run-failure', () => {
     expect(parsed.parse_status).toBe('timeout');
   });
 
-  test('cli_not_found parse-status persists correctly', () => {
-    const output = runCLI([
-      'record-run-failure',
-      '--batch-id',
-      'batch_test_rf_003',
-      '--parse-status',
-      'cli_not_found',
-    ]);
-    const parsed = JSON.parse(output);
-    expect(parsed.parse_status).toBe('cli_not_found');
+  test('invalid parse-status (e.g. cli_not_found) is rejected — only spec enum values allowed', () => {
+    const { spawnSync } = require('node:child_process');
+    const result = spawnSync(
+      'node',
+      [
+        CLI_PATH,
+        'record-run-failure',
+        '--batch-id',
+        'batch_test_rf_003',
+        '--parse-status',
+        'cli_not_found',
+      ],
+      { env: { ...process.env, HOME: tmpDir }, encoding: 'utf8' },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/not allowed/i);
   });
 
   test('invalid parse-status exits non-zero', () => {

--- a/tests/scripts/learning-curator-proposal-ingestor.test.js
+++ b/tests/scripts/learning-curator-proposal-ingestor.test.js
@@ -696,9 +696,9 @@ describe('recordRunFailure — writes failure manifest', () => {
     expect(manifest.raw_response_saved).toBe(false);
   });
 
-  test('persisted manifest has correct fields for all 3 parse_status values', () => {
+  test('persisted manifest has correct fields for both spec parse_status values', () => {
     const { recordRunFailure } = getIngestor();
-    const statuses = ['transport_error', 'timeout', 'cli_not_found'];
+    const statuses = ['transport_error', 'timeout'];
     const runsDir = path.join(tmpDir, '.arcforge', 'learning', 'curator-runs');
 
     for (const parseStatus of statuses) {

--- a/tests/scripts/learning-curator-proposal-ingestor.test.js
+++ b/tests/scripts/learning-curator-proposal-ingestor.test.js
@@ -658,3 +658,85 @@ describe('ingestProposal — rule_version namespace split (criterion 5)', () => 
     expect(eqmRuleVersion).toBe('v1-project_obs_count');
   });
 });
+
+// ---------------------------------------------------------------------------
+// PR-F: recordRunFailure — failure manifest for daemon transport errors
+// ---------------------------------------------------------------------------
+
+describe('recordRunFailure — writes failure manifest', () => {
+  test('transport_error: writes manifest file to curator-runs dir', () => {
+    const { recordRunFailure } = getIngestor();
+    const result = recordRunFailure({
+      batchId: 'batch_x',
+      parseStatus: 'transport_error',
+      detail: 'claude exit 1',
+      homeDir: tmpDir,
+    });
+
+    expect(result.run_id).toMatch(/^curator_run_/);
+    expect(result.parse_status).toBe('transport_error');
+    expect(result.accepted).toBe(0);
+    expect(result.rejected).toBe(0);
+
+    const runsDir = path.join(tmpDir, '.arcforge', 'learning', 'curator-runs');
+    const manifestPath = path.join(runsDir, `${result.run_id}.manifest.json`);
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(manifest.schema_version).toBe(1);
+    expect(manifest.parse_status).toBe('transport_error');
+    expect(manifest.accepted_count).toBe(0);
+    expect(manifest.rejected_count).toBe(0);
+    expect(manifest.handed_to_layer5).toBe(false);
+    expect(manifest.source_batch_id).toBe('batch_x');
+    expect(manifest.detail).toBe('claude exit 1');
+    expect(manifest.prompt_hash).toBeNull();
+    expect(manifest.response_hash).toBeNull();
+    expect(manifest.raw_prompt_saved).toBe(false);
+    expect(manifest.raw_response_saved).toBe(false);
+  });
+
+  test('persisted manifest has correct fields for all 3 parse_status values', () => {
+    const { recordRunFailure } = getIngestor();
+    const statuses = ['transport_error', 'timeout', 'cli_not_found'];
+    const runsDir = path.join(tmpDir, '.arcforge', 'learning', 'curator-runs');
+
+    for (const parseStatus of statuses) {
+      const result = recordRunFailure({
+        batchId: `batch_${parseStatus}`,
+        parseStatus,
+        detail: `test detail for ${parseStatus}`,
+        homeDir: tmpDir,
+      });
+
+      expect(result.parse_status).toBe(parseStatus);
+      const manifestPath = path.join(runsDir, `${result.run_id}.manifest.json`);
+      expect(fs.existsSync(manifestPath)).toBe(true);
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      expect(manifest.parse_status).toBe(parseStatus);
+      expect(manifest.accepted_count).toBe(0);
+      expect(manifest.rejected_count).toBe(0);
+      expect(manifest.handed_to_layer5).toBe(false);
+    }
+  });
+
+  test('run_id is deterministic-ish: same batchId+parseStatus within same second gives same run_id', () => {
+    const { recordRunFailure } = getIngestor();
+    // Same call twice should produce manifests with the same run_id (idempotent-ish)
+    const r1 = recordRunFailure({
+      batchId: 'batch_idem',
+      parseStatus: 'timeout',
+      detail: 'first call',
+      homeDir: tmpDir,
+    });
+    const r2 = recordRunFailure({
+      batchId: 'batch_idem',
+      parseStatus: 'timeout',
+      detail: 'second call',
+      homeDir: tmpDir,
+    });
+    // Both runs produce same run_id (same batchId+parseStatus+timestamp-second)
+    expect(r1.run_id).toBe(r2.run_id);
+  });
+});


### PR DESCRIPTION
## Summary

PR-F of the 2026-05-22 re-audit drift fixes. Closes Drift #1 — daemon now writes a CuratorRunManifest on every claude-CLI failure path. Spec acceptance #10 ("manifest for every attempted run") finally holds end-to-end.

## Drift closed

**Drift #1 — CuratorRunManifest on daemon-side failures**: previously, when the bash daemon's claude invocation failed (exit non-zero, watchdog timeout, or CLI binary missing), the daemon \`return\`ed without writing a manifest. Audit trail vanished.

Now: 3 failure paths in \`observer-daemon.sh\` invoke a new \`record-run-failure\` CLI subcommand that writes the manifest before returning.

## Changes

**Library (`proposal-ingestor.js`)**
- New exported function \`recordRunFailure({ batchId, parseStatus, detail, homeDir })\` — builds + persists a minimal \`CuratorRunManifest\` with \`accepted_count: 0\`, \`rejected_count: 0\`, \`proposal_count: 0\`, \`handed_to_layer5: false\`. Reuses existing \`persistRunManifest()\`.

**CLI (`cli.js`)**
- New \`record-run-failure\` subcommand: \`--batch-id <id> --parse-status <transport_error|timeout> --detail "<msg>"\`. Allowlist enforces the spec \`parse_status\` enum.

**Daemon (`observer-daemon.sh`)**
- 3 failure paths wired:
  - **\`transport_error\`** — claude exit non-zero (no JSON file)
  - **\`timeout\`** — watchdog killed claude (detected via \`.watchdog-fired.<batch_id>\` marker file)
  - **\`transport_error\` (detail: "claude CLI not found in PATH")** — \`command -v claude\` empty
- New \`last_was_timeout\` flag prevents writing a duplicate \`transport_error\` manifest when all retries were watchdog-killed.
- \`.watchdog-fired.*\` marker added to EXIT/TERM cleanup traps alongside \`.curator-response.*.json\`.

## Spec compliance (simplify pass)

- \`parse_status\` allowed values match spec layer-4 §parse_status enum exactly (transport_error | timeout). CLI-binary-missing maps to \`transport_error\` with the specific reason carried in \`detail\` — keeps the spec enum stable.
- \`proposal_count: 0\` now emitted on failure manifests (spec marks it required).

## Tests added

- \`tests/scripts/learning-curator-proposal-ingestor.test.js\`: \`recordRunFailure\` unit coverage (manifest path + shape + both parse_status values).
- \`tests/scripts/learning-curator-cli.test.js\` (new file): subcommand happy path + invalid parse_status rejected.
- \`skills/arc-observing/tests/run-tests.sh\` (extended): C4 PR-F (timeout manifest written), C4 PR-F (no spurious transport_error when all retries timed out), PR-F-T1 (transport_error manifest written on exit-1).

## Test plan

- [x] \`npm run test:scripts\` — 1835 pass
- [x] \`npm run test:hooks\` — 213 pass
- [x] \`npm run test:node\` — 7 pass
- [x] \`npm run test:skills\` — 546 pass
- [x] Daemon shell tests — 17 pass (was 16; +3 PR-F, -2 collapsed)
- [x] \`npm run lint\` — clean
- [x] E2-G3 daemon E2E test still passes

## Risk

Medium-Low. New code path; existing success paths untouched. The new \`last_was_timeout\` flag has function-local scope (cannot leak across daemon cycles). Node startup cost (~50-100ms × ≤3 invocations per analyze_project cycle) is negligible against a 5-minute daemon poll.

## Stacking

Based on \`feat/learning-curator-pivot\`. Touches \`proposal-ingestor.js\` which PR-E (#52) also touches — PR-F will need a rebase after PR-E merges (mechanical: both additive on different functions).

Per the parent plan at \`/Users/gregho/.claude/plans/swift-forging-axolotl.md\`. After both PR-E and PR-F merge, the 4 re-audit drifts are all closed and the report can be re-rendered with everything PASS.