### PR TITLE
fix(docs): correct Windows install/uninstall in opencode & gemini guides

### DIFF
--- a/docs/README.gemini.md
+++ b/docs/README.gemini.md
@@ -123,6 +123,17 @@ for skill in ~/.agents/arcforge/skills/arc-*/; do
 done
 ```
 
+### Uninstalling (PowerShell)
+
+Remove each skill junction (`rmdir`, which detaches the junction without touching the source):
+
+```powershell
+Get-ChildItem "$env:USERPROFILE\.gemini\skills\arc-*" -Directory | ForEach-Object {
+  cmd /c rmdir $_.FullName
+}
+Remove-Item -Recurse -Force "$env:USERPROFILE\.agents\arcforge"  # optional
+```
+
 ## Troubleshooting
 
 ### Skills not found

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -129,7 +129,7 @@ git clone https://github.com/GregoryHo/arcforge.git "%USERPROFILE%\.agents\arcfo
 mkdir "%USERPROFILE%\.config\opencode\skills"
 mklink /J "%USERPROFILE%\.config\opencode\skills\arcforge" "%USERPROFILE%\.agents\arcforge\skills"
 mkdir "%USERPROFILE%\.config\opencode\plugins"
-mklink /J "%USERPROFILE%\.config\opencode\plugins\arcforge.js" "%USERPROFILE%\.agents\arcforge\.opencode\plugins\arcforge.js"
+mklink "%USERPROFILE%\.config\opencode\plugins\arcforge.js" "%USERPROFILE%\.agents\arcforge\.opencode\plugins\arcforge.js"
 ```
 
 ### PowerShell
@@ -139,8 +139,10 @@ git clone https://github.com/GregoryHo/arcforge.git "$env:USERPROFILE\.agents\ar
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.config\opencode\skills"
 cmd /c mklink /J "$env:USERPROFILE\.config\opencode\skills\arcforge" "$env:USERPROFILE\.agents\arcforge\skills"
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.config\opencode\plugins"
-cmd /c mklink /J "$env:USERPROFILE\.config\opencode\plugins\arcforge.js" "$env:USERPROFILE\.agents\arcforge\.opencode\plugins\arcforge.js"
+cmd /c mklink "$env:USERPROFILE\.config\opencode\plugins\arcforge.js" "$env:USERPROFILE\.agents\arcforge\.opencode\plugins\arcforge.js"
 ```
+
+> **Note:** The skills link is a directory junction (`/J`) and needs no special privileges. The plugin link is a *file* symbolic link (`mklink` without `/J`), which requires **Developer Mode** enabled (Settings → For developers) or an elevated prompt. Without either, use the Git Bash variant below, or `copy` the file in place of the symlink and re-copy it after each update.
 
 ### Git Bash
 
@@ -150,6 +152,16 @@ mkdir -p ~/.config/opencode/skills
 ln -s ~/.agents/arcforge/skills ~/.config/opencode/skills/arcforge
 mkdir -p ~/.config/opencode/plugins
 ln -sf ~/.agents/arcforge/.opencode/plugins/arcforge.js ~/.config/opencode/plugins/arcforge.js
+```
+
+### Uninstalling (PowerShell)
+
+Remove the skills junction (`rmdir`) and the plugin file link (`del`):
+
+```powershell
+cmd /c rmdir "$env:USERPROFILE\.config\opencode\skills\arcforge"
+del "$env:USERPROFILE\.config\opencode\plugins\arcforge.js"
+Remove-Item -Recurse -Force "$env:USERPROFILE\.agents\arcforge"  # optional
 ```
 
 ## Testing


### PR DESCRIPTION
## Windows install-doc fixes (deferred from the v3.2.0 release audit)

Follow-up to #60. The release audit surfaced three **pre-existing, Windows-only** install-doc issues that needed a design decision, so they were deferred out of the release. This PR resolves them.

### Changes

**1. `README.opencode.md` — broken plugin symlink (`warn`)**
The Windows cmd/PowerShell blocks linked the plugin **file** `arcforge.js` with `mklink /J`. `/J` creates a *directory junction* and fails on a file → the OpenCode plugin step was broken for Windows users.
- **Fix:** use a *file symbolic link* (`mklink` without `/J`) — the Windows analog of the existing Git Bash `ln -sf`.
- **Design note (in the doc):** file symlinks require **Developer Mode** or an elevated prompt. A `/H` hard link was rejected because it breaks when `git pull` replaces the file during updates. The skills link keeps `/J` (its target is a directory).

**2 & 3. Missing Windows uninstall sections (`warn`)**
`README.codex.md` had a `### Uninstalling (PowerShell)` subsection; `README.opencode.md` and `README.gemini.md` did not, so their Unix `unlink`/`rm` guidance didn't apply to Windows junctions.
- **OpenCode:** removes the skills junction (`cmd /c rmdir`) + plugin file link (`del`).
- **Gemini:** iterates and `cmd /c rmdir`s each per-skill junction.

### Scope
- Windows sections only — **no** `master`→`main` fetch-URL change here (that's in the release PR #60, to avoid overlap).
- Docs-only; no code/test/lint surface touched.

### Test plan
- [x] `mklink /J` retained for skills (directory), removed for the plugin (file)
- [x] No `master`/version/code changes on this branch (`git diff main` = 2 docs files)
- [ ] Windows commands are pattern-correct (`mklink`, `cmd /c rmdir`, `del`) — not runnable in CI; reviewer with a Windows box welcome to spot-check
