### PR TITLE
feat(cli): status --json emits absolute worktree path per epic (WT-1)

### DIFF
--- a/docs/guide/worktree-workflow.md
+++ b/docs/guide/worktree-workflow.md
@@ -41,8 +41,11 @@ derived at runtime, and the derivation rule has evolved before (previously
 `.worktrees/<epic>/` inside the repo). Use the CLI:
 
 ```bash
-arcforge status --json   # returns epic.worktree.path absolutely
+arcforge status --json   # each epic carries .path — the absolute worktree path (null until expanded)
 ```
+
+Read `.path` from the **base checkout**. Inside a worktree, the local dag
+copy has `worktree: null` for every epic, so `.path` is always null there.
 
 ## The `.arcforge-epic` Marker
 
@@ -165,8 +168,8 @@ arcforge status        # 看哪些 epic ready
 # 2. 為 ready 的 epic 建立 worktree
 arcforge expand --epic epic-auth --project-setup
 
-# 3. 用 arcforge status --json 取得 worktree 絕對路徑，然後進入
-cd "$(arcforge status --json | jq -r '.epics[] | select(.id=="epic-auth") | .worktree')"
+# 3. 用 arcforge status --json 取得 worktree 絕對路徑（.path 欄位），然後進入
+cd "$(arcforge status --json | jq -r '.epics[] | select(.id=="epic-auth") | .path')"
 
 # 4. 檢查依賴
 arcforge sync --direction from-base
@@ -196,11 +199,11 @@ arcforge status
 cd /path/to/project
 arcforge status
 
-# 2. 取得 in_progress 的 worktree 絕對路徑
+# 2. 在 base 取得 in_progress epic 的 worktree 絕對路徑（.path 欄位）
 arcforge status --json
 
 # 3. 進入該路徑並繼續
-cd "<path from JSON>"
+cd "$(arcforge status --json | jq -r '.epics[] | select(.id=="epic-auth") | .path')"
 arcforge sync --direction from-base
 ```
 
@@ -257,4 +260,4 @@ clear the DAG entry.
 2. **不要手動 git merge / Never hand-merge**：使用 `arcforge merge`，它會正確更新 DAG
 3. **Blocked 就停止 / Stop when blocked**：如果 sync 顯示 blocked_by 不為空，先完成依賴的 epic
 4. **`.arcforge-epic` 是關鍵 / The marker is load-bearing**：這個檔案標記你在 worktree 內，包含同步資訊
-5. **絕不硬寫路徑 / Never hardcode paths**：讀取 `arcforge status --json` 或呼叫 `scripts/lib/worktree-paths.js` 取得絕對路徑
+5. **絕不硬寫路徑 / Never hardcode paths**：在 base checkout 讀取 `arcforge status --json` 的 `.path` 欄位，或呼叫 `scripts/lib/worktree-paths.js` 取得絕對路徑。在 worktree 內 `.path` 恆為 null（本地 dag 副本 `worktree: null`），不要從 worktree 內讀取

--- a/scripts/lib/coordinator-core.js
+++ b/scripts/lib/coordinator-core.js
@@ -105,6 +105,11 @@ class Coordinator {
         status: epic.status,
         progress: epic.completionRatio(),
         worktree: epic.worktree,
+        // Absolute worktree path, derived at read time from the stored
+        // worktree value (additive — `worktree` keeps the raw dag value).
+        // null when the epic has not been expanded; always null when read
+        // from a worktree's local dag copy, where every worktree is null.
+        path: epic.worktree ? this._resolveWorktreePath(epic.worktree) : null,
         features: epic.features.map((f) => ({
           id: f.id,
           name: f.name,

--- a/tests/scripts/cli-multi-spec.test.js
+++ b/tests/scripts/cli-multi-spec.test.js
@@ -3,8 +3,9 @@ const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
-const { stringifyDagYaml } = require('../../scripts/lib/yaml-parser');
+const { stringifyDagYaml, parseDagYaml } = require('../../scripts/lib/yaml-parser');
 const { TaskStatus } = require('../../scripts/lib/models');
+const { getWorktreePath } = require('../../scripts/lib/worktree-paths');
 
 const CLI = path.resolve(__dirname, '../../scripts/cli.js');
 
@@ -73,6 +74,23 @@ describe('CLI multi-spec UX', () => {
     expect(parsed).toHaveProperty('specs');
     expect(Object.keys(parsed.specs).sort()).toEqual(['spec-a', 'spec-b']);
     expect(parsed.specs['spec-a'].epics).toHaveLength(1);
+  });
+
+  test('status aggregation carries per-epic path (derived when worktree set, null otherwise)', () => {
+    writeSpec(root, 'spec-a', ['epic-a1']);
+    writeSpec(root, 'spec-b', ['epic-b1']);
+    // Mark spec-a's epic as expanded — status derives the absolute path
+    // from the stored worktree value at read time (no real worktree dir
+    // is needed for derivation).
+    const dagPath = path.join(root, 'specs', 'spec-a', 'dag.yaml');
+    const dag = parseDagYaml(fs.readFileSync(dagPath, 'utf8'));
+    dag.epics[0].worktree = 'epic-a1';
+    fs.writeFileSync(dagPath, stringifyDagYaml(dag));
+
+    const { stdout } = runCli(root, ['status', '--json']);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.specs['spec-a'].epics[0].path).toBe(getWorktreePath(root, 'spec-a', 'epic-a1'));
+    expect(parsed.specs['spec-b'].epics[0].path).toBeNull();
   });
 
   test('next with two specs requires --spec-id', () => {

--- a/tests/scripts/coordinator-status-path.test.js
+++ b/tests/scripts/coordinator-status-path.test.js
@@ -1,0 +1,79 @@
+/**
+ * Coordinator.status() — absolute worktree path emission (WT-1).
+ *
+ * status() emits `path` per epic: the absolute worktree path derived at
+ * read time from the stored `worktree` value (null when not expanded).
+ * The pin test fixes the fact that `.path` is only meaningful from the
+ * BASE checkout — a worktree's local dag copy carries `worktree: null`
+ * for every epic, so `status --json` from a worktree cwd reports null.
+ * Skill text must never instruct reading `.path` from inside a worktree.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { Coordinator } = require('../../scripts/lib/coordinator');
+const { getWorktreePath, parseWorktreePath } = require('../../scripts/lib/worktree-paths');
+const {
+  runGit,
+  setupRepo,
+  cleanupWorktrees,
+  DEFAULT_SPEC_ID,
+} = require('./coordinator-test-helpers');
+
+const CLI = path.resolve(__dirname, '../../scripts/cli.js');
+
+describe('Coordinator.status() — worktree path emission', () => {
+  let root;
+
+  beforeEach(() => {
+    root = setupRepo();
+    // Commit the dag so the epic worktree checkout carries its own local
+    // copy — the committed copy still has `worktree: null` for every epic
+    // (expand mutates only the base's working-tree dag.yaml).
+    runGit(['add', '.'], root);
+    runGit(['commit', '-q', '-m', 'chore: add dag'], root);
+  });
+
+  afterEach(() => {
+    cleanupWorktrees(root);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('expanded epic carries an absolute, parseable path; unexpanded stays null', () => {
+    new Coordinator(root, DEFAULT_SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+
+    const result = new Coordinator(root, DEFAULT_SPEC_ID).status();
+    const epicA = result.epics.find((e) => e.id === 'epic-a');
+    const epicB = result.epics.find((e) => e.id === 'epic-b');
+
+    // `worktree` keeps the raw dag value (epic id) — `path` is additive.
+    expect(epicA.worktree).toBe('epic-a');
+    expect(path.isAbsolute(epicA.path)).toBe(true);
+    expect(parseWorktreePath(epicA.path)).not.toBeNull();
+    expect(epicA.path).toBe(getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a'));
+
+    expect(epicB.worktree).toBeNull();
+    expect(epicB.path).toBeNull();
+  });
+
+  test('pin: status --json from a worktree cwd reports path null (local dag copy has worktree: null)', () => {
+    new Coordinator(root, DEFAULT_SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+    const worktreePath = getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a');
+
+    const stdout = execFileSync('node', [CLI, 'status', '--json'], {
+      cwd: worktreePath,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: worktreePath },
+      encoding: 'utf8',
+    });
+    const parsed = JSON.parse(stdout);
+    const epicA = parsed.epics.find((e) => e.id === 'epic-a');
+
+    // The worktree-local dag copy never knows about its own expansion, so
+    // `.path` is null from inside a worktree. Never instruct reading
+    // `.path` from a worktree cwd — read it from the base checkout.
+    expect(epicA.worktree).toBeNull();
+    expect(epicA.path).toBeNull();
+  });
+});

--- a/tests/scripts/coordinator.test.js
+++ b/tests/scripts/coordinator.test.js
@@ -1,4 +1,6 @@
+const path = require('node:path');
 const { DAG, TaskStatus } = require('../../scripts/lib/models');
+const { parseWorktreePath } = require('../../scripts/lib/worktree-paths');
 
 // We test Coordinator's pure scheduling logic by injecting a DAG directly,
 // bypassing file I/O. For methods that call _saveDag (which uses withLock + fs),
@@ -70,6 +72,23 @@ describe('Coordinator', () => {
       const result = coord.status({ blockedOnly: true });
       expect(result.epics).toHaveLength(1);
       expect(result.epics[0].id).toBe('epic-1');
+    });
+
+    it('should report path: null for epics without a worktree', () => {
+      const coord = createCoordinator(twoEpicDag());
+      const result = coord.status();
+      expect(result.epics[0].path).toBeNull();
+      expect(result.epics[1].path).toBeNull();
+    });
+
+    it('should derive an absolute, parseable path for an expanded epic without touching worktree', () => {
+      const coord = createCoordinator(twoEpicDag({ epic1Worktree: 'epic-1' }));
+      const result = coord.status();
+      // The raw dag value stays in `worktree`; `path` is strictly additive.
+      expect(result.epics[0].worktree).toBe('epic-1');
+      expect(path.isAbsolute(result.epics[0].path)).toBe(true);
+      expect(parseWorktreePath(result.epics[0].path)).not.toBeNull();
+      expect(result.epics[1].path).toBeNull();
     });
 
     it('should report progress as completion ratio', () => {


### PR DESCRIPTION
Wave 0 of the capability seam-fix plan (PR-1a). Makes 18 shipped instructions true at once: five skills + the guide tell agents to read the absolute worktree path from `status --json`, but the engine returned the epic id in `worktree` and no path.

## What
- `scripts/lib/coordinator-core.js` `status()`: each `epics[]` entry gains `path: epic.worktree ? this._resolveWorktreePath(epic.worktree) : null` — strictly additive, the `worktree` field is untouched (no consumer breaks)
- `docs/guide/worktree-workflow.md`: stale claim fixed, `| .worktree` → `| .path` in jq examples, scenario 3 + caution #5 made consistent (`grep -n '| .worktree'` now empty)

## Acceptance evidence (adversarially reviewed & replayed: approve)
- Jest: expanded→path absolute and `parseWorktreePath()` non-null; not-expanded→null; multi-spec aggregation branch carries path
- NEW pin test: `status --json` from a worktree cwd → epic `path` is null (worktree-local dag copy has `worktree:null`) — pins the "never instruct reading .path from inside a worktree" fact for WT-4's wording
- Fixture: `jq -r '.epics[0].path'` output is cd-able
- `npm test` all 5 runners green; lint green