### PR TITLE
feat(hooks): PostToolUse model-visible feedback helper, spike-verified (RV-1)

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -62,7 +62,8 @@ Use `readStdinSync()` + `parseStdinJson()` from `scripts/lib/utils.js` to read.
 |-----------|----------|----------|---------|
 | `stderr` (`log()`, `console.error()`) | **Nobody** | **NO** — condensed into "N hooks ran", invisible even in Ctrl+O | Internal diagnostics only |
 | `stdout` `{"systemMessage": "..."}` | **User** | **YES** — shown as "HookEvent:Tool says:" | Suggestions, warnings, notifications |
-| `stdout` `{"hookSpecificOutput": {"additionalContext": "..."}}` | **Claude** | YES — injected into context | Context injection (SessionStart, UserPromptSubmit only) |
+| `stdout` `{"hookSpecificOutput": {"additionalContext": "..."}}` | **Claude** | YES — injected into context | Context injection (SessionStart, UserPromptSubmit, PostToolUse — PostToolUse spike-verified v2.1.172, incl. Task-subagent tool calls; rendered as "PostToolUse:Tool hook additional context:") |
+| `stdout` `{"decision": "block", "reason": "..."}` | **Claude** | YES — reason fed back to the model (PostToolUse renders it as "hook blocking error"; spike-verified v2.1.172) | Stop hooks (`outputDecision`); PostToolUse corrective blocking only — for non-error feedback prefer `additionalContext` |
 | Exit code 2 | Claude Code engine | N/A — blocks action | Blocking hooks only (PreToolUse, UserPromptSubmit, Stop) |
 
 **CRITICAL**: `stderr` is **invisible** in all events (verified: PostToolUse, Stop). Claude Code condenses it regardless of hook count. Do NOT use stderr for anything the user needs to see.
@@ -71,8 +72,9 @@ Use `readStdinSync()` + `parseStdinJson()` from `scripts/lib/utils.js` to read.
 
 **Rules:**
 - User-visible message → `output({ systemMessage: "..." })` (only mechanism that works)
-- Context for Claude → `outputContext(text, eventName)` (SessionStart/UserPromptSubmit only)
+- Context for Claude → `outputContext(text, eventName)` (SessionStart/UserPromptSubmit)
 - Both at once → `outputCombined(userMsg, claudeCtx, eventName)` (verified: Claude Code processes all keys in a single JSON)
+- PostToolUse feedback for Claude → `outputPostToolUseFeedback(reason, { systemMessage })` (exactly one merged JSON object; spike-verified v2.1.172 — model still receives `additionalContext` when `systemMessage` is present)
 - Internal diagnostics → `log(msg)` (stderr, but user will never see it)
 - Never use `console.log` — goes to stdout, contaminates hook protocol
 

--- a/hooks/__tests__/utils.test.js
+++ b/hooks/__tests__/utils.test.js
@@ -19,6 +19,8 @@ const {
   getTimestamp,
   createSessionCounter,
   parseStdinJson,
+  buildPostToolUseFeedback,
+  outputPostToolUseFeedback,
 } = require('../../scripts/lib/utils');
 
 describe('escapeForJson', () => {
@@ -330,5 +332,62 @@ describe('parseStdinJson', () => {
   it('should return null for invalid JSON', () => {
     assert.strictEqual(parseStdinJson('not json'), null);
     assert.strictEqual(parseStdinJson(''), null);
+  });
+});
+
+describe('buildPostToolUseFeedback', () => {
+  it('should return the spike-verified pure field object', () => {
+    assert.deepStrictEqual(buildPostToolUseFeedback('fix the type error'), {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: 'fix the type error',
+      },
+    });
+  });
+
+  it('should throw on non-string or empty reason', () => {
+    assert.throws(() => buildPostToolUseFeedback(null), /non-empty string/);
+    assert.throws(() => buildPostToolUseFeedback(42), /non-empty string/);
+    assert.throws(() => buildPostToolUseFeedback('   '), /non-empty string/);
+  });
+});
+
+describe('outputPostToolUseFeedback', () => {
+  const originalLog = console.log;
+  let stdoutLines;
+
+  beforeEach(() => {
+    stdoutLines = [];
+    console.log = (...args) => stdoutLines.push(args.join(' '));
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  it('should emit exactly one JSON object containing both fields when systemMessage given', () => {
+    outputPostToolUseFeedback('fix the type error', { systemMessage: 'Formatted: file.ts' });
+    assert.strictEqual(stdoutLines.length, 1);
+    const parsed = JSON.parse(stdoutLines[0]);
+    assert.deepStrictEqual(parsed, {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: 'fix the type error',
+      },
+      systemMessage: 'Formatted: file.ts',
+    });
+  });
+
+  it('should emit exactly one JSON object with only the model field when no systemMessage', () => {
+    outputPostToolUseFeedback('fix the type error');
+    assert.strictEqual(stdoutLines.length, 1);
+    const parsed = JSON.parse(stdoutLines[0]);
+    assert.deepStrictEqual(parsed, {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: 'fix the type error',
+      },
+    });
+    assert.ok(!('systemMessage' in parsed));
   });
 });

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -407,6 +407,54 @@ function outputDecisionHighlight(reason) {
 }
 
 /**
+ * Build the model-visible PostToolUse feedback fields (pure — no I/O).
+ *
+ * Spike-verified on Claude Code v2.1.172 (2026-06-11, neutral-cwd /tmp/pthook-spike):
+ * - PostToolUse `hookSpecificOutput.additionalContext` REACHES THE MODEL,
+ *   rendered as "PostToolUse:<Tool> hook additional context: <text>"
+ *   (canary HOOK-CANARY-2/PLUGH echoed verbatim by the model).
+ * - The same channel also reaches Task-tool subagent implementers
+ *   (canary HOOK-CANARY-3 echoed verbatim from inside a subagent Write).
+ * - `{ decision: 'block', reason }` also reaches the model but is rendered as a
+ *   "hook blocking error" (canary HOOK-CANARY-1/XYZZY) — error framing, so it is
+ *   reserved for corrective blocking, not routine feedback.
+ *
+ * @param {string} reason - Model-visible feedback text
+ * @returns {Object} { hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext } }
+ */
+function buildPostToolUseFeedback(reason) {
+  if (typeof reason !== 'string' || !reason.trim()) {
+    throw new Error('buildPostToolUseFeedback: reason must be a non-empty string');
+  }
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext: reason,
+    },
+  };
+}
+
+/**
+ * Emit model-visible PostToolUse feedback as EXACTLY ONE JSON object on stdout.
+ * An optional user-visible systemMessage is merged into the SAME object
+ * (single-output pattern — two separate JSON lines were never verified).
+ * Merged-object delivery spike-verified on Claude Code v2.1.172: the model
+ * still receives additionalContext when systemMessage is present
+ * (canary HOOK-CANARY-4/FILFRE echoed verbatim).
+ *
+ * @param {string} reason - Model-visible feedback text
+ * @param {Object} [options]
+ * @param {string} [options.systemMessage] - User-visible message merged into the same JSON object
+ */
+function outputPostToolUseFeedback(reason, { systemMessage } = {}) {
+  const result = buildPostToolUseFeedback(reason);
+  if (systemMessage) {
+    result.systemMessage = systemMessage;
+  }
+  output(result);
+}
+
+/**
  * Sanitize a raw session id for safe use as a path component.
  * Valid ids (UUIDs, ppid numbers) pass through unchanged. On any
  * traversal/control-char failure, fail-safe to a stable hash rather than
@@ -698,6 +746,8 @@ module.exports = {
   outputCombined,
   outputDecision,
   outputDecisionHighlight,
+  buildPostToolUseFeedback,
+  outputPostToolUseFeedback,
   // Color utilities (internal: colors, colorize, supportsColor)
   // Session management
   getSessionId,


### PR DESCRIPTION
Wave 0 keystone (PR-0e). Empirically verifies that PostToolUse hooks CAN reach the model, corrects the repo's visibility table, and ships the shared helper that RV-3 (quality-check re-aim), RV-5 (arc-remind autopilot escalation), and ICL-10 (compaction-prep channel) all consume. **All three downstream tasks are unblocked.**

## Spike results (claude --version: 2.1.172, neutral cwd /tmp/pthook-spike, canary tokens never present in driving prompts — verbatim echo proves model delivery)
| Round | Mechanism | Result |
|---|---|---|
| 1 | `{"decision":"block","reason":...}` | **Reaches model** — but rendered as "hook blocking error" (error framing; wrong for routine feedback, re-edit-loop risk). File still written (PostToolUse fires after the tool) |
| 2 | `hookSpecificOutput.additionalContext` | **Reaches model**, neutral framing ✓ |
| 3 | additionalContext, Write performed by Task-tool subagent | **Reaches the subagent model** — confirms the fan-out leg (S6) |
| 4 (bonus) | single merged JSON `{systemMessage + hookSpecificOutput}` | Both audiences receive — validates the helper's single-output shape. A failed first attempt (hook emitting nothing) returned NO-CANARY-SEEN: negative control, the model does not hallucinate canaries |

Raw transcripts archived: `~/.arcforge/evidence/wave0-rv1-spike-transcripts.tgz`

## What ships
- `scripts/lib/utils.js`: `buildPostToolUseFeedback(reason)` (pure field object, typeof-guarded per security.md) + `outputPostToolUseFeedback(reason, { systemMessage })` (exactly ONE merged JSON object). JSDoc records verified version + all canary outcomes. additionalContext shape chosen over decision:block (error framing documented in the table instead)
- `.claude/rules/hooks.md` Output Visibility table corrected (one edit, as the plan mandates)
- `hooks/__tests__/utils.test.js`: asserts stdout parses as exactly one JSON object containing both fields

## Review
Adversarially reviewed: approve. Reviewer independently reproduced the mechanism with a reviewer-chosen canary driven through the shipped helper itself.