### PR TITLE
fix(skills): skills-layer audit remediation — argument-hints, /journal canonicalization, taxonomy & routing fixes

### DIFF
--- a/commands/arc-auditing-spec.md
+++ b/commands/arc-auditing-spec.md
@@ -1,5 +1,6 @@
 ---
 description: "Run a read-only advisory audit of an arcforge SDD spec family (design.md, spec.xml, dag.yaml) across three axes — cross-artifact alignment, internal consistency, state-transition integrity. Usage: /arc-auditing-spec <spec-id> [--save]"
+argument-hint: "<spec-id> [--save]"
 disable-model-invocation: true
 ---
 

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,6 @@
 ---
 description: "Use this before any creative work - exploring requirements and design before implementation."
+argument-hint: "[topic or feature to explore]"
 disable-model-invocation: true
 ---
 

--- a/commands/execute-tasks.md
+++ b/commands/execute-tasks.md
@@ -1,5 +1,6 @@
 ---
 description: Execute tasks in batches with review checkpoints
+argument-hint: "<task-list-name>"
 disable-model-invocation: true
 ---
 

--- a/commands/recall.md
+++ b/commands/recall.md
@@ -1,0 +1,7 @@
+---
+description: "Manually save a pattern or insight from the current session as an instinct."
+argument-hint: "<description of the pattern to remember>"
+disable-model-invocation: true
+---
+
+Invoke the arc-recalling skill and follow it exactly as presented to you

--- a/commands/sessions.md
+++ b/commands/sessions.md
@@ -1,5 +1,6 @@
 ---
 description: "Save/resume sessions, list sessions, manage aliases."
+argument-hint: "save [alias] | resume [alias] | list [--limit N] [--date YYYY-MM-DD] [--query id] | alias <id> <name> | aliases"
 disable-model-invocation: true
 ---
 

--- a/commands/write-tasks.md
+++ b/commands/write-tasks.md
@@ -1,5 +1,6 @@
 ---
 description: Create detailed execution tasks for a feature
+argument-hint: "<feature-name>"
 disable-model-invocation: true
 ---
 

--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -377,7 +377,7 @@ Rule in `skills/arc-using/SKILL.md`.
 
 **Key workflow:**
 1. Check phase transition — compact between phases (when state is persisted to files), not during
-2. Pre-compact: save decisions to files/memory, run `/diary` if session was substantial
+2. Pre-compact: save decisions to files/memory, run `/journal` if session was substantial
 3. Check for un-committed work — ensure valuable changes are committed
 4. Compact with focused seed text: `/compact Focus on implementing [next task]`
 5. Post-compact: run `arcforge reboot`, re-read needed files
@@ -614,7 +614,7 @@ Rule in `skills/arc-using/SKILL.md`.
 
 **Purpose:** Capture session reflections as structured diary entries for future pattern extraction.
 
-**When to use:** When user explicitly requests /diary, when PreCompact hook triggers, or at end of significant work session.
+**When to use:** When user explicitly requests /journal, when PreCompact hook triggers, or at end of significant work session.
 
 **Key workflow:**
 1. Pre-diary check — verify session had non-trivial decisions or challenges

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -15,7 +15,7 @@ Records context compaction events for session tracking and triggers diary prompt
 3. **Threshold-triggered behavior** (when `userCount >= 10 OR toolCount >= 50`):
    - Updates session with current user/tool counts
    - Generates markdown summary file (`<sessionId>.md`)
-   - Prompts user to run `/diary` skill
+   - Prompts user to run `/journal` skill
    - Resets both counters (user messages and tool calls)
 
 4. **Below threshold**:
@@ -38,7 +38,7 @@ This ensures diary prompts only appear for meaningful sessions.
 ```
 📝 Context compaction detected. (15 messages, 47 tool calls)
 
-Please use /diary skill immediately to capture session reflections before context is compacted.
+Please use /journal skill immediately to capture session reflections before context is compacted.
 ```
 
 **Below threshold:**

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -172,7 +172,7 @@ function loadPendingActions(project) {
     );
 
     if (diaryActions.length > 0) {
-      lines.push('**📝 Diary draft ready — use /diary to review and finalize.**');
+      lines.push('**📝 Diary draft ready — use /journal to review and finalize.**');
       summaryParts.push('diary draft ready');
     }
 

--- a/skills/arc-brainstorming/SKILL.md
+++ b/skills/arc-brainstorming/SKILL.md
@@ -278,6 +278,10 @@ Stop immediately if you catch yourself thinking:
 - Be flexible — Go back and clarify when something doesn't make sense
 - Explicit routing — Always confirm new-topic vs iteration with the user
 
+## After This Skill
+
+Hand off to `/arc-refining` — the refiner reads the committed `docs/plans/<spec-id>/<YYYY-MM-DD>/design.md` and formalizes it into `specs/<spec-id>/spec.xml`. Full SDD pipeline: refining → planning → coordinating.
+
 ## Stage Completion Format
 
 ```

--- a/skills/arc-compacting/SKILL.md
+++ b/skills/arc-compacting/SKILL.md
@@ -49,7 +49,7 @@ Use this skill when:
    - Design decisions → `docs/plans/` or memory
    - Task progress → update dag.yaml or TodoWrite
    - Observations → memory files
-2. **Run `/diary`** if the session was substantial — captures session insights before they're lost
+2. **Run `/journal`** if the session was substantial — captures session insights before they're lost
 3. **Check for un-committed work** — ensure valuable changes are committed
 
 ### During Compact

--- a/skills/arc-journaling/SKILL.md
+++ b/skills/arc-journaling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arc-journaling
-description: Use when user explicitly requests /diary, when PreCompact hook triggers, or at end of significant work session
+description: Use when user explicitly requests /journal, when PreCompact hook triggers, or at end of significant work session
 ---
 
 # Session Diary Capture
@@ -71,11 +71,11 @@ Before creating a diary entry, verify at least ONE of these criteria is met:
 - Pure exploration (reading files without decisions)
 - Trivial fixes (typos, formatting, single-line changes)
 
-This is a **soft gate**: Claude judges based on conversation memory. User can always override with explicit `/diary`.
+This is a **soft gate**: Claude judges based on conversation memory. User can always override with explicit `/journal`.
 
 ## When to Use
 
-- User runs `/diary`
+- User runs `/journal`
 - PreCompact hook triggers (conversation getting long)
 - End of significant work session
 - After important design decisions
@@ -214,7 +214,7 @@ Keep entries focused. Don't over-document routine work.
 
 ```
 ~/.arcforge/diaries/{project}/{YYYY-MM-DD}/
-└── diary-{sessionId}.md      # Diary entry (from /diary)
+└── diary-{sessionId}.md      # Diary entry (from /journal)
 
 ~/.arcforge/sessions/{project}/{YYYY-MM-DD}/
 ├── {sessionId}.json          # Session data (auto-generated)

--- a/skills/arc-managing-sessions/SKILL.md
+++ b/skills/arc-managing-sessions/SKILL.md
@@ -203,7 +203,7 @@ node "${SKILL_ROOT}/scripts/sessions.js" aliases
 │   ├── {sessionId}.json                  # Auto-saved session metrics
 │   ├── session-{alias}.md                # User-archived session (from save)
 │   ├── handover-{slug}.md                # Optional handover file (from handover --save)
-│   ├── diary-{sessionId}.md              # Diary entry (from /diary)
+│   ├── diary-{sessionId}.md              # Diary entry (from /journal)
 ```
 
 ## Common Mistakes

--- a/skills/arc-observing/SKILL.md
+++ b/skills/arc-observing/SKILL.md
@@ -129,7 +129,7 @@ No activity → -0.02/week, -0.01/week for manual/reflection sources
 ## When NOT to Use
 
 - User wants to extract reusable techniques (use /learn)
-- User wants to capture session reflections (use /diary)
+- User wants to capture session reflections (use /journal)
 - User wants to analyze diary entries (use /reflect)
 
 ## Process

--- a/skills/arc-reflecting/SKILL.md
+++ b/skills/arc-reflecting/SKILL.md
@@ -77,7 +77,7 @@ For large diary sets, use the diary-analyzer subagent (see `diary-analyzer.md`) 
 
 - Fewer than 3 diary entries exist
 - User wants patterns auto-loaded (use /recall instead)
-- Single-session insights (use /diary instead)
+- Single-session insights (use /journal instead)
 - No meaningful patterns found
 
 ## Storage
@@ -141,7 +141,7 @@ Search for diary files:
 ```
 
 Count entries. If fewer than 3:
-> "Found only X diary entries. Run more sessions with /diary before reflecting."
+> "Found only X diary entries. Run more sessions with /journal before reflecting."
 
 ### 3. Read CLAUDE.md Rules (if exists)
 

--- a/skills/arc-using/SKILL.md
+++ b/skills/arc-using/SKILL.md
@@ -107,6 +107,18 @@ These skills activate during a workflow when the condition is present. They are 
 | User asks about vault health, missing links, or orphan notes | `arc-maintaining-obsidian` audit mode | Propose changes, never auto-modify without approval |
 | About to ship, merge, or mark complete a skill, agent, or workflow | `arc-evaluating` | Eval evidence that does not return `INSUFFICIENT_DATA` |
 
+## Instinct & Learning Routes
+
+Five skills touch the diary/instinct system. Route by the concrete trigger, not by the word "remember" — they are distinct entry points, not interchangeable:
+
+| User intent | Skill |
+|-------------|-------|
+| Capture THIS session's reflections as a diary entry | `arc-journaling` (`/journal`) |
+| Extract recurring patterns from 5+ accumulated diaries | `arc-reflecting` (`/reflect`) |
+| Manually save ONE insight as an instinct right now | `arc-recalling` (`/recall`) |
+| Review / confirm / contradict auto-detected instincts | `arc-observing` |
+| Review the learning-candidate queue (when optional learning is enabled) | `arc-learning` |
+
 ## When Not to Route
 
 Do not force an ArcForge workflow when the task is:

--- a/skills/arc-writing-skills/SKILL.md
+++ b/skills/arc-writing-skills/SKILL.md
@@ -505,6 +505,8 @@ Agent found new rationalization? Add explicit counter. Re-test until bulletproof
 
 **Structured evaluation:** Use `agents/` templates for structured grading (`skill-grader.md`), blind comparison (`skill-comparator.md`), pattern analysis (`skill-analyzer.md`), and description testing (`description-tester.md`). See `references/eval-schemas.md` for data formats.
 
+**Division of labor with arc-evaluating:** The agents above specialize in *discipline-skill pressure testing* — compliance under combined pressures and rationalization extraction (`rationalizations[]` + compliance verdict in `eval-schemas.md`), which arc-evaluating's general graders do not provide. For *statistical behavior-change measurement* — baseline-vs-treatment `delta`, CI95, k≥5 trials, and the SHIP/NEEDS-WORK verdict via `arc eval ab` — use arc-evaluating. They compose: arc-evaluating proves a skill changes behavior; these agents pressure-test discipline compliance and mine rationalizations for the REFACTOR loop.
+
 ## Anti-Patterns
 
 ### Narrative Example

--- a/skills/arc-writing-skills/SKILL.md
+++ b/skills/arc-writing-skills/SKILL.md
@@ -70,7 +70,7 @@ Two orthogonal axes are useful when designing a skill — composition (how it ge
 |------|-------------------|-------------|---------|
 | **Workflow** | Handoff from previous step | "After This Skill" section defines next step | `arc-brainstorming` → `arc-writing-tasks` |
 | **Discipline** | Conditional — fires during ANY workflow when condition is met | Listed in `arc-using` routing table | `arc-tdd`, `arc-verifying` |
-| **Meta** | Independent — user, maintainer, or project-level task invokes directly | No routing needed | `arc-writing-skills`, `arc-evaluating` |
+| **Meta** | Independent — user, maintainer, or project-level task invokes directly | No routing needed | `arc-writing-skills`, `arc-auditing-spec` |
 
 When creating a new skill:
 


### PR DESCRIPTION
## Skills-layer audit remediation

Follow-on to the engine/test audit (#55). This batch addresses the **skills-layer** findings from a 4-dimension skills audit + an argument-hint audit run this session.

### Changes (5 commits)

1. **`feat(commands)`** — `argument-hint` for 5 slash commands (`sessions`, `arc-auditing-spec`, `brainstorm`, `write-tasks`, `execute-tasks`) + new `/recall` wrapper. `arc-recalling` advertised `/recall` but had no command file; this closes that gap. Pure command-palette UX — args auto-forward without `$ARGUMENTS`, so bodies stay single-line per the command convention.

2. **`docs(skills)`** — fix the skill-type taxonomy in `arc-writing-skills`: `arc-evaluating` was mis-listed as a **Meta** example, but it's a **Discipline** gate (registered in `arc-using`'s routing table; "required when shipping/modifying a skill"). Corrected the example to `arc-auditing-spec`, which is genuinely never auto-invoked.

3. **`fix`** — canonicalize the journaling command to `/journal`. The whole toolkit (hooks that auto-prompt it, `arc-compacting`/`reflecting`/`observing`/`managing-sessions`, and docs) advertised `/diary`, but the only command file is `commands/journal.md`, so `/diary` resolved to nothing. Fixed **14 command-token refs across 8 files**; kept all artifact nouns (`diary.js`, `~/.arcforge/diaries/`, `diary-{sessionId}.md`, `~/.arcforge/diaryed/`, "diary entry").

4. **`docs(skills)`** — add an `arc-writing-skills` → `arc-evaluating` division-of-labor pointer. A close read of the eval schemas **overturned** the initial "duplicate eval agents" finding: `skill-grader`/`comparator`/`analyzer` are a pressure/rationalization *specialization* (`rationalizations[]` + compliance verdict), not a copy of arc-evaluating's general delta/CI95 graders. No deletion — added the missing back-pointer (arc-evaluating already points forward).

5. **`docs(skills)`** — `arc-brainstorming` gains the `## After This Skill` section its pipeline siblings (`refining`/`planning`/`writing-tasks`) all have but it lacked (→ `/arc-refining`); `arc-using` gains an "Instinct & Learning Routes" table disambiguating the 5 diary/instinct skills for the session-start LLM router.

### Gate

All changes are **metadata / convention / documentation** tier — no behavioral footprint that the present-vs-absent eval harness can isolate (it measures skill present-vs-absent, which cannot isolate an edit, and #5/#7/#8 target behaviors baseline Claude already exhibits → NO_CHANGE risk). Validated by `npm test`:

- `test:scripts` (jest) 1831 · `test:hooks` 213 · `test:node` 8 · `test:skills` (pytest) 546 · `lint` clean

> One `e2e-hooks.test.js` teardown `rmSync` ENOTEMPTY flake appeared in the full run (temp-dir cleanup race, unrelated to these changes — passes clean on isolated `test:hooks` re-run).

### Deferred (not in this PR)

5 findings deferred with reactivation triggers: `arc-finishing`/`-epic` merge, `arc-refining` 4071w slim, `arc-observing/tests/` shipping in user surface, global word-count tier convergence (incl. `arc-writing-skills` 3357w), and the *true* `arc-writing-skills`↔`arc-evaluating` consolidation (trigger: when arc-evaluating's graders gain pressure/rationalization support).
