### PR TITLE
feat(hooks): deterministic worktree/research guards + completion-boundary reminders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,23 @@ jobs:
           version: latest
       - run: biome ci .
 
+  skill-eval-annotation:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Annotate skill changes lacking eval evidence
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          node scripts/check-skill-eval-annotation.js
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
           fi
       - name: Verify no version drift across canonical locations
         run: node scripts/check-version-sync.js
+      - name: Verify eval benchmark is fresh
+        run: node scripts/check-benchmark-freshness.js
       - name: Extract release notes from CHANGELOG
         id: changelog
         env:

--- a/docs/plans/hook-hardening-design.md
+++ b/docs/plans/hook-hardening-design.md
@@ -1,0 +1,188 @@
+# Hook Hardening Design — moving select skill intents from ICL to deterministic hooks
+
+**Status:** Tier 1 + Tier 2 (first slice) implemented. Contributor-facing design note (not shipped).
+**Date:** 2026-06-04
+
+## Problem
+
+Most arcforge skill "gates" are enforced purely by in-context-learning (ICL):
+prose in a `SKILL.md` that only shapes behavior if the skill happens to be
+loaded, and which the model can silently skip. A survey of all 33 skills + all
+10 hooks confirmed:
+
+- **The hook layer is 100% advisory/observational today.** No hook blocks; no
+  hook reads epic/DAG state. The block-capable helpers (`outputDecision`, exit 2)
+  exist in `scripts/lib/utils.js` but are used by zero hooks.
+- Every skill gate is either pure prose or a self-invoked CLI check the agent
+  bypasses by ignoring the skill.
+
+The goal: move the gates that have a **precise mechanical discriminator** into
+hooks, as either a hard block ("hard limit") or a deterministic reminder.
+
+## Framework: tier = discriminator precision, not event capability
+
+Whether a hook event *can* block (PreToolUse / Stop / UserPromptSubmit can;
+PostToolUse / PreCompact / SessionStart cannot) is the easy part. The hard part
+is whether a mechanical signal exists that is precise enough to act on without
+catching legitimate work. That precision assigns the tier:
+
+- **Tier 1 — hard block.** A discrete deterministic event with a signal ⇔
+  violation discriminator and near-zero legitimate collision.
+- **Tier 2 — deterministic reminder.** Deterministic trigger, but the violation
+  is probabilistic — nudge, never block.
+- **Tier 3 — stays ICL.** Semantic gate, no mechanical proxy. Inventing a proxy
+  is worse than nothing (false blocks train the model and user to bypass).
+
+### Two cross-cutting constraints
+
+1. **No "skill-active sentinel."** A global hook cannot tell which skill is in
+   play. So any *per-skill discipline* gate (read-only audits, mutation rules,
+   "do X before Y within this skill") cannot be scoped by a global hook — it
+   would fire everywhere. Only gates tied to a globally-meaningful discrete event
+   are hookable: a git command, a specific CLI invocation, a write to a canonical
+   path, or the `.arcforge-epic` marker. Per-skill read-only discipline belongs
+   in subagent `allowed-tools` frontmatter (as `arc-auditing-spec` already does),
+   not a hook.
+
+2. **No-op-without-arcforge-context is existential, not nice-to-have.** Hooks
+   ship to every user. A blocking hook that misfires on a project that isn't
+   mid-epic makes the user disable arcforge hooks wholesale — you lose all of
+   them, not one. Every blocking hook must be provably inert when there is no
+   `.arcforge-epic` marker and no `specs/*/dag.yaml`, and that inertness must be
+   a tested invariant. (All 10 existing hooks already no-op gracefully, but none
+   *block* — the first blocking hook is the first whose false-positive actively
+   harms a user.)
+
+## Survey results (full skill × hook map)
+
+### Tier 1 — hard-block candidates
+
+| Candidate | Discriminator | Disposition |
+|-----------|---------------|-------------|
+| Worktree phase guard: raw `git merge` inside a worktree | `.arcforge-epic` present + `git merge` | **BUILT** (`arc-guard` G2) |
+| Worktree phase guard: loop inside a worktree | `.arcforge-epic` present + loop invocation | **BUILT** (`arc-guard` G3) |
+| Direct `git worktree add` (bypass `arcforge expand`) | literal `git worktree add` in an arcforge project (`specs/`) | **BUILT as a NUDGE** (`arc-remind`) — not a block: a base session may legitimately open a non-epic worktree (e.g. PR review), so a hard block would false-positive |
+| `arc-finishing` ↔ `arc-finishing-epic` routing | marker present/absent | Collapses into G2 — blocking raw `git merge` inside a worktree *is* the routing redirect |
+| `arc-researching` config immutability | `research-config.md` exists + edit targets it | **BUILT** (`arc-guard` R-immutable) — the locked judge must not be edited mid-loop; near-zero false-positive (file written only at Step-4 lock) |
+| `arc-researching` scope fence | `research-config.md` CANNOT paths | **BUILT, conservatively** (`arc-guard` R-scope) — blocks only CANNOT entries that resolve to an **existing** file/dir; free-form prose / globs are skipped (a missed fence is recoverable; a false block mid-loop is not) |
+| `arc-writing-skills` eval-before-ship | commit/push after a SKILL.md edit | **BUILT — BOTH** a shippable plugin nudge (`arc-remind`, once/session) AND a non-blocking CI annotation (`ci.yml`). Not a hard gate: the metadata-only carve-out means no precise per-PR signal |
+| `arc-releasing` benchmark-freshness | `benchmarks/latest.json` `.generated` vs prev tag | **BUILT — CI only** (`release.yml`, scoped hard-fail). arc-releasing is contributor-only *by its own design* — so this stays in CI, not the shipped plugin |
+
+### Tier 2 — deterministic reminders
+
+| Candidate | Discriminator | Disposition |
+|-----------|---------------|-------------|
+| `arc-verifying` + `arc-requesting-review` at completion | `gh pr create` / `gh pr merge` | **BUILT** (`arc-remind`, one PR-boundary reminder; tracks test-seen this session) |
+| `arc-tdd` production-edit-before-test | edit w/o preceding failing test | Deferred — refactor (explicitly blessed by arc-tdd) is indistinguishable; reminder-only at best |
+| `arc-evaluating` SKILL edit w/o eval | SKILL.md edit w/o fresh benchmark | Deferred — metadata-only carve-out collides |
+| edit on `main`/`master` (no arcforge setup) | first **code** edit on main/master, once/session | **BUILT** (`arc-remind`, project-general). NB: an earlier "active DAG + on main" scope was rejected as *anti-correlated* with intent — the worktree runs on the epic branch, so an edit-on-main session is the base/coordinator (legitimately editing main with an active DAG), while the real "implementing on main with no setup" case has *no* DAG yet. The shipped version drops the DAG condition: first code (non-doc) edit to main/master, once/session, on any project. |
+
+### Tier 3 — stays ICL (do not hook)
+
+`arc-debugging` (root-cause leaves no trace), `arc-receiving-review` (forbidden-
+phrase regex is unblockable pre-send and over-matches genuine agreement),
+`arc-dispatching-parallel` (task independence is semantic), `arc-brainstorming`
+explore-first, `arc-refining` R3 no-invention, `arc-writing-tasks` bite-sized,
+and **`arc-using`** (deliberately non-enforceable — "skills are tools, not laws";
+a forcing hook contradicts its philosophy).
+
+### Already enforced — not ICL gaps (do not rebuild)
+
+- `arc-releasing` version-sync: `check:versions` + CI.
+- `arc-observing` / `arc-learning`: core gates enforced by daemon/CLI
+  architecture, not prose.
+- `arc-auditing-spec` / `arc-maintaining-obsidian` mutation discipline:
+  subagent `allowed-tools` frontmatter is the mechanism, not a hook.
+
+### Partially covered by existing hooks
+
+- `arc-compacting` ← `compact-suggester` (tool-count + read/write ratio; can't
+  block, phase-boundary semantics uncovered).
+- `arc-journaling` ← `pre-compact` (auto diary-draft; can't block).
+
+## What was built
+
+Two plugin hooks + a canonical-source extraction + two CI gates. Each hook
+dispatches by tool (`Bash`, `Edit`, `Write`) and emits at most one outcome per
+call; the fast no-op path (no marker / no `research-config.md`) is a single
+`existsSync`, so the PreToolUse hot-path cost stays low. Both hooks are registered
+under separate `tool == "Bash"/"Edit"/"Write"` matcher groups — proven matcher
+grammar (`quality-check` uses `tool == "Edit"`), avoiding an untestable `||`.
+
+### `scripts/lib/marker.js` (new)
+
+Extracted `readArcforgeMarker` out of `coordinator.js` into a lightweight module
+(`MARKER_FILENAME`, `markerPath`, `hasArcforgeMarker`, `readArcforgeMarker`) so a
+hot-path hook can check the marker without `require`-ing the ~1000-line
+coordinator + its YAML parser. `coordinator.js` re-imports and re-exports it, so
+`cli.js`'s existing import is unaffected. `hasArcforgeMarker` is a cheap
+`fs.existsSync`; YAML parse happens only on the deny path.
+
+### `hooks/arc-guard/main.js` (PreToolUse, BLOCKING, synchronous)
+
+Hard blocks via `{ hookSpecificOutput: { permissionDecision: 'deny',
+permissionDecisionReason } }`, exit 0. Fail-open on any error.
+
+- **Bash, gated by `.arcforge-epic` in cwd** — **G2** raw `git merge` (excl.
+  `git merge-base` and `--abort/--continue/--quit` via lookahead) → redirect to
+  the `finish-epic.js` flow; **G3** arcforge loop invocation → redirect to base.
+- **Edit/Write, gated by `research-config.md` in cwd** — **R-immutable** editing
+  the locked contract → deny (names the human-approved unlock escape);
+  **R-scope** editing a CANNOT-modify path that resolves to an existing file/dir
+  → deny. Prose/glob CANNOT entries are skipped (conservative).
+
+### `hooks/arc-remind/main.js` (PostToolUse, NON-BLOCKING)
+
+User-facing `systemMessage` nudges (intentionally to the user, not Claude — these
+are human-in-the-loop). Per-session counters keep them rare/context-aware.
+
+- **PR boundary** (`gh pr create`/`merge`) → verify (arc-verifying) + review
+  (arc-requesting-review), noting whether a test ran this session.
+- **`git worktree add`** in an arcforge project → prefer `arcforge expand` for
+  epic worktrees.
+- **`git commit`/`push` after a SKILL.md edit**, once/session → re-run the eval
+  (arc-writing-skills Iron Law) — the shippable, user-facing eval-before-ship gate.
+- **First code (non-doc) edit on `main`/`master`**, once/session → prefer a branch
+  or epic worktree for feature work (arc-executing-tasks). Project-general — no DAG
+  condition (that signal is anti-correlated with intent; see the Tier-2 table).
+
+### CI gates
+
+- `scripts/check-benchmark-freshness.js` + step in `release.yml` — scoped hard-fail
+  if eval-backed surface changed since the previous tag but
+  `evals/benchmarks/latest.json` `.generated` is not newer. First-release and
+  doc-only releases pass. Contributor-only by arc-releasing's own design.
+- `scripts/check-skill-eval-annotation.js` + PR job in `ci.yml` — non-blocking
+  GitHub `::warning::` when a PR changes a `skills/*/SKILL.md` without a matching
+  eval/test/benchmark update. Non-blocking because the metadata-only carve-out
+  means there is no precise per-PR signal; the deterministic user-facing
+  enforcement is the arc-remind nudge above.
+
+### Tests
+
+`hooks/__tests__/arc-guard.test.js`, `arc-remind.test.js`, and
+`tests/scripts/check-ci-gates.test.js` exercise the pure cores (export pure
+functions, assert directly). Key cases: the **no-op invariants** (no marker /
+no research-config → never denies), the **`git merge-base` & conflict-recovery
+false-positive guards**, **`loop.js`-as-a-file-arg** (read vs run), the
+**CANNOT-path prose-skip**, and a **wire-format e2e** (subprocess stdin→stdout
+asserting the real `permissionDecision: 'deny'` JSON — the one thing the pure-core
+tests can't cover).
+
+> Live blocking cannot be verified in this repo — the arcforge plugin is disabled
+> here (`arcforge@arcforge-dev: false`). The unit tests piping crafted stdin are
+> the sufficient, correct verification; a live end-to-end check needs
+> `claude --plugin-dir .` and is out of scope for the build.
+
+## Design rules for future hardening hooks
+
+1. Assign the tier by discriminator precision, not by whether the event can block.
+2. A blocking hook must be provably inert without arcforge context — as a tested
+   invariant. False-positive on the block path is the expensive direction.
+3. Per-skill discipline (read-only, "do X before Y within a skill") is not
+   hookable globally — use subagent `allowed-tools`.
+4. Reminders are still ICL — but *deterministically triggered* ICL whose value is
+   that they fire even when the skill was never loaded. Keep them rare and
+   anchored to discrete, high-signal events.
+5. Keep command patterns conservative; prefer a missed block (safe) over a false
+   block (expensive).

--- a/hooks/__tests__/arc-guard.test.js
+++ b/hooks/__tests__/arc-guard.test.js
@@ -1,0 +1,299 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+// A cwd that carries an `.arcforge-epic` marker (i.e. an epic worktree).
+function makeWorktree(specId = 'demo-spec') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-guard-wt-'));
+  fs.writeFileSync(path.join(dir, '.arcforge-epic'), `spec_id: ${specId}\nepic: epic-001\n`);
+  return dir;
+}
+
+// A cwd with no marker (a base session / ordinary project).
+function makeBase() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'arc-guard-base-'));
+}
+
+describe('arc-guard evaluate', () => {
+  let dirs;
+
+  beforeEach(() => {
+    dirs = [];
+    delete require.cache[require.resolve('../arc-guard/main')];
+    delete require.cache[require.resolve('../../scripts/lib/marker')];
+  });
+
+  afterEach(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function wt(specId) {
+    const d = makeWorktree(specId);
+    dirs.push(d);
+    return d;
+  }
+  function base() {
+    const d = makeBase();
+    dirs.push(d);
+    return d;
+  }
+
+  it('no-op invariant: no marker in cwd → never denies, even for git merge', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const reason = evaluate({
+      tool_name: 'Bash',
+      tool_input: { command: 'git merge main' },
+      cwd: base(),
+    });
+    assert.strictEqual(reason, null);
+  });
+
+  it('ignores non-Bash tools entirely', () => {
+    const { evaluate } = require('../arc-guard/main');
+    assert.strictEqual(
+      evaluate({ tool_name: 'Edit', tool_input: { file_path: '/x' }, cwd: wt() }),
+      null,
+    );
+  });
+
+  it('blocks raw `git merge` inside a worktree and points to the coordinator', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const reason = evaluate({
+      tool_name: 'Bash',
+      tool_input: { command: 'git merge main' },
+      cwd: wt('my-spec'),
+    });
+    assert.ok(reason, 'should deny');
+    assert.ok(reason.includes('finish-epic.js'), 'should redirect to the coordinator flow');
+    assert.ok(reason.includes('my-spec'), 'should name the spec from the marker');
+  });
+
+  it('does NOT block `git merge-base` (false-positive guard)', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const reason = evaluate({
+      tool_name: 'Bash',
+      tool_input: { command: 'git merge-base HEAD origin/main' },
+      cwd: wt(),
+    });
+    assert.strictEqual(reason, null);
+  });
+
+  it('does NOT block `git log --merges` (false-positive guard)', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const reason = evaluate({
+      tool_name: 'Bash',
+      tool_input: { command: 'git log --merges --oneline' },
+      cwd: wt(),
+    });
+    assert.strictEqual(reason, null);
+  });
+
+  it('does NOT block merge conflict-recovery (--abort/--continue/--quit)', () => {
+    const { evaluate } = require('../arc-guard/main');
+    for (const cmd of ['git merge --abort', 'git merge --continue', 'git merge --quit']) {
+      assert.strictEqual(
+        evaluate({ tool_name: 'Bash', tool_input: { command: cmd }, cwd: wt() }),
+        null,
+        `should allow recovery: ${cmd}`,
+      );
+    }
+  });
+
+  it('still blocks a real merge with flags (`git merge --no-ff main`)', () => {
+    const { evaluate } = require('../arc-guard/main');
+    assert.ok(
+      evaluate({ tool_name: 'Bash', tool_input: { command: 'git merge --no-ff main' }, cwd: wt() }),
+    );
+  });
+
+  it('does NOT block reading/diffing a file named loop.js', () => {
+    const { evaluate } = require('../arc-guard/main');
+    for (const cmd of ['cat scripts/lib/loop.js', 'git diff scripts/lib/loop.js']) {
+      assert.strictEqual(
+        evaluate({ tool_name: 'Bash', tool_input: { command: cmd }, cwd: wt() }),
+        null,
+        `should allow file access: ${cmd}`,
+      );
+    }
+  });
+
+  it('blocks starting an arcforge loop inside a worktree', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const reason = evaluate({
+      tool_name: 'Bash',
+      tool_input: { command: 'node scripts/cli.js loop --spec my-spec' },
+      cwd: wt(),
+    });
+    assert.ok(reason, 'should deny');
+    assert.ok(reason.includes('loop'), 'should mention loops');
+    assert.ok(reason.includes('base'), 'should steer to the base session');
+  });
+
+  it('allows benign commands inside a worktree', () => {
+    const { evaluate } = require('../arc-guard/main');
+    assert.strictEqual(
+      evaluate({ tool_name: 'Bash', tool_input: { command: 'npm test' }, cwd: wt() }),
+      null,
+    );
+    assert.strictEqual(
+      evaluate({ tool_name: 'Bash', tool_input: { command: 'git status' }, cwd: wt() }),
+      null,
+    );
+  });
+
+  it('handles malformed input without throwing', () => {
+    const { evaluate } = require('../arc-guard/main');
+    assert.strictEqual(evaluate(null), null);
+    assert.strictEqual(evaluate({ tool_name: 'Bash' }), null);
+    assert.strictEqual(evaluate({ tool_name: 'Bash', tool_input: {} }), null);
+  });
+});
+
+// Exercises main()'s actual wire format end-to-end (subprocess + stdin → stdout).
+// This is the one thing evaluate() unit tests can't cover: that the hook emits the
+// PreToolUse deny JSON the engine acts on. Live blocking can't be tested here (the
+// plugin is disabled in this repo), so this is the closest proxy.
+describe('arc-guard main() wire format', () => {
+  const { execFileSync } = require('node:child_process');
+  const hookPath = require.resolve('../arc-guard/main');
+  let dirs;
+
+  beforeEach(() => {
+    dirs = [];
+  });
+  afterEach(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function run(payload) {
+    const out = execFileSync('node', [hookPath], {
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+    });
+    return out.trim();
+  }
+
+  it('emits permissionDecision:deny JSON for a blocked command', () => {
+    const cwd = makeWorktree('e2e-spec');
+    dirs.push(cwd);
+    const out = run({ tool_name: 'Bash', tool_input: { command: 'git merge main' }, cwd });
+    const parsed = JSON.parse(out);
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PreToolUse');
+    assert.strictEqual(parsed.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(parsed.hookSpecificOutput.permissionDecisionReason.includes('finish-epic.js'));
+  });
+
+  it('emits nothing (allows) when there is no marker', () => {
+    const cwd = makeBase();
+    dirs.push(cwd);
+    const out = run({ tool_name: 'Bash', tool_input: { command: 'git merge main' }, cwd });
+    assert.strictEqual(out, '');
+  });
+});
+
+// A cwd with a locked research-config.md plus the files it references.
+function makeResearch() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-guard-res-'));
+  fs.mkdirSync(path.join(dir, 'src'));
+  fs.mkdirSync(path.join(dir, 'evals'));
+  fs.writeFileSync(path.join(dir, 'src', 'protected.js'), '// protected');
+  fs.writeFileSync(path.join(dir, 'src', 'allowed.js'), '// allowed');
+  fs.writeFileSync(path.join(dir, 'evals', 'bench.json'), '{}');
+  fs.writeFileSync(
+    path.join(dir, 'research-config.md'),
+    '# Research Config\n\n## Scope\nCAN modify: src/allowed.js\n' +
+      'CANNOT modify: src/protected.js, evals/, nonexistent-prose-token\n',
+  );
+  return dir;
+}
+
+describe('arc-guard research-config blocks (Edit/Write)', () => {
+  let dirs;
+  beforeEach(() => {
+    dirs = [];
+    delete require.cache[require.resolve('../arc-guard/main')];
+  });
+  afterEach(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+  function research() {
+    const d = makeResearch();
+    dirs.push(d);
+    return d;
+  }
+
+  it('no-op when there is no research-config.md', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-guard-plain-'));
+    dirs.push(cwd);
+    assert.strictEqual(
+      evaluate({ tool_name: 'Edit', tool_input: { file_path: path.join(cwd, 'any.js') }, cwd }),
+      null,
+    );
+  });
+
+  it('blocks editing the locked research-config.md itself', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const cwd = research();
+    const reason = evaluate({
+      tool_name: 'Edit',
+      tool_input: { file_path: path.join(cwd, 'research-config.md') },
+      cwd,
+    });
+    assert.ok(reason, 'should deny');
+    assert.ok(reason.includes('locked'), 'should name it as the locked contract');
+    assert.ok(reason.includes('disable'), 'should name the sanctioned escape');
+  });
+
+  it('blocks editing an exact CANNOT-modify file', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const cwd = research();
+    const reason = evaluate({
+      tool_name: 'Write',
+      tool_input: { file_path: path.join(cwd, 'src', 'protected.js') },
+      cwd,
+    });
+    assert.ok(reason, 'should deny');
+    assert.ok(reason.includes('CANNOT-modify') || reason.includes('scope'));
+  });
+
+  it('blocks editing a file under a CANNOT-modify directory', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const cwd = research();
+    assert.ok(
+      evaluate({
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(cwd, 'evals', 'bench.json') },
+        cwd,
+      }),
+    );
+  });
+
+  it('allows editing a file inside the CAN-modify scope', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const cwd = research();
+    assert.strictEqual(
+      evaluate({
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(cwd, 'src', 'allowed.js') },
+        cwd,
+      }),
+      null,
+    );
+  });
+
+  it('parseCannotPaths keeps only existing paths, skipping prose tokens', () => {
+    const { parseCannotPaths } = require('../arc-guard/main');
+    const cwd = research();
+    const text = fs.readFileSync(path.join(cwd, 'research-config.md'), 'utf8');
+    const entries = parseCannotPaths(text, cwd);
+    assert.ok(entries.includes(path.join(cwd, 'src', 'protected.js')));
+    assert.ok(entries.includes(path.join(cwd, 'evals')));
+    assert.ok(
+      !entries.some((e) => e.includes('nonexistent-prose-token')),
+      'should skip a non-existent prose token',
+    );
+  });
+});

--- a/hooks/__tests__/arc-remind.test.js
+++ b/hooks/__tests__/arc-remind.test.js
@@ -1,0 +1,153 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('arc-remind command classification', () => {
+  beforeEach(() => {
+    delete require.cache[require.resolve('../arc-remind/main')];
+  });
+
+  it('recognizes common test runners', () => {
+    const { isTestCommand } = require('../arc-remind/main');
+    for (const c of ['npm test', 'npm run test', 'pytest -q', 'go test ./...', 'cargo test']) {
+      assert.ok(isTestCommand(c), `should detect: ${c}`);
+    }
+  });
+
+  it('does not treat non-test commands as tests', () => {
+    const { isTestCommand } = require('../arc-remind/main');
+    for (const c of ['git status', 'npm install', 'node build.js', 'gh pr create']) {
+      assert.strictEqual(isTestCommand(c), false, `should not detect: ${c}`);
+    }
+  });
+
+  it('recognizes PR-boundary commands only', () => {
+    const { isPrBoundary } = require('../arc-remind/main');
+    assert.ok(isPrBoundary('gh pr create --fill'));
+    assert.ok(isPrBoundary('gh pr merge 12 --squash'));
+    assert.strictEqual(isPrBoundary('gh pr view 12'), false);
+    assert.strictEqual(isPrBoundary('gh pr list'), false);
+    assert.strictEqual(isPrBoundary('git push'), false);
+  });
+});
+
+describe('arc-remind buildReminder', () => {
+  beforeEach(() => {
+    delete require.cache[require.resolve('../arc-remind/main')];
+  });
+
+  it('returns null for non-PR commands', () => {
+    const { buildReminder } = require('../arc-remind/main');
+    assert.strictEqual(buildReminder('git commit -m x', false), null);
+    assert.strictEqual(buildReminder('npm test', true), null);
+  });
+
+  it('reminds about verify + review at the PR boundary', () => {
+    const { buildReminder } = require('../arc-remind/main');
+    const msg = buildReminder('gh pr create', false);
+    assert.ok(msg, 'should produce a reminder');
+    assert.ok(msg.includes('arc-verifying'), 'should mention arc-verifying');
+    assert.ok(msg.includes('arc-requesting-review'), 'should mention arc-requesting-review');
+  });
+
+  it('notes when no test was observed this session', () => {
+    const { buildReminder } = require('../arc-remind/main');
+    assert.ok(buildReminder('gh pr create', false).includes('No test command'));
+  });
+
+  it('notes when a test was observed this session', () => {
+    const { buildReminder } = require('../arc-remind/main');
+    assert.ok(buildReminder('gh pr merge 3', true).includes('A test command ran'));
+  });
+});
+
+describe('arc-remind worktree-add + ship-a-skill nudges', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const os = require('node:os');
+  beforeEach(() => {
+    delete require.cache[require.resolve('../arc-remind/main')];
+  });
+
+  it('classifies worktree-add and ship commands', () => {
+    const { isWorktreeAdd, isShipCommand } = require('../arc-remind/main');
+    assert.ok(isWorktreeAdd('git worktree add ../wt feature'));
+    assert.strictEqual(isWorktreeAdd('git worktree list'), false);
+    assert.ok(isShipCommand('git commit -m x'));
+    assert.ok(isShipCommand('git push origin head'));
+    assert.strictEqual(isShipCommand('git status'), false);
+  });
+
+  it('recognizes SKILL.md edits only', () => {
+    const { isSkillFile } = require('../arc-remind/main');
+    assert.ok(isSkillFile('skills/arc-tdd/SKILL.md'));
+    assert.ok(isSkillFile('/abs/path/skills/arc-x/SKILL.md'));
+    assert.strictEqual(isSkillFile('skills/arc-tdd/README.md'), false);
+    assert.strictEqual(isSkillFile('SKILL.md.bak'), false);
+  });
+
+  it('detects an arcforge project by the specs/ directory', () => {
+    const { isArcforgeProject } = require('../arc-remind/main');
+    const withSpecs = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-remind-as-'));
+    const without = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-remind-ns-'));
+    try {
+      fs.mkdirSync(path.join(withSpecs, 'specs'));
+      assert.strictEqual(isArcforgeProject(withSpecs), true);
+      assert.strictEqual(isArcforgeProject(without), false);
+    } finally {
+      fs.rmSync(withSpecs, { recursive: true, force: true });
+      fs.rmSync(without, { recursive: true, force: true });
+    }
+  });
+
+  it('builds the worktree-add and eval-before-ship nudges', () => {
+    const { worktreeAddNudge, evalBeforeShipNudge } = require('../arc-remind/main');
+    assert.ok(worktreeAddNudge().includes('arcforge expand'));
+    assert.ok(evalBeforeShipNudge().includes('arc-writing-skills'));
+  });
+});
+
+describe('arc-remind main-branch nudge', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const os = require('node:os');
+  beforeEach(() => {
+    delete require.cache[require.resolve('../arc-remind/main')];
+  });
+
+  it('parses the branch from .git/HEAD contents', () => {
+    const { branchFromHead } = require('../arc-remind/main');
+    assert.strictEqual(branchFromHead('ref: refs/heads/main\n'), 'main');
+    assert.strictEqual(branchFromHead('ref: refs/heads/feat/x-y\n'), 'feat/x-y');
+    assert.strictEqual(branchFromHead('a1b2c3d4 (detached)\n'), null);
+  });
+
+  it('distinguishes code files from docs', () => {
+    const { isCodeFile } = require('../arc-remind/main');
+    assert.ok(isCodeFile('src/app.js'));
+    assert.ok(isCodeFile('Makefile'));
+    assert.strictEqual(isCodeFile('README.md'), false);
+    assert.strictEqual(isCodeFile('notes.txt'), false);
+  });
+
+  it('detects main/master via .git/HEAD, false otherwise', () => {
+    const { isMainBranch } = require('../arc-remind/main');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-remind-git-'));
+    try {
+      fs.mkdirSync(path.join(dir, '.git'));
+      fs.writeFileSync(path.join(dir, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+      assert.strictEqual(isMainBranch(dir), true);
+      fs.writeFileSync(path.join(dir, '.git', 'HEAD'), 'ref: refs/heads/feat/x\n');
+      assert.strictEqual(isMainBranch(dir), false);
+      assert.strictEqual(isMainBranch(path.join(dir, 'nonexistent')), false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('builds the main-branch nudge', () => {
+    const { mainBranchNudge } = require('../arc-remind/main');
+    const msg = mainBranchNudge();
+    assert.ok(msg.includes('main'));
+    assert.ok(msg.includes('arc-executing-tasks') || msg.includes('branch'));
+  });
+});

--- a/hooks/arc-guard/README.md
+++ b/hooks/arc-guard/README.md
@@ -1,0 +1,50 @@
+# arc-guard
+
+PreToolUse **blocking** hook. Hardens the Worktree Rule (documented in
+`arc-using`) from advisory prose into a deterministic gate.
+
+## What it does
+
+Dispatches by tool. Each rule has its own self-gating signal and is a no-op
+otherwise; it denies via `permissionDecision: 'deny'`.
+
+| Rule | Tool | Gate (signal) | Trigger → redirect |
+|------|------|---------------|--------------------|
+| G2 | Bash | `.arcforge-epic` in cwd | raw `git merge` → arc-finishing-epic flow (`finish-epic.js merge`/`sync`) |
+| G3 | Bash | `.arcforge-epic` in cwd | arcforge loop invocation → run it from the base session (`arc-looping`) |
+| R-immutable | Edit/Write | `research-config.md` in cwd | editing the locked contract → it's the immutable judge (names the human-approved unlock escape) |
+| R-scope | Edit/Write | `research-config.md` in cwd | editing a CANNOT-modify path → out-of-scope write |
+
+## Why these and the precision choices
+
+- **`.arcforge-epic` is the one high-precision discriminator** arcforge has. G2/G3
+  are self-gated by it (marker present ⇔ "you're an implementer in a worktree").
+  Rules that would fire from a **base** session ("block out-of-worktree edits")
+  were deliberately not added — a base session legitimately coordinates (edits
+  `dag.yaml`, `specs/`), so blocking there false-positives.
+- **`git merge`** excludes `git merge-base` and conflict-recovery
+  (`--abort/--continue/--quit`) — those run legitimately during the epic merge
+  flow. **Loop** matches invocations, not `cat`/`diff` of a file named `loop.js`.
+- **R-scope blocks only CANNOT entries that resolve to an existing file/dir.**
+  `research-config.md`'s CANNOT list is free-form prose, so prose words and globs
+  are skipped. A missed fence is recoverable (the research loop runs on a branch
+  and resets); a false block mid-loop is not.
+
+See `docs/plans/hook-hardening-design.md` for the full tier analysis.
+
+## No-op invariant (tested)
+
+When cwd has no `.arcforge-epic` marker (Bash rules) and no `research-config.md`
+(Edit/Write rules), the hook emits nothing and the tool call proceeds. A
+false-positive on the block path is the expensive failure mode (users disable
+arcforge hooks wholesale), so the gates are narrow and the patterns conservative
+(`git merge` excludes `git merge-base`; R-scope blocks only existing paths). The
+invariant is enforced by `hooks/__tests__/arc-guard.test.js`.
+
+## Mechanism
+
+PreToolUse stdout JSON `{ hookSpecificOutput: { hookEventName: 'PreToolUse',
+permissionDecision: 'deny', permissionDecisionReason } }`, exit 0; the reason is
+fed back to Claude. Registered **without `async`** — async hooks cannot block.
+The coordinator's own git calls use `execFileSync` (not the Bash tool), so they
+bypass this hook; G2 only ever sees the agent's manual `git merge`.

--- a/hooks/arc-guard/main.js
+++ b/hooks/arc-guard/main.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * arc-guard - PreToolUse deterministic BLOCK guard for arcforge workflows.
+ *
+ * Hardens a few skill invariants from advisory prose into hard gates. Each rule
+ * fires only when a precise, self-gating signal is present, and is a no-op
+ * otherwise. A false-positive on the block path is the expensive failure mode
+ * (users disable arcforge hooks wholesale), so every rule is narrow.
+ *
+ * Bash rules — gated by the `.arcforge-epic` marker in cwd (i.e. inside a worktree):
+ *   G2  raw `git merge`        -> redirect to the arc-finishing-epic coordinator flow
+ *   G3  arcforge loop launch   -> loops run from the base session, not a worktree
+ *
+ * Edit/Write rules — gated by `research-config.md` in cwd (i.e. an arc-researching
+ * loop is locked):
+ *   R-immutable  editing research-config.md     -> the locked judge is immutable
+ *   R-scope      editing a CANNOT-modify path   -> out-of-scope write (exact paths only)
+ *
+ * NO-OP INVARIANT (tested): with no `.arcforge-epic` marker (Bash) and no
+ * `research-config.md` (Edit/Write) in cwd, the hook emits nothing and the tool
+ * call proceeds untouched.
+ *
+ * BLOCK MECHANISM: PreToolUse stdout JSON
+ *   { hookSpecificOutput: { hookEventName: 'PreToolUse',
+ *       permissionDecision: 'deny', permissionDecisionReason } }
+ * with exit 0; the reason is fed back to Claude. The hook MUST run synchronously
+ * (registered without `async`) — async hooks cannot block. The coordinator's own
+ * git calls use execFileSync (not the Bash tool), so they bypass this hook — the
+ * Bash rules only ever see the agent's manual command, which is the violation.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { readStdinSync, parseStdinJson, output } = require('../../scripts/lib/utils');
+const { hasArcforgeMarker, readArcforgeMarker } = require('../../scripts/lib/marker');
+
+// `git merge` that INITIATES a merge. Excludes `git merge-base`/`-file` (lookahead:
+// next char is whitespace or end) AND conflict-recovery (`--abort`/`--continue`/
+// `--quit`) — those are exactly what a worktree implementer runs during the
+// arc-finishing-epic conflict flow, so blocking them would misdirect.
+const GIT_MERGE_RE = /\bgit\s+merge(?!\s+--(?:abort|continue|quit)\b)(?=\s|$)/;
+// Arcforge loop INVOCATIONS only — not reading/diffing a file named loop.js.
+const LOOP_RE = /\bnode\s+\S*loop\.js\b|\bcli\.js\s+loop\b|\barcforge\s+loop\b/;
+
+const RESEARCH_CONFIG = 'research-config.md';
+
+/**
+ * Build a deny reason for a Bash command known to run inside a worktree, or null.
+ * @param {string} command - the Bash command being run
+ * @param {string|undefined} specId - spec id from the marker, for a clearer message
+ * @returns {string|null}
+ */
+function denyReason(command, specId) {
+  const scope = specId ? ` (spec ${specId})` : '';
+  if (GIT_MERGE_RE.test(command)) {
+    return (
+      `You're inside an arcforge epic worktree${scope} (an .arcforge-epic marker is present). ` +
+      "Raw `git merge` here bypasses the coordinator's DAG and marker bookkeeping. " +
+      'Use the arc-finishing-epic flow instead: `finish-epic.js merge` to merge the epic out, ' +
+      'or `finish-epic.js sync --direction from-base` to pull base in. ' +
+      'A genuine manual merge belongs in the base checkout, not the worktree.'
+    );
+  }
+  if (LOOP_RE.test(command)) {
+    return (
+      `You're inside an arcforge epic worktree${scope} (an .arcforge-epic marker is present). ` +
+      'Arcforge loops run from the project root / base session, not from inside a worktree — ' +
+      'a nested loop duplicates coordination. Exit to the base checkout and start the loop there ' +
+      '(see arc-looping).'
+    );
+  }
+  return null;
+}
+
+/** Bash rule dispatch (G2/G3). */
+function evaluateBash(input, cwd) {
+  const command = input.tool_input?.command;
+  if (typeof command !== 'string' || !command) return null;
+  // Self-gating + no-op invariant: only active inside an epic worktree.
+  if (!hasArcforgeMarker(cwd)) return null;
+  // Cheap pattern check before the (rare) YAML parse for spec id.
+  if (!GIT_MERGE_RE.test(command) && !LOOP_RE.test(command)) return null;
+  const marker = readArcforgeMarker(cwd);
+  return denyReason(command, marker?.spec_id);
+}
+
+/**
+ * Parse the CANNOT-modify entries of a locked research-config.md into resolved
+ * absolute paths — but ONLY those that resolve to an existing file/dir. Free-form
+ * prose, glob patterns, and the unfilled `{template}` placeholder resolve to
+ * nothing on disk and are skipped. Erring toward skipping is deliberate: a missed
+ * fence is recoverable (the research loop runs on a branch and resets), a false
+ * block mid-loop is not.
+ * @param {string} configText
+ * @param {string} cwd
+ * @returns {string[]} absolute paths that exist and are off-limits
+ */
+function parseCannotPaths(configText, cwd) {
+  const entries = [];
+  for (const line of configText.split('\n')) {
+    const m = line.match(/CANNOT\s+modify\s*:\s*(.+)/i);
+    if (!m) continue;
+    for (const raw of m[1].split(/[\s,]+/)) {
+      const clean = raw.replace(/^[`'"{(]+|[`'"})]+$/g, '');
+      if (!clean) continue;
+      const resolved = path.resolve(cwd, clean);
+      if (fs.existsSync(resolved)) entries.push(resolved);
+    }
+  }
+  return entries;
+}
+
+/** Edit/Write rule dispatch (research-config immutability + scope fence). */
+function evaluateFileEdit(input, cwd) {
+  const filePath = input.tool_input?.file_path;
+  if (typeof filePath !== 'string' || !filePath) return null;
+
+  const configPath = path.resolve(cwd, RESEARCH_CONFIG);
+  // No-op invariant: only active when a locked research contract exists in cwd.
+  if (!fs.existsSync(configPath)) return null;
+
+  const target = path.resolve(cwd, filePath);
+
+  if (target === configPath) {
+    return (
+      '`research-config.md` is the locked research contract — the immutable judge of an ' +
+      'arc-researching loop. The autonomous loop must not silently edit what it measures. ' +
+      'If a human approved changing it (e.g. raising Trials), edit it manually outside the ' +
+      'loop or temporarily disable the arc-guard hook; do not modify it from within the run.'
+    );
+  }
+
+  let configText;
+  try {
+    configText = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return null;
+  }
+  for (const entry of parseCannotPaths(configText, cwd)) {
+    if (target === entry || target.startsWith(entry + path.sep)) {
+      return (
+        `\`${filePath}\` is inside the CANNOT-modify scope of research-config.md. ` +
+        "arc-researching's Iron Law #1: never modify files outside the declared scope. " +
+        'If this file genuinely needs to change, the contract is wrong — stop and tell the human.'
+      );
+    }
+  }
+  return null;
+}
+
+/**
+ * Pure decision core for a PreToolUse event. Returns a deny reason, or null to allow.
+ * @param {Object|null} input - parsed hook stdin
+ * @returns {string|null}
+ */
+function evaluate(input) {
+  if (!input) return null;
+  const cwd = input.cwd || process.cwd();
+  if (input.tool_name === 'Bash') return evaluateBash(input, cwd);
+  if (input.tool_name === 'Edit' || input.tool_name === 'Write') {
+    return evaluateFileEdit(input, cwd);
+  }
+  return null;
+}
+
+function main() {
+  try {
+    const reason = evaluate(parseStdinJson(readStdinSync()));
+    if (reason) {
+      output({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: reason,
+        },
+      });
+    }
+  } catch {
+    // Never crash the session — on any error, allow the tool call (fail-open).
+  }
+}
+
+module.exports = {
+  evaluate,
+  denyReason,
+  parseCannotPaths,
+  GIT_MERGE_RE,
+  LOOP_RE,
+  RESEARCH_CONFIG,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/hooks/arc-remind/README.md
+++ b/hooks/arc-remind/README.md
@@ -1,0 +1,41 @@
+# arc-remind
+
+PostToolUse **non-blocking** hook. Hardens several discipline triggers from
+skill-context-only prose into deterministically-fired, user-facing nudges.
+
+## What it does
+
+Dispatches by tool; emits a user-facing `systemMessage` for these triggers:
+
+| Trigger | Tool | Nudge |
+|---------|------|-------|
+| `gh pr create` / `gh pr merge` | Bash | verify (`arc-verifying`) + review (`arc-requesting-review`); notes whether a test ran this session |
+| `git worktree add` in an arcforge project (`specs/`) | Bash | prefer `arcforge expand` for epic worktrees (`arc-using-worktrees`) |
+| `git commit` / `push` after a SKILL.md edit (once/session) | Bash + Edit/Write | re-run the eval before shipping (`arc-writing-skills` Iron Law) |
+| first code (non-doc) edit on `main`/`master` (once/session) | Edit/Write | prefer a branch / epic worktree for feature work (`arc-executing-tasks`) |
+
+The last one is the shippable, user-facing half of eval-before-ship; the
+`ci.yml` annotation is the arcforge-repo half (the plugin is disabled here).
+Edit/Write events are observed only to track that a `SKILL.md` was edited.
+
+## Why the PR boundary
+
+A pull request is the cleanest mechanical proxy for "claiming work complete" — a
+commit is not a completion claim, a PR is. Anchoring here keeps the reminder rare
+and high-signal. Anchoring to every commit, or to every edit on `main`, would be
+a noise machine that gets the hook disabled (arcforge itself develops on `main`).
+
+## Audience: the user, not Claude
+
+A PostToolUse `systemMessage` is shown to the **user** (additionalContext-to-
+Claude is SessionStart / UserPromptSubmit only). This is deliberate: verification
+is human-in-the-loop, and a user-facing nudge avoids the model performatively
+running a test just to satisfy a hook. PostToolUse cannot block; this hook only
+ever reminds.
+
+## State
+
+Tracks a per-session `arc-remind-test-seen` counter (incremented when a test
+runner command is seen) so the reminder can note when no verification ran.
+
+See `docs/plans/hook-hardening-design.md` for the full tier analysis.

--- a/hooks/arc-remind/main.js
+++ b/hooks/arc-remind/main.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * arc-remind - PostToolUse deterministic REMINDER hook (NON-BLOCKING).
+ *
+ * Hardens discipline triggers that are otherwise pure ICL (they only fire if the
+ * relevant skill happens to be loaded) into deterministically-fired nudges. A hook
+ * fires regardless — that is the point of moving them here. PostToolUse cannot
+ * block; this hook only ever reminds, and reminders go to the USER (a PostToolUse
+ * `systemMessage` reaches the user, not Claude). That is deliberate: these are
+ * human-in-the-loop nudges, not instructions for the model to perform.
+ *
+ * Reminders (all rare / high-signal by construction):
+ *   PR boundary   `gh pr create`/`merge`  -> verify (arc-verifying) + review
+ *                                            (arc-requesting-review); notes whether
+ *                                            a test ran this session
+ *   worktree add  `git worktree add` in an arcforge project -> prefer `arcforge
+ *                                            expand` for epic worktrees
+ *   ship a skill  `git commit`/`push` after editing a SKILL.md (once/session)
+ *                                         -> re-run the eval (arc-writing-skills
+ *                                            Iron Law)
+ *
+ * State: per-session counters (test-seen, skill-edited, skill-ship-warned) so
+ * nudges stay rare and context-aware.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  readStdinSync,
+  parseStdinJson,
+  setSessionIdFromInput,
+  output,
+  createSessionCounter,
+} = require('../../scripts/lib/utils');
+
+// Common test runners — broad enough to catch the usual suspects, scoped to avoid noise.
+const TEST_CMD_RE =
+  /\b(?:npm (?:run )?test|npm t|yarn test|pnpm (?:run )?test|jest|vitest|pytest|go test|cargo test|mvn test|gradle test|rspec|phpunit|ctest|make test)\b/;
+const PR_BOUNDARY_RE = /\bgh\s+pr\s+(?:create|merge)\b/;
+const WORKTREE_ADD_RE = /\bgit\s+worktree\s+add\b/;
+const SHIP_RE = /\bgit\s+(?:commit|push)\b/;
+const SKILL_FILE_RE = /(?:^|\/)SKILL\.md$/;
+// Doc-ish extensions that don't count as "implementing" — editing these on main
+// is not the signal we want to nudge on.
+const DOC_EXTENSIONS = new Set(['.md', '.mdx', '.txt', '.rst']);
+
+function isTestCommand(command) {
+  return typeof command === 'string' && TEST_CMD_RE.test(command);
+}
+function isPrBoundary(command) {
+  return typeof command === 'string' && PR_BOUNDARY_RE.test(command);
+}
+function isWorktreeAdd(command) {
+  return typeof command === 'string' && WORKTREE_ADD_RE.test(command);
+}
+function isShipCommand(command) {
+  return typeof command === 'string' && SHIP_RE.test(command);
+}
+function isSkillFile(filePath) {
+  return typeof filePath === 'string' && SKILL_FILE_RE.test(filePath);
+}
+
+/** A code (non-doc) file — the kind of edit that signals "implementing". */
+function isCodeFile(filePath) {
+  if (typeof filePath !== 'string' || !filePath) return false;
+  return !DOC_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+/** Parse a branch name out of `.git/HEAD` contents, or null (detached / unknown). */
+function branchFromHead(headContent) {
+  if (typeof headContent !== 'string') return null;
+  const m = headContent.match(/^ref:\s*refs\/heads\/(.+)\s*$/m);
+  return m ? m[1].trim() : null;
+}
+
+/** Is cwd's git checkout on the main/master branch? Cheap: reads cwd/.git/HEAD. */
+function isMainBranch(cwd) {
+  try {
+    const branch = branchFromHead(fs.readFileSync(path.join(cwd, '.git', 'HEAD'), 'utf8'));
+    return branch === 'main' || branch === 'master';
+  } catch {
+    return false;
+  }
+}
+
+/** Heuristic: is cwd an arcforge-managed project (so `arcforge expand` applies)? */
+function isArcforgeProject(cwd) {
+  try {
+    return fs.existsSync(path.join(cwd, 'specs'));
+  } catch {
+    return false;
+  }
+}
+
+/** PR-boundary verify + review reminder, or null when not a PR command. */
+function buildReminder(command, testSeen) {
+  if (!isPrBoundary(command)) return null;
+  const verifyNote = testSeen
+    ? 'A test command ran this session.'
+    : 'No test command was observed this session.';
+  return (
+    '\n🔍 PR boundary reached. Before treating this as complete:\n' +
+    '  • Fresh verification evidence — see arc-verifying (run the actual checks now).\n' +
+    '  • Review before merge — see arc-requesting-review.\n' +
+    `  ${verifyNote}\n`
+  );
+}
+
+function worktreeAddNudge() {
+  return (
+    '\n🌳 Manual `git worktree add` in an arcforge project. For EPIC worktrees, ' +
+    '`arcforge expand` (see arc-using-worktrees) creates the `.arcforge-epic` marker and ' +
+    'keeps the DAG in sync — prefer it for epic work. (Fine for a non-epic worktree.)\n'
+  );
+}
+
+function mainBranchNudge() {
+  return (
+    '\n🌿 You’re editing code directly on `main`/`master`. For feature work, arcforge ' +
+    'workflows prefer a dedicated branch or epic worktree (arc-executing-tasks / ' +
+    'arc-coordinating) so main stays releasable. Ignore if working on main is intentional here.\n'
+  );
+}
+
+function evalBeforeShipNudge() {
+  return (
+    '\n🧪 You edited a skill this session and are committing. arc-writing-skills’ Iron Law: ' +
+    're-run the skill’s eval (RED → GREEN → REFACTOR) before shipping a behavioral change — ' +
+    'an untested skill edit should not ship.\n'
+  );
+}
+
+function counter(name) {
+  return createSessionCounter(name);
+}
+function bump(name) {
+  const c = counter(name);
+  c.write(c.read() + 1);
+}
+
+function main() {
+  try {
+    const input = parseStdinJson(readStdinSync());
+    if (!input) return;
+    setSessionIdFromInput(input);
+    const tool = input.tool_name;
+
+    // Edit/Write: track SKILL.md edits, and nudge once on the first code edit to main.
+    if (tool === 'Edit' || tool === 'Write') {
+      const filePath = input.tool_input?.file_path || '';
+      const cwd = input.cwd || process.cwd();
+      if (isSkillFile(filePath)) bump('arc-remind-skill-edited');
+      if (
+        isCodeFile(filePath) &&
+        counter('arc-remind-main-warned').read() === 0 &&
+        isMainBranch(cwd)
+      ) {
+        bump('arc-remind-main-warned');
+        output({ systemMessage: mainBranchNudge() });
+      }
+      return;
+    }
+
+    if (tool !== 'Bash') return;
+    const command = input.tool_input?.command || '';
+    const cwd = input.cwd || process.cwd();
+
+    // Record that a test ran (used by the PR-boundary note); a test command is
+    // never also one of the trigger commands below, so stop here.
+    if (isTestCommand(command)) {
+      bump('arc-remind-test-seen');
+      return;
+    }
+
+    if (isPrBoundary(command)) {
+      output({ systemMessage: buildReminder(command, counter('arc-remind-test-seen').read() > 0) });
+      return;
+    }
+
+    if (isWorktreeAdd(command) && isArcforgeProject(cwd)) {
+      output({ systemMessage: worktreeAddNudge() });
+      return;
+    }
+
+    // Ship-a-skill nudge: committing/pushing after editing a SKILL.md, once/session.
+    if (
+      isShipCommand(command) &&
+      counter('arc-remind-skill-edited').read() > 0 &&
+      counter('arc-remind-skill-ship-warned').read() === 0
+    ) {
+      bump('arc-remind-skill-ship-warned');
+      output({ systemMessage: evalBeforeShipNudge() });
+    }
+  } catch {
+    // Non-blocking — never crash the session.
+  }
+}
+
+module.exports = {
+  isTestCommand,
+  isPrBoundary,
+  isWorktreeAdd,
+  isShipCommand,
+  isSkillFile,
+  isCodeFile,
+  branchFromHead,
+  isMainBranch,
+  isArcforgeProject,
+  buildReminder,
+  worktreeAddNudge,
+  evalBeforeShipNudge,
+  mainBranchNudge,
+  TEST_CMD_RE,
+  PR_BOUNDARY_RE,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -63,6 +63,33 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "tool == \"Bash\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/arc-guard/main.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/arc-guard/main.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Write\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/arc-guard/main.js\""
+          }
+        ]
+      },
+      {
         "matcher": ".*",
         "hooks": [
           {
@@ -109,6 +136,33 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/compact-suggester/main.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Bash\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/arc-remind/main.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Edit\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/arc-remind/main.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "tool == \"Write\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/arc-remind/main.js\""
           }
         ]
       },

--- a/scripts/check-benchmark-freshness.js
+++ b/scripts/check-benchmark-freshness.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+/**
+ * check-benchmark-freshness.js — fail a release if its eval benchmark is stale.
+ *
+ * arc-releasing's Iron Law: any release that touched eval-backed surface must
+ * regenerate a fresh benchmark before tagging. `release.yml` already enforces
+ * version-sync and tag-match, but nothing checked benchmark freshness — it was a
+ * hand-run step in the skill. This wires it.
+ *
+ * The check is deterministic: `evals/benchmarks/latest.json` carries a `generated`
+ * ISO timestamp. If the surface that the benchmark measures changed since the
+ * previous release tag, the benchmark must have been regenerated AFTER that tag.
+ *
+ * Scoped to avoid false-failing a doc-only release: if no eval-backed file changed
+ * between the previous tag and HEAD, the check passes regardless of benchmark age.
+ * First release (no previous tag) passes — there's nothing to compare against.
+ *
+ * Contributor-only (runs in release.yml on `v*` tags); the blast radius is the
+ * arcforge release itself. Exits 0 (fresh / not applicable) or 1 (stale).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const BENCHMARK_FILE = 'evals/benchmarks/latest.json';
+
+// Paths whose change means the benchmark's subject changed and must be re-run.
+const EVAL_BACKED_PREFIXES = ['skills/', 'evals/scenarios/', 'evals/fixtures/'];
+
+/**
+ * Pure core: given the benchmark's generated time, the previous tag's commit
+ * time, and whether eval-backed surface changed, decide if the benchmark is stale.
+ * @param {string|null} generatedISO - `.generated` from latest.json (null if absent)
+ * @param {string|null} prevTagISO - previous release tag commit time (null = first release)
+ * @param {boolean} evalSurfaceChanged
+ * @returns {{ stale: boolean, reason: string }}
+ */
+function isBenchmarkStale(generatedISO, prevTagISO, evalSurfaceChanged) {
+  if (!prevTagISO) {
+    return { stale: false, reason: 'first release — no previous tag to compare against' };
+  }
+  if (!evalSurfaceChanged) {
+    return { stale: false, reason: 'no eval-backed surface changed since the previous release' };
+  }
+  const generated = generatedISO ? Date.parse(generatedISO) : NaN;
+  if (Number.isNaN(generated)) {
+    return { stale: true, reason: 'benchmark has no parseable `generated` timestamp' };
+  }
+  const prevTag = Date.parse(prevTagISO);
+  if (generated <= prevTag) {
+    return {
+      stale: true,
+      reason: `benchmark generated ${generatedISO} is not newer than the previous release (${prevTagISO})`,
+    };
+  }
+  return {
+    stale: false,
+    reason: `benchmark generated ${generatedISO} is newer than the previous release`,
+  };
+}
+
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim();
+}
+
+function readGeneratedISO() {
+  const abs = path.join(repoRoot, BENCHMARK_FILE);
+  if (!fs.existsSync(abs)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(abs, 'utf8')).generated || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Most recent tag strictly before the current release tag, or null on first release. */
+function previousTag(currentTag) {
+  try {
+    const ref = currentTag ? `${currentTag}^` : 'HEAD^';
+    return git(['describe', '--tags', '--abbrev=0', ref]) || null;
+  } catch {
+    return null;
+  }
+}
+
+function evalSurfaceChangedSince(prevTag) {
+  let changed;
+  try {
+    changed = git(['diff', '--name-only', prevTag, 'HEAD']).split('\n').filter(Boolean);
+  } catch {
+    // If the diff can't be computed, fail safe toward enforcing (treat as changed).
+    return true;
+  }
+  return changed.some((f) => EVAL_BACKED_PREFIXES.some((p) => f.startsWith(p)));
+}
+
+function main() {
+  const currentTag = process.env.GITHUB_REF_NAME || null;
+  const prevTag = previousTag(currentTag);
+  const generatedISO = readGeneratedISO();
+  const prevTagISO = prevTag ? git(['log', '-1', '--format=%cI', prevTag]) : null;
+  const evalSurfaceChanged = prevTag ? evalSurfaceChangedSince(prevTag) : false;
+
+  const { stale, reason } = isBenchmarkStale(generatedISO, prevTagISO, evalSurfaceChanged);
+
+  console.log('Benchmark freshness check');
+  console.log(`  previous tag:   ${prevTag || '(none — first release)'}`);
+  console.log(`  benchmark gen:  ${generatedISO || '(missing)'}`);
+  console.log(`  eval surface:   ${evalSurfaceChanged ? 'changed' : 'unchanged'}`);
+  console.log('');
+
+  if (stale) {
+    console.error(
+      `::error::Stale benchmark — ${reason}. Regenerate the benchmark before releasing.`,
+    );
+    process.exit(1);
+  }
+  console.log(`OK — ${reason}.`);
+  process.exit(0);
+}
+
+module.exports = { isBenchmarkStale, EVAL_BACKED_PREFIXES };
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/check-skill-eval-annotation.js
+++ b/scripts/check-skill-eval-annotation.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * check-skill-eval-annotation.js — warn (never block) when a PR changes a skill's
+ * spec without a matching eval/benchmark update.
+ *
+ * arc-writing-skills' Iron Law is "eval before ship". A hard CI gate can't enforce
+ * it precisely: there is no mechanical way to tell a behavioral SKILL.md edit from
+ * a typo/metadata edit (the carve-out), so a blocking check would false-fire. This
+ * emits a non-blocking GitHub annotation instead — a visible nudge a reviewer can
+ * judge. The deterministic, user-facing enforcement lives in the arc-remind hook;
+ * this is the arcforge-repo safeguard (the plugin is disabled here).
+ *
+ * Always exits 0. Diffs BASE_REF...HEAD (BASE_REF defaults to origin/main).
+ */
+
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+/** Does the changed-file set carry eval evidence for skill `name`? */
+function hasEvidence(name, changed) {
+  const underscore = name.replace(/-/g, '_');
+  return changed.some(
+    (f) =>
+      f === `tests/skills/test_skill_${underscore}.py` ||
+      (f.startsWith('evals/results/') && f.includes(name)) ||
+      f.startsWith('evals/benchmarks/'),
+  );
+}
+
+/**
+ * Pure core: from a changed-file list, return the skill names whose SKILL.md
+ * changed without any matching eval/test/benchmark evidence in the same diff.
+ * @param {string[]} changed
+ * @returns {string[]}
+ */
+function skillsNeedingEval(changed) {
+  const names = changed
+    .filter((f) => /^skills\/[^/]+\/SKILL\.md$/.test(f))
+    .map((f) => f.split('/')[1]);
+  return names.filter((name) => !hasEvidence(name, changed));
+}
+
+function main() {
+  const base = process.env.BASE_REF || 'origin/main';
+  let changed = [];
+  try {
+    changed = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+      .split('\n')
+      .filter(Boolean);
+  } catch (err) {
+    console.log(`Skipping skill-eval annotation: could not diff against ${base} (${err.message})`);
+    process.exit(0);
+  }
+
+  const flagged = skillsNeedingEval(changed);
+  for (const name of flagged) {
+    console.log(
+      `::warning file=skills/${name}/SKILL.md::SKILL.md changed without a matching eval/benchmark ` +
+        `update. If this was a behavioral change, re-run the eval (arc-writing-skills Iron Law). ` +
+        `Ignore for typo/metadata-only edits.`,
+    );
+  }
+  if (flagged.length === 0) {
+    console.log('No skill spec changed without matching eval evidence.');
+  }
+  process.exit(0);
+}
+
+module.exports = { skillsNeedingEval, hasEvidence };
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/lib/coordinator.js
+++ b/scripts/lib/coordinator.js
@@ -21,35 +21,12 @@ const {
   parseWorktreePath,
   getEpicBranchName,
 } = require('./worktree-paths');
+const { readArcforgeMarker } = require('./marker');
 
 // Lock timeouts for DAG transactions that include slow git operations.
 // Default withLock timeout is 5s; these accommodate heavier workloads.
 const EXPAND_LOCK_TIMEOUT = 30000; // git worktree add + fs ops
 const MERGE_LOCK_TIMEOUT = 60000; // git merge can be slow on large repos
-
-/**
- * Read the `.arcforge-epic` marker from a directory, returning the parsed
- * object or null if the file is missing / unreadable. The marker schema
- * carries at least `{ epic, spec_id, base_worktree, base_branch, local }`
- * when authored by `expandWorktrees`.
- *
- * Shared by `Coordinator.dagPath`, `Coordinator._inferEpicIdFromWorktree`,
- * and `cli.resolveSpecId` — the worktree marker is the single source of
- * truth linking a checkout back to its spec-id, so all three callers
- * must stay in lockstep on how they parse it.
- *
- * @param {string} dir - Directory containing the marker (typically projectRoot).
- * @returns {Object|null} parsed marker or null
- */
-function readArcforgeMarker(dir) {
-  const markerPath = path.join(dir, '.arcforge-epic');
-  if (!fs.existsSync(markerPath)) return null;
-  try {
-    return parseDagYaml(fs.readFileSync(markerPath, 'utf8'));
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Coordinator class - manages DAG operations for a single spec

--- a/scripts/lib/marker.js
+++ b/scripts/lib/marker.js
@@ -1,0 +1,65 @@
+/**
+ * marker.js - canonical reader for the `.arcforge-epic` worktree marker.
+ *
+ * The marker is written into an epic worktree root by `coordinator.expandWorktrees`
+ * and is the single source of truth linking a checkout back to its spec-id. It is
+ * the one high-precision discriminator arcforge has for "am I inside an epic
+ * worktree" — `Coordinator.dagPath`, `cli.resolveSpecId`, and the arc-guard hook
+ * all parse it, so they must stay in lockstep on how they read it.
+ *
+ * Extracted into this lightweight module so hot-path callers (e.g. a PreToolUse
+ * hook that fires on every Bash call) can check for / read the marker without
+ * pulling in the ~1000-line coordinator module.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { parseDagYaml } = require('./yaml-parser');
+
+const MARKER_FILENAME = '.arcforge-epic';
+
+/**
+ * Absolute path to the marker within a directory.
+ * @param {string} dir - Directory expected to hold the marker (typically a worktree root).
+ * @returns {string|null} marker path, or null when `dir` is not a usable string
+ */
+function markerPath(dir) {
+  if (typeof dir !== 'string' || !dir) return null;
+  return path.join(dir, MARKER_FILENAME);
+}
+
+/**
+ * Cheap existence check — does `dir` carry an `.arcforge-epic` marker?
+ * Use this on hot paths; it does no YAML parsing.
+ * @param {string} dir
+ * @returns {boolean}
+ */
+function hasArcforgeMarker(dir) {
+  const p = markerPath(dir);
+  if (!p) return false;
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read and parse the `.arcforge-epic` marker, returning the parsed object or
+ * null when the file is missing / unreadable. The schema carries at least
+ * `{ epic, spec_id, base_worktree, base_branch, local }` when authored by
+ * `expandWorktrees`.
+ * @param {string} dir
+ * @returns {Object|null}
+ */
+function readArcforgeMarker(dir) {
+  const p = markerPath(dir);
+  if (!p || !hasArcforgeMarker(dir)) return null;
+  try {
+    return parseDagYaml(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { MARKER_FILENAME, markerPath, hasArcforgeMarker, readArcforgeMarker };

--- a/tests/scripts/check-ci-gates.test.js
+++ b/tests/scripts/check-ci-gates.test.js
@@ -1,0 +1,68 @@
+const { isBenchmarkStale } = require('../../scripts/check-benchmark-freshness');
+const { skillsNeedingEval } = require('../../scripts/check-skill-eval-annotation');
+
+describe('isBenchmarkStale', () => {
+  const PREV = '2026-05-01T00:00:00.000Z';
+
+  it('passes on first release (no previous tag)', () => {
+    expect(isBenchmarkStale('2020-01-01T00:00:00Z', null, true).stale).toBe(false);
+  });
+
+  it('passes when no eval-backed surface changed', () => {
+    expect(isBenchmarkStale('2020-01-01T00:00:00Z', PREV, false).stale).toBe(false);
+  });
+
+  it('fails when eval surface changed and benchmark is older than the previous release', () => {
+    expect(isBenchmarkStale('2026-04-01T00:00:00.000Z', PREV, true).stale).toBe(true);
+  });
+
+  it('passes when eval surface changed and benchmark is newer than the previous release', () => {
+    expect(isBenchmarkStale('2026-05-06T00:00:00.000Z', PREV, true).stale).toBe(false);
+  });
+
+  it('fails when the benchmark has no parseable generated timestamp', () => {
+    expect(isBenchmarkStale(null, PREV, true).stale).toBe(true);
+    expect(isBenchmarkStale('not-a-date', PREV, true).stale).toBe(true);
+  });
+});
+
+describe('skillsNeedingEval', () => {
+  it('flags a SKILL.md change with no matching eval evidence', () => {
+    expect(skillsNeedingEval(['skills/arc-tdd/SKILL.md'])).toEqual(['arc-tdd']);
+  });
+
+  it('does not flag when the matching test file changed', () => {
+    expect(
+      skillsNeedingEval(['skills/arc-tdd/SKILL.md', 'tests/skills/test_skill_arc_tdd.py']),
+    ).toEqual([]);
+  });
+
+  it('does not flag when a matching eval result changed', () => {
+    expect(
+      skillsNeedingEval([
+        'skills/arc-tdd/SKILL.md',
+        'evals/results/eval-arc-tdd-test-first-gate/run.json',
+      ]),
+    ).toEqual([]);
+  });
+
+  it('does not flag when the benchmark was regenerated', () => {
+    expect(skillsNeedingEval(['skills/arc-tdd/SKILL.md', 'evals/benchmarks/latest.json'])).toEqual(
+      [],
+    );
+  });
+
+  it('ignores non-skill changes', () => {
+    expect(skillsNeedingEval(['scripts/lib/utils.js', 'README.md'])).toEqual([]);
+  });
+
+  it('flags only the skills lacking evidence in a mixed change set', () => {
+    expect(
+      skillsNeedingEval([
+        'skills/arc-tdd/SKILL.md',
+        'skills/arc-debugging/SKILL.md',
+        'tests/skills/test_skill_arc_debugging.py',
+      ]),
+    ).toEqual(['arc-tdd']);
+  });
+});


### PR DESCRIPTION
## Summary

Moves select arcforge skill invariants from in-context-learning (ICL) prose into **deterministic hooks**. Before this, the hook layer was 100% advisory — no hook blocked or read epic/DAG state. This adds the first blocking hook, plus user-facing reminders and two CI gates.

Full survey + tier framework: `docs/plans/hook-hardening-design.md`.

## Framework

Tier is assigned by **discriminator precision**, not by whether the event *can* block:
- **Tier 1 (block)** — discrete signal ⇔ violation, near-zero legitimate collision.
- **Tier 2 (remind)** — deterministic trigger, probabilistic violation → nudge.
- Two hard constraints: no "skill-active sentinel" (per-skill discipline isn't globally hookable → use `allowed-tools`), and **no-op-without-arcforge-context is existential** (a false block makes users disable arcforge hooks wholesale — enforced as a tested invariant).

## What's in here

**`scripts/lib/marker.js`** — extracts `readArcforgeMarker` out of `coordinator.js` (re-exported, so `cli.js` is unaffected) so the hot-path hook avoids requiring the ~1000-line coordinator.

**`hooks/arc-guard/`** (PreToolUse, blocking, synchronous):
- Bash, gated by `.arcforge-epic`: block raw `git merge` (excl. `merge-base` / `--abort|--continue|--quit`) → coordinator flow; block arcforge loop launches → run from base.
- Edit/Write, gated by `research-config.md`: block edits to the locked contract; block edits to CANNOT-modify paths that resolve to an **existing** file/dir (prose/globs skipped — conservative).

**`hooks/arc-remind/`** (PostToolUse, non-blocking, user-facing `systemMessage`):
- PR boundary (`gh pr create`/`merge`) → verify + review reminder.
- `git worktree add` in an arcforge project → prefer `arcforge expand`.
- commit/push after a SKILL.md edit (once/session) → eval-before-ship.
- first code edit on `main`/`master` (once/session) → prefer a branch/worktree.

**CI:** `release.yml` benchmark-freshness gate (scoped hard-fail, contributor-only by arc-releasing's design); `ci.yml` non-blocking skill-eval annotation.

## Testing

All 5 runners green; lint clean.
- `hooks/__tests__/arc-guard.test.js`, `arc-remind.test.js`, `tests/scripts/check-ci-gates.test.js` exercise pure cores.
- Key cases: **no-op invariants** (no marker / no research-config → never denies), **`git merge-base` & conflict-recovery false-positive guards**, **`loop.js`-as-file-arg** (read vs run), **CANNOT-path prose-skip**, and a **wire-format e2e** asserting the real `permissionDecision: 'deny'` JSON.

> Live blocking can't be verified in this repo (plugin disabled here); unit tests piping crafted stdin are the verification. A live check needs `claude --plugin-dir .`.

## Notes for review

- The main-branch nudge deliberately has **no** "active DAG" condition — that signal is anti-correlated with intent (the worktree runs on the epic branch, so an edit-on-main session is the base/coordinator legitimately editing main with an active DAG; the real "implementing on main with no setup" case has no DAG yet).