### PR TITLE
fix(cli): lifecycle-aware, worktree-aware loop sentinel (AF-2)

### DIFF
--- a/hooks/__tests__/sdd-ratify-guard.test.js
+++ b/hooks/__tests__/sdd-ratify-guard.test.js
@@ -91,6 +91,33 @@ describe('sdd-ratify-guard evaluate', () => {
     assert.strictEqual(reason, null, 'Should allow arcforge ratify when no sentinel');
   });
 
+  // (a2) worktree cwd (.arcforge-epic marker) + running sentinel at BASE → DENY
+  // AF-2 / S6-1: the sentinel lives at the loop's project root (base), never in
+  // a fresh worktree — the guard must resolve the marker's base_worktree first.
+  it('(a2) ratify from an epic-worktree cwd is denied when the base has a running sentinel', () => {
+    const { evaluate } = require(HOOK_PATH);
+    const base = dir();
+    const worktree = dir();
+    fs.writeFileSync(
+      path.join(base, SENTINEL),
+      JSON.stringify({ iteration: 1, status: 'running' }),
+    );
+    fs.writeFileSync(
+      path.join(worktree, '.arcforge-epic'),
+      `epic: epic-1\nspec_id: my-spec\nbase_worktree: ${base}\nbase_branch: main\n`,
+    );
+
+    const reason = evaluate({
+      tool_name: 'Bash',
+      tool_input: { command: 'arcforge ratify my-spec D-001' },
+      cwd: worktree,
+    });
+    assert.ok(
+      reason !== null,
+      'Should deny ratify from a worktree cwd when the base sentinel is running',
+    );
+  });
+
   // (d) non-ratify command + sentinel → ALLOW
   it('(d) non-ratify Bash command with sentinel is allowed', () => {
     const { evaluate } = require(HOOK_PATH);

--- a/hooks/sdd-ratify-guard/README.md
+++ b/hooks/sdd-ratify-guard/README.md
@@ -4,7 +4,7 @@ PreToolUse hook that provides best-effort denial of `arcforge ratify` Bash invoc
 
 ## What It Does
 
-Intercepts `Bash` tool calls whose command matches `arcforge ratify` or `node <path>/cli.js ratify`. If the loop sentinel (`.arcforge-loop.json`) is present at project root, the hook **denies** the tool call.
+Intercepts `Bash` tool calls whose command matches `arcforge ratify` or `node <path>/cli.js ratify`. If the loop sentinel (`.arcforge-loop.json`) reports a **live** loop — status `running` (or unreadable) with a fresh heartbeat (mtime within 30 minutes) — the hook **denies** the tool call. A finished loop (terminal status or `finished_at`) or a stale heartbeat does not block. When the cwd is an epic worktree (`.arcforge-epic` marker), the sentinel is checked at the marker's `base_worktree`.
 
 ## Why This Exists
 
@@ -12,7 +12,7 @@ Intercepts `Bash` tool calls whose command matches `arcforge ratify` or `node <p
 
 This hook is the **best-effort harness layer** (Task 3b). The **primary deterministic gate** is the engine-side check in `scripts/cli/ratify-command.js`:
 - Refuses to mint when `ARCFORGE_MODE !== 'attended'`
-- Refuses to mint when `.arcforge-loop.json` sentinel is present
+- Refuses to mint when `.arcforge-loop.json` reports a live loop (same lifecycle-aware check)
 
 ## Honest Limits
 
@@ -22,7 +22,7 @@ Do not rely on this hook alone for security — the combination of engine gate +
 
 ## Sentinel File
 
-The sentinel is `.arcforge-loop.json` at project root — the same file maintained by `scripts/loop.js`. Its presence signals an active or recently interrupted autonomous loop.
+The sentinel is `.arcforge-loop.json` at project root — the same file maintained by `scripts/loop.js`. The file persists after a loop finishes (it is the loop's resume state and is never deleted by this gate); only a live loop blocks: status `running` (or an unreadable file) with an mtime heartbeat fresher than 30 minutes (`LOOP_HEARTBEAT_STALE_MS`).
 
 ## Fail-Open
 

--- a/hooks/sdd-ratify-guard/main.js
+++ b/hooks/sdd-ratify-guard/main.js
@@ -3,8 +3,10 @@
  * sdd-ratify-guard — PreToolUse best-effort guard for "arcforge ratify" in loop context.
  *
  * Task 3b (B1 "辅"): Intercepts Bash tool calls containing "arcforge ratify" or
- * "node scripts/cli.js ratify" and DENIES them when the loop sentinel
- * (.arcforge-loop.json) is present at project root.
+ * "node scripts/cli.js ratify" and DENIES them when a LIVE loop is detected
+ * via the lifecycle-aware sentinel check (loopSentinelPresent: status
+ * "running" + fresh heartbeat; worktree cwds resolve to their base via the
+ * .arcforge-epic marker; a finished loop's sentinel does not block).
  *
  * HONEST LIMITS (per implementation-plan.md §0.5 B1 decision):
  *   - This hook IS bypassable with --dangerously-skip-permissions. That is a known,
@@ -48,15 +50,19 @@ function evaluate(input) {
 
   const cwd = input.cwd || process.cwd();
 
-  // Check for loop sentinel.
+  // Lifecycle-aware live-loop check (worktree cwds resolve to their base).
   if (!sentinelPresent(cwd)) return null;
 
   return (
-    `"arcforge ratify" denied — loop sentinel ${LOOP_SENTINEL} detected at ${cwd}.\n` +
-    `Ratification must not occur inside an autonomous loop (B1 harness guard).\n` +
-    `Note: the primary engine gate (ARCFORGE_MODE check in ratify-command.js) provides\n` +
-    `the deterministic guarantee. This hook is best-effort and bypassable by\n` +
-    `--dangerously-skip-permissions (known limit, per implementation-plan.md §0.5 B1).`
+    `"arcforge ratify" denied — a live autonomous loop was detected for ${cwd}\n` +
+    `(${LOOP_SENTINEL} reports a running loop with a fresh heartbeat).\n` +
+    `Ratification is a human decision and must not happen while a loop is running.\n` +
+    `Recovery: wait for the loop to finish — a finished loop records a terminal\n` +
+    `status and this gate clears automatically; a killed loop clears once its\n` +
+    `heartbeat is stale (30 minutes). Then re-run the ratify command in an\n` +
+    `attended session. Never delete ${LOOP_SENTINEL} — it is the loop's resume state.\n` +
+    `Note: the primary engine gate in ratify-command.js provides the deterministic\n` +
+    `guarantee; this hook is the best-effort harness layer (B1).`
   );
 }
 

--- a/scripts/cli/ratify-command.js
+++ b/scripts/cli/ratify-command.js
@@ -5,9 +5,11 @@
  * status: proposed → accepted with a human-asserted ratified_by marker.
  *
  * B1 ENGINE GATE (PRIMARY, deterministic):
- *   Refuses to mint when ARCFORGE_MODE !== 'attended' OR loop sentinel
- *   (.arcforge-loop.json) is present at project root. This is the real floor —
- *   not harness-dependent.
+ *   Refuses to mint when ARCFORGE_MODE !== 'attended' OR a LIVE loop is
+ *   detected via the lifecycle-aware sentinel check (loopSentinelPresent:
+ *   .arcforge-loop.json with status "running" and a fresh heartbeat; a
+ *   finished loop's sentinel stays on disk and does not block). This is the
+ *   real floor — not harness-dependent.
  *
  * HONEST SCOPING (security note):
  *   ratified_by is a HUMAN-ASSERTED marker, NOT forgery-proof. Zero external
@@ -161,9 +163,15 @@ async function runRatifyCommand(positional, projectRoot) {
 
   if (loopSentinelPresent(projectRoot)) {
     console.error(
-      `Error: "arcforge ratify" refused — loop sentinel ${LOOP_SENTINEL} detected.\n` +
-        `Ratification must not occur inside an autonomous loop. Stop the loop first,\n` +
-        `then run "arcforge ratify" in an attended session.`,
+      `Error: "arcforge ratify" refused — a live autonomous loop was detected\n` +
+        `(${LOOP_SENTINEL} reports a running loop with a fresh heartbeat).\n` +
+        `Ratification is a human decision and must not happen while a loop is running.\n` +
+        `Recovery: wait for the loop to finish — a finished loop records a terminal\n` +
+        `status and no longer blocks — then re-run in an attended session:\n` +
+        `  arcforge ratify ${specId} ${dId}\n` +
+        `If the loop was killed without finishing, this gate clears on its own once\n` +
+        `the heartbeat is stale (30 minutes). Never delete ${LOOP_SENTINEL} — it is\n` +
+        `the loop's resume state.`,
     );
     process.exit(1);
   }

--- a/scripts/lib/sdd-decision-ledger.js
+++ b/scripts/lib/sdd-decision-ledger.js
@@ -12,6 +12,7 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const { parseYamlSequence } = require('./yaml-parser');
 const { parseSpecHeader } = require('./sdd-spec-header');
+const { readArcforgeMarker } = require('./marker');
 
 // ---------------------------------------------------------------------------
 // getHeadLedgerContent — git helper for HEAD-relative ledger content.
@@ -348,14 +349,59 @@ function checkSpecDecisionGraph({ specXmlContent, ledger, productVision }) {
 const LOOP_SENTINEL = '.arcforge-loop.json';
 
 /**
- * Returns true if the loop sentinel exists at projectRoot.
- * Fail-closed: returns false on any I/O error.
- * @param {string} projectRoot
+ * Heartbeat staleness window for a sentinel that claims to be running.
+ * scripts/loop.js saveLoopState rewrites the file every iteration, so a live
+ * loop always has a fresh mtime. 30 minutes is the plan-proposed value
+ * (AF-2) — changing it requires owner confirmation.
+ */
+const LOOP_HEARTBEAT_STALE_MS = 30 * 60 * 1000;
+
+/**
+ * Lifecycle-aware check: is an autonomous loop LIVE for this directory?
+ *
+ * Effective-root resolution (AF-2 / S6-1): when `dir` carries a
+ * `.arcforge-epic` marker (epic worktree), the sentinel is checked at the
+ * marker's `base_worktree` — the sentinel is an untracked file at the loop's
+ * project root and never exists inside a fresh worktree.
+ *
+ * Lifecycle semantics:
+ *   - no sentinel file                        → false
+ *   - parsed `finished_at` present            → false (loop finished)
+ *   - parsed terminal status (!== 'running')  → false (loop reached a
+ *     terminal state: complete/failed/max_runs/…)
+ *   - status 'running', unparseable JSON, or
+ *     missing status (ambiguous)              → mtime heartbeat: fresh
+ *     (within LOOP_HEARTBEAT_STALE_MS) → true; stale → false.
+ *
+ * The state file is NEVER deleted or moved here — loop resume depends on it.
+ * Returns false on any I/O error (a broken check must not block ratify).
+ * @param {string} dir - cwd or project root to check (worktree-aware).
  * @returns {boolean}
  */
-function loopSentinelPresent(projectRoot) {
+function loopSentinelPresent(dir) {
   try {
-    return fs.existsSync(path.join(projectRoot, LOOP_SENTINEL));
+    let root = dir;
+    const marker = readArcforgeMarker(dir);
+    if (marker && typeof marker.base_worktree === 'string' && marker.base_worktree) {
+      root = marker.base_worktree;
+    }
+    const sentinelPath = path.join(root, LOOP_SENTINEL);
+    if (!fs.existsSync(sentinelPath)) return false;
+
+    let parsed = null;
+    try {
+      parsed = JSON.parse(fs.readFileSync(sentinelPath, 'utf8'));
+    } catch {
+      // Unparseable → fall through to the conservative heartbeat check.
+    }
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.finished_at) return false;
+      if (typeof parsed.status === 'string' && parsed.status !== 'running') return false;
+    }
+
+    // 'running', unparseable, or ambiguous: trust the heartbeat.
+    const mtimeMs = fs.statSync(sentinelPath).mtimeMs;
+    return Date.now() - mtimeMs < LOOP_HEARTBEAT_STALE_MS;
   } catch {
     return false;
   }
@@ -368,5 +414,6 @@ module.exports = {
   validateDecisionLedger,
   checkSpecDecisionGraph,
   LOOP_SENTINEL,
+  LOOP_HEARTBEAT_STALE_MS,
   loopSentinelPresent,
 };

--- a/scripts/lib/sdd-utils.js
+++ b/scripts/lib/sdd-utils.js
@@ -35,6 +35,7 @@ const {
   validateDecisionLedger,
   checkSpecDecisionGraph,
   LOOP_SENTINEL,
+  LOOP_HEARTBEAT_STALE_MS,
   loopSentinelPresent,
 } = require('./sdd-decision-ledger');
 const {
@@ -87,5 +88,6 @@ module.exports = {
   checkSpecDecisionGraph,
   // D6 P3: B1 loop sentinel — canonical export for ratify-command + hook.
   LOOP_SENTINEL,
+  LOOP_HEARTBEAT_STALE_MS,
   loopSentinelPresent,
 };

--- a/tests/scripts/loop-sentinel.test.js
+++ b/tests/scripts/loop-sentinel.test.js
@@ -1,0 +1,185 @@
+/**
+ * loop-sentinel.test.js — AF-2 lifecycle-aware loop sentinel matrix.
+ *
+ * loopSentinelPresent(dir) semantics under test:
+ *   - terminal status (anything !== 'running') or finished_at present → false
+ *   - status 'running' + fresh heartbeat (mtime)                      → true
+ *   - status 'running' + stale heartbeat (> LOOP_HEARTBEAT_STALE_MS)  → false
+ *   - unparseable JSON + fresh heartbeat (conservative)               → true
+ *   - dir with .arcforge-epic marker resolves to marker.base_worktree
+ *     before checking the sentinel (S6-1 worktree-aware)
+ *   - no marker → today's behavior (check dir itself)
+ *   - the state file is NEVER deleted or moved by the check (AF-5 resume)
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  LOOP_SENTINEL,
+  LOOP_HEARTBEAT_STALE_MS,
+  loopSentinelPresent,
+} = require('../../scripts/lib/sdd-utils');
+
+describe('loopSentinelPresent (lifecycle-aware, AF-2)', () => {
+  let tmpDirs;
+
+  beforeEach(() => {
+    tmpDirs = [];
+  });
+
+  afterEach(() => {
+    for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function makeDir(prefix = 'loop-sentinel-') {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  function writeSentinel(dir, content) {
+    const p = path.join(dir, LOOP_SENTINEL);
+    fs.writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content, null, 2));
+    return p;
+  }
+
+  /** Backdate a file's mtime past the heartbeat staleness window. */
+  function makeStale(filePath) {
+    const past = new Date(Date.now() - LOOP_HEARTBEAT_STALE_MS - 60 * 1000);
+    fs.utimesSync(filePath, past, past);
+  }
+
+  /** Write an .arcforge-epic marker pointing at a base worktree. */
+  function writeMarker(worktreeDir, baseDir) {
+    fs.writeFileSync(
+      path.join(worktreeDir, '.arcforge-epic'),
+      `epic: epic-1\nspec_id: my-spec\nbase_worktree: ${baseDir}\nbase_branch: main\n`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle matrix (no marker — dir is the project root).
+  // -------------------------------------------------------------------------
+
+  it('no sentinel file → false', () => {
+    expect(loopSentinelPresent(makeDir())).toBe(false);
+  });
+
+  it('terminal status (complete) → false even with fresh mtime', () => {
+    const dir = makeDir();
+    writeSentinel(dir, { iteration: 3, status: 'complete' });
+    expect(loopSentinelPresent(dir)).toBe(false);
+  });
+
+  it('terminal status (failed) → false', () => {
+    const dir = makeDir();
+    writeSentinel(dir, { iteration: 2, status: 'failed' });
+    expect(loopSentinelPresent(dir)).toBe(false);
+  });
+
+  it('finished_at present → false even if status is running', () => {
+    const dir = makeDir();
+    writeSentinel(dir, { status: 'running', finished_at: '2026-06-11T00:00:00Z' });
+    expect(loopSentinelPresent(dir)).toBe(false);
+  });
+
+  it('status running + fresh heartbeat → true', () => {
+    const dir = makeDir();
+    writeSentinel(dir, { iteration: 1, status: 'running' });
+    expect(loopSentinelPresent(dir)).toBe(true);
+  });
+
+  it('status running + stale heartbeat → false', () => {
+    const dir = makeDir();
+    const p = writeSentinel(dir, { iteration: 1, status: 'running' });
+    makeStale(p);
+    expect(loopSentinelPresent(dir)).toBe(false);
+  });
+
+  it('unparseable JSON + fresh heartbeat → true (conservative)', () => {
+    const dir = makeDir();
+    writeSentinel(dir, '{not json');
+    expect(loopSentinelPresent(dir)).toBe(true);
+  });
+
+  it('unparseable JSON + stale heartbeat → false', () => {
+    const dir = makeDir();
+    const p = writeSentinel(dir, '{not json');
+    makeStale(p);
+    expect(loopSentinelPresent(dir)).toBe(false);
+  });
+
+  it('parseable JSON without a status field + fresh heartbeat → true (conservative)', () => {
+    // Ambiguous lifecycle (e.g. legacy/foreign sentinel) falls back to the
+    // heartbeat, mirroring the unparseable-file conservatism.
+    const dir = makeDir();
+    writeSentinel(dir, { iteration: 1, running: true });
+    expect(loopSentinelPresent(dir)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Worktree-aware resolution (S6-1).
+  // -------------------------------------------------------------------------
+
+  it('marker worktree + base running sentinel → true', () => {
+    const base = makeDir('loop-sentinel-base-');
+    const worktree = makeDir('loop-sentinel-wt-');
+    writeSentinel(base, { iteration: 1, status: 'running' });
+    writeMarker(worktree, base);
+    expect(loopSentinelPresent(worktree)).toBe(true);
+  });
+
+  it('marker worktree + base terminal sentinel → false', () => {
+    const base = makeDir('loop-sentinel-base-');
+    const worktree = makeDir('loop-sentinel-wt-');
+    writeSentinel(base, { iteration: 3, status: 'complete', finished_at: '2026-06-11T00:00:00Z' });
+    writeMarker(worktree, base);
+    expect(loopSentinelPresent(worktree)).toBe(false);
+  });
+
+  it('marker worktree + no sentinel at base → false', () => {
+    const base = makeDir('loop-sentinel-base-');
+    const worktree = makeDir('loop-sentinel-wt-');
+    writeMarker(worktree, base);
+    expect(loopSentinelPresent(worktree)).toBe(false);
+  });
+
+  it("directory without marker keeps today's behavior (checks dir itself)", () => {
+    // A running sentinel in the dir itself is honored — no marker, no redirect.
+    const dir = makeDir();
+    writeSentinel(dir, { iteration: 1, status: 'running' });
+    expect(loopSentinelPresent(dir)).toBe(true);
+    // And a sibling dir is unaffected.
+    expect(loopSentinelPresent(makeDir())).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-destructive invariant (AF-5 resume depends on the state file).
+  // -------------------------------------------------------------------------
+
+  it('never deletes or moves the state file, for any lifecycle state', () => {
+    const terminal = makeDir();
+    const tPath = writeSentinel(terminal, { status: 'complete', finished_at: 'x' });
+    const running = makeDir();
+    const rPath = writeSentinel(running, { status: 'running' });
+    const stale = makeDir();
+    const sPath = writeSentinel(stale, { status: 'running' });
+    makeStale(sPath);
+
+    loopSentinelPresent(terminal);
+    loopSentinelPresent(running);
+    loopSentinelPresent(stale);
+
+    expect(fs.existsSync(tPath)).toBe(true);
+    expect(fs.existsSync(rPath)).toBe(true);
+    expect(fs.existsSync(sPath)).toBe(true);
+    // Content untouched too.
+    expect(JSON.parse(fs.readFileSync(tPath, 'utf8')).status).toBe('complete');
+  });
+
+  it('returns false on unusable input instead of throwing', () => {
+    expect(loopSentinelPresent(path.join(makeDir(), 'does-not-exist'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Wave 0 of the capability seam-fix plan (PR-0d). Fixes the bug where a finished loop's stale sentinel permanently locks out `arcforge ratify`, and the seam where the sentinel check always returns false from a worktree cwd (which would disable the autopilot guard chain).

## What
- `loopSentinelPresent(dir)` rewritten in `scripts/lib/sdd-decision-ledger.js`:
  - Resolves the effective root first — a cwd with an `.arcforge-epic` marker resolves via `readArcforgeMarker().base_worktree` to the base before checking (the sentinel is an untracked file at project root; fresh worktrees never have it) 【S6-1】
  - Terminal status (anything ≠ `running`) or `finished_at` present → false; `running`/unparseable → mtime heartbeat with `LOOP_HEARTBEAT_STALE_MS` = 30 min (plan-proposed value)
  - State file is never deleted/moved (AF-5 resume depends on it)
- Refusal texts in `scripts/cli/ratify-command.js` and `hooks/sdd-ratify-guard/main.js` now name the real, runnable recovery ("Stop the loop first" with no recovery path is gone)

## Acceptance evidence (adversarially reviewed & replayed: approve)
- New `tests/scripts/loop-sentinel.test.js` full matrix: terminal→allow, running+fresh→deny, running+stale→allow, unparseable+fresh→deny (conservative), marker-worktree+base-running→deny, marker-worktree+base-terminal→allow, markerless dir→today's behavior
- New worktree-cwd deny case in `hooks/__tests__/sdd-ratify-guard.test.js`
- Manual tmp-project verification: ratify passes the sentinel gate under a terminal sentinel
- `npm test` all 5 runners green; lint green