### PR TITLE
feat(cli): generic worktree engine — arcforge worktree add|list|remove (WT-2)

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -13,6 +13,7 @@
  *   cleanup [epic_ids...]           Remove worktrees for completed epics
  *   sync [--direction from-base|to-base|both|scan]  Sync state
  *   reboot                          Get context for new session
+ *   worktree add|list|remove        Generic (non-epic) worktree management
  *   schema [--json] [--example]     Show dag.yaml schema
  *   loop [--pattern sequential|dag] [--max-runs N] [--max-cost $N]  Run autonomous loop
  *   eval list                        List eval scenarios
@@ -115,6 +116,15 @@ async function main() {
       case 'reboot':
       case 'loop': {
         runDagCommand(args, { projectRoot, asJson });
+        break;
+      }
+
+      case 'worktree': {
+        // Generic (non-epic) worktree management. Engine + dispatch live in
+        // scripts/lib/worktree-generic.js; epic worktrees stay with
+        // expand/cleanup (remove redirects marker'd trees there).
+        const { runWorktreeCommand } = require('./lib/worktree-generic');
+        output(runWorktreeCommand(args, projectRoot), asJson);
         break;
       }
 

--- a/scripts/cli/help.js
+++ b/scripts/cli/help.js
@@ -53,6 +53,20 @@ COMMANDS:
   cleanup [epic_ids...] [--spec-id <id>]
       Remove worktrees for completed epics.
 
+  worktree add <name> [--branch <b>] [--from <ref>] [--setup]
+      Create a generic (non-epic) worktree at ~/.arcforge/worktrees/.
+      --branch         Branch to check out (default: <name>; created if missing)
+      --from           Base ref when creating a new branch (default: HEAD)
+      --setup          Auto-detect and run installer (npm/pip/cargo/go)
+
+  worktree list [--json]
+      List all worktrees annotated by kind: base|epic|generic|external.
+
+  worktree remove <name> [--force]
+      Remove a generic worktree and prune git metadata. Epic worktrees
+      are refused — use 'cleanup' for those.
+      --force          Remove even with uncommitted changes
+
   sync [--direction from-base|to-base|both|scan] [--spec-id <id>]
       Synchronize state between worktree and base DAG.
       --direction      Sync direction (auto-detected if omitted)

--- a/scripts/lib/coordinator-worktree-ops.js
+++ b/scripts/lib/coordinator-worktree-ops.js
@@ -265,6 +265,25 @@ module.exports = {
   cleanupWorktrees(options = {}) {
     const { epicIds } = options;
 
+    // Find base worktree
+    const basePath = this._findBaseWorktree();
+    if (!basePath) {
+      throw new Error('Base worktree not found via git worktree list');
+    }
+
+    // If not in base, delegate to the base coordinator (same delegation as
+    // mergeEpics). A worktree's local dag copy carries `worktree: null` for
+    // every epic, so running cleanup from a worktree cwd would otherwise be
+    // a silent no-op.
+    if (basePath !== this.projectRoot) {
+      const baseCoord = new this.constructor(basePath, this.specId);
+      return baseCoord._cleanupWorktreesInBase(epicIds);
+    }
+
+    return this._cleanupWorktreesInBase(epicIds);
+  },
+
+  _cleanupWorktreesInBase(epicIds) {
     let epics;
     if (epicIds) {
       epics = this.dag.epics.filter((e) => epicIds.includes(e.id));

--- a/scripts/lib/worktree-generic.js
+++ b/scripts/lib/worktree-generic.js
@@ -1,0 +1,283 @@
+/**
+ * worktree-generic.js — generic (non-epic) worktree engine.
+ *
+ * Backs the `arcforge worktree add|list|remove` CLI subcommands. Generic
+ * worktrees reuse the canonical derivation from worktree-paths.js with a
+ * null specId (the documented legacy-null hash branch), so they live at
+ * ~/.arcforge/worktrees/<project>-<hash6>-<slug>/ beside epic worktrees
+ * with no hash collision (epic hashes fold the spec id in).
+ *
+ * Discrimination needs NO new marker file:
+ *   kind = parseWorktreePath × hasArcforgeMarker
+ *     managed ∧ marker  → epic     (coordinator lifecycle: expand/cleanup)
+ *     managed ∧ ¬marker → generic  (this module)
+ *     ¬managed          → base (first such entry) or external
+ *
+ * Error strategy: lib tier — throw with context. The CLI catch prints the
+ * message and exits 1.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { getDefaultInstallCommand } = require('./package-manager');
+const { hasArcforgeMarker, readArcforgeMarker } = require('./marker');
+const { sanitizeProjectName } = require('./utils');
+const { getWorktreeRoot, getWorktreePath, parseWorktreePath } = require('./worktree-paths');
+
+function runGit(args, cwd) {
+  try {
+    const stdout = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || err.message,
+      exitCode: err.status || 1,
+    };
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+}
+
+function branchExists(projectRoot, branch) {
+  return (
+    runGit(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], projectRoot).exitCode === 0
+  );
+}
+
+/**
+ * Create a generic worktree at the canonical location.
+ *
+ * Branch defaults to `name`; an existing branch is checked out as-is, a
+ * missing one is created from `from` (default: HEAD of the base checkout).
+ *
+ * @param {Object} options
+ * @param {string} options.projectRoot - Repository root the worktree belongs to.
+ * @param {string} options.name - Worktree name; slugified for the directory name.
+ * @param {string} [options.branch] - Branch to check out (default: name).
+ * @param {string} [options.from] - Base ref when creating a new branch (default: HEAD).
+ * @param {boolean} [options.setup=false] - Auto-detect and run the project installer.
+ * @returns {{name: string, slug: string, branch: string, branch_created: boolean, path: string}}
+ */
+function addGenericWorktree({ projectRoot, name, branch, from, setup = false }) {
+  requireNonEmptyString(projectRoot, 'projectRoot');
+  requireNonEmptyString(name, 'name');
+  const root = path.resolve(projectRoot);
+
+  const slug = sanitizeProjectName(name);
+  const worktreePath = getWorktreePath(root, null, slug);
+  if (fs.existsSync(worktreePath)) {
+    throw new Error(`Worktree already exists at ${worktreePath}`);
+  }
+
+  const branchName = branch || name;
+  const exists = branchExists(root, branchName);
+  if (exists && from) {
+    throw new Error(
+      `Branch '${branchName}' already exists — --from only applies when creating a new branch. ` +
+        'Drop --from to check out the existing branch.',
+    );
+  }
+
+  fs.mkdirSync(getWorktreeRoot(), { recursive: true });
+  const gitArgs = exists
+    ? ['worktree', 'add', worktreePath, branchName]
+    : ['worktree', 'add', worktreePath, '-b', branchName, from || 'HEAD'];
+  const result = runGit(gitArgs, root);
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to create worktree '${slug}': ${result.stderr.trim()}`);
+  }
+
+  const out = { name, slug, branch: branchName, branch_created: !exists, path: worktreePath };
+  if (setup) out.setup_command = runProjectSetup(worktreePath, slug);
+  return out;
+}
+
+/**
+ * Auto-detect and run the project installer inside a fresh worktree.
+ * Returns the command string that ran, or null when no installer applies.
+ */
+function runProjectSetup(worktreePath, slug) {
+  const installCmd = getDefaultInstallCommand(worktreePath);
+  if (!installCmd) return null;
+  try {
+    const [cmd, ...cmdArgs] = installCmd;
+    // stdio: 'inherit' streams installer output live and avoids the 1 MB
+    // maxBuffer that `npm install` can exceed (same rationale as the
+    // coordinator's _runSubprocess).
+    execFileSync(cmd, cmdArgs, { cwd: worktreePath, stdio: 'inherit' });
+  } catch (err) {
+    throw new Error(
+      `Project setup failed for '${slug}' (exit ${err.status || 1}). Command: ${installCmd.join(' ')}`,
+    );
+  }
+  return installCmd.join(' ');
+}
+
+/**
+ * List every worktree git knows about, annotated by kind.
+ *
+ * Kinds: `base` (first non-managed entry — the main checkout), `epic`
+ * (managed path carrying an .arcforge-epic marker; `epic`/`spec_id` are
+ * attached), `generic` (managed, no marker), `external` (any other
+ * non-managed entry, e.g. a user-placed raw-git worktree).
+ *
+ * @param {Object} options
+ * @param {string} options.projectRoot - Any checkout of the repository.
+ * @returns {{count: number, worktrees: Array<Object>}}
+ */
+function listWorktrees({ projectRoot }) {
+  requireNonEmptyString(projectRoot, 'projectRoot');
+  const root = path.resolve(projectRoot);
+
+  const result = runGit(['worktree', 'list', '--porcelain'], root);
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to list worktrees: ${result.stderr.trim()}`);
+  }
+
+  const entries = [];
+  let current = null;
+  for (const line of result.stdout.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      current = { path: line.slice(9) };
+      entries.push(current);
+    } else if (current && line.startsWith('HEAD ')) {
+      current.head = line.slice(5);
+    } else if (current && line.startsWith('branch ')) {
+      current.branch = line.slice(7).replace(/^refs\/heads\//, '');
+    }
+  }
+
+  let baseAssigned = false;
+  const worktrees = entries.map((entry) => {
+    const managed = parseWorktreePath(entry.path) !== null;
+    const marked = hasArcforgeMarker(entry.path);
+    let kind;
+    if (managed) {
+      kind = marked ? 'epic' : 'generic';
+    } else if (!baseAssigned) {
+      kind = 'base';
+      baseAssigned = true;
+    } else {
+      kind = 'external';
+    }
+    const item = { path: entry.path, branch: entry.branch || null, head: entry.head || null, kind };
+    if (marked) {
+      const marker = readArcforgeMarker(entry.path);
+      item.epic = marker?.epic ?? null;
+      item.spec_id = marker?.spec_id ?? null;
+    }
+    return item;
+  });
+
+  return { count: worktrees.length, worktrees };
+}
+
+/**
+ * Remove a generic worktree and prune git's registry.
+ *
+ * Refuses epic (marker-bearing) worktrees — those belong to the
+ * coordinator's `arcforge cleanup` — and refuses non-managed paths
+ * outright (external worktrees are managed with raw git). A dirty tree
+ * is refused unless `force` is set.
+ *
+ * @param {Object} options
+ * @param {string} options.projectRoot - Repository root the worktree belongs to.
+ * @param {string} options.target - Worktree name, or an absolute managed path.
+ * @param {boolean} [options.force=false] - Remove even with uncommitted changes.
+ * @returns {{removed: boolean, path: string}}
+ */
+function removeGenericWorktree({ projectRoot, target, force = false }) {
+  requireNonEmptyString(projectRoot, 'projectRoot');
+  requireNonEmptyString(target, 'target');
+  const root = path.resolve(projectRoot);
+
+  const resolved = path.isAbsolute(target)
+    ? path.resolve(target)
+    : getWorktreePath(root, null, sanitizeProjectName(target));
+  if (parseWorktreePath(resolved) === null) {
+    throw new Error(
+      `Not an arcforge-managed worktree: ${resolved}. External worktrees are removed with raw git (git worktree remove).`,
+    );
+  }
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Worktree not found: ${resolved}`);
+  }
+  if (hasArcforgeMarker(resolved)) {
+    throw new Error(
+      `Refusing to remove epic worktree ${resolved} — it is tracked by the coordinator DAG. Use \`arcforge cleanup\` instead.`,
+    );
+  }
+
+  const status = runGit(['status', '--porcelain'], resolved);
+  if (status.exitCode !== 0) {
+    throw new Error(`Failed to check worktree status: ${status.stderr.trim()}`);
+  }
+  if (status.stdout.trim() && !force) {
+    throw new Error(
+      `Worktree has uncommitted changes: ${resolved}. Pass --force to remove anyway.`,
+    );
+  }
+
+  // Filesystem remove + one prune, same approach as the coordinator's
+  // cleanupWorktrees: `git worktree remove` is fragile around untracked
+  // files, while rm + prune has the same net effect on git state.
+  fs.rmSync(resolved, { recursive: true, force: true });
+  const prune = runGit(['worktree', 'prune'], root);
+  if (prune.exitCode !== 0) {
+    throw new Error(`git worktree prune failed: ${prune.stderr.trim()}`);
+  }
+
+  return { removed: true, path: resolved };
+}
+
+/**
+ * Single dispatch entry for the `worktree` CLI command. Returns the result
+ * object for the caller to print; throws on usage errors and failures.
+ *
+ * @param {Object} args - Parsed CLI args ({ positional, flags, options }).
+ * @param {string} projectRoot
+ * @returns {Object}
+ */
+function runWorktreeCommand(args, projectRoot) {
+  const sub = args.positional[0];
+  if (sub === 'add') {
+    const name = args.positional[1];
+    if (!name)
+      throw new Error('Usage: worktree add <name> [--branch <b>] [--from <ref>] [--setup]');
+    return addGenericWorktree({
+      projectRoot,
+      name,
+      branch: args.options.branch,
+      from: args.options.from,
+      setup: Boolean(args.flags.setup),
+    });
+  }
+  if (sub === 'list') {
+    return listWorktrees({ projectRoot });
+  }
+  if (sub === 'remove') {
+    const target = args.positional[1];
+    if (!target) throw new Error('Usage: worktree remove <name> [--force]');
+    return removeGenericWorktree({ projectRoot, target, force: Boolean(args.flags.force) });
+  }
+  throw new Error(
+    'Usage: worktree add <name> [--branch <b>] [--from <ref>] [--setup] | worktree list [--json] | worktree remove <name> [--force]',
+  );
+}
+
+module.exports = {
+  addGenericWorktree,
+  listWorktrees,
+  removeGenericWorktree,
+  runWorktreeCommand,
+};

--- a/tests/scripts/coordinator-cleanup-delegation.test.js
+++ b/tests/scripts/coordinator-cleanup-delegation.test.js
@@ -1,0 +1,70 @@
+/**
+ * Coordinator.cleanupWorktrees — base delegation from a worktree cwd (WT-2,
+ * S2-3 engine hardening).
+ *
+ * A worktree's local dag copy carries `worktree: null` for every epic, so
+ * cleanup run from a worktree-cwd coordinator used to be a silent no-op.
+ * It now delegates to the base coordinator (same pattern as mergeEpics):
+ * the worktree is actually removed and the base dag updated.
+ */
+
+const fs = require('node:fs');
+
+const { Coordinator } = require('../../scripts/lib/coordinator');
+const { getWorktreePath } = require('../../scripts/lib/worktree-paths');
+const {
+  runGit,
+  setupRepo,
+  readDagFromDisk,
+  cleanupWorktrees,
+  DEFAULT_SPEC_ID,
+} = require('./coordinator-test-helpers');
+
+describe('Coordinator.cleanupWorktrees — worktree-cwd base delegation', () => {
+  let root;
+
+  beforeEach(() => {
+    // realpath keeps the repo root in the same symlink-free space as the
+    // paths git prints in `worktree list`, so the delegation comparison
+    // and base-side hash derivation stay consistent on macOS.
+    root = fs.realpathSync(setupRepo({ prefix: 'arcforge-cleanup-deleg-' }));
+    // Commit the dag so the epic worktree checkout carries its own local
+    // copy (with `worktree: null` for every epic).
+    runGit(['add', '.'], root);
+    runGit(['commit', '-q', '-m', 'chore: add dag'], root);
+  });
+
+  afterEach(() => {
+    cleanupWorktrees(root);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('cleanup from a worktree-cwd coordinator removes the worktree and updates the base dag', () => {
+    new Coordinator(root, DEFAULT_SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+    const worktreePath = getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a');
+    expect(fs.existsSync(worktreePath)).toBe(true);
+
+    const removed = new Coordinator(worktreePath, DEFAULT_SPEC_ID).cleanupWorktrees({
+      epicIds: ['epic-a'],
+    });
+
+    expect(removed).toEqual([worktreePath]);
+    expect(fs.existsSync(worktreePath)).toBe(false);
+    const dag = readDagFromDisk(root);
+    expect(dag.epics.find((e) => e.id === 'epic-a').worktree).toBeNull();
+  });
+
+  test('cleanup from the base coordinator behaves as before (no delegation detour)', () => {
+    new Coordinator(root, DEFAULT_SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+    const worktreePath = getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a');
+
+    const removed = new Coordinator(root, DEFAULT_SPEC_ID).cleanupWorktrees({
+      epicIds: ['epic-a'],
+    });
+
+    expect(removed).toEqual([worktreePath]);
+    expect(fs.existsSync(worktreePath)).toBe(false);
+    const dag = readDagFromDisk(root);
+    expect(dag.epics.find((e) => e.id === 'epic-a').worktree).toBeNull();
+  });
+});

--- a/tests/scripts/worktree-generic.test.js
+++ b/tests/scripts/worktree-generic.test.js
@@ -1,0 +1,187 @@
+/**
+ * worktree-generic.js — generic (non-epic) worktree engine (WT-2).
+ *
+ * Isolation: HOME is overridden to a temp dir per test (auto-diary.test.js
+ * pattern) so canonical worktree paths derive under the test HOME, never
+ * the real ~/.arcforge/worktrees. Two overrides are needed: process.env.HOME
+ * covers CLI subprocesses, while an os.homedir() spy covers in-process
+ * derivations (Jest sandboxes process.env, so mutating it does not reach
+ * the real environment that os.homedir() reads). Repo and HOME dirs are
+ * realpath'd so getWorktreePath derivation and git's printed paths live in
+ * the same (symlink-free) space on macOS.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const {
+  addGenericWorktree,
+  listWorktrees,
+  removeGenericWorktree,
+} = require('../../scripts/lib/worktree-generic');
+const { Coordinator } = require('../../scripts/lib/coordinator');
+const {
+  getWorktreeRoot,
+  getWorktreePath,
+  parseWorktreePath,
+} = require('../../scripts/lib/worktree-paths');
+const { runGit, setupRepo, DEFAULT_SPEC_ID } = require('./coordinator-test-helpers');
+
+const CLI = path.resolve(__dirname, '../../scripts/cli.js');
+
+function runCli(args, cwd) {
+  try {
+    const stdout = execFileSync('node', [CLI, ...args], {
+      cwd,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    return { stdout: err.stdout || '', stderr: err.stderr || err.message, exitCode: err.status };
+  }
+}
+
+describe('worktree-generic', () => {
+  const originalHome = process.env.HOME;
+  let testHome;
+  let root;
+
+  beforeEach(() => {
+    const realTmp = fs.realpathSync(os.tmpdir());
+    testHome = fs.mkdtempSync(path.join(realTmp, 'wtg-home-'));
+    process.env.HOME = testHome;
+    jest.spyOn(os, 'homedir').mockReturnValue(testHome);
+    root = fs.realpathSync(setupRepo({ prefix: 'wtg-repo-' }));
+    runGit(['add', '.'], root);
+    runGit(['commit', '-q', '-m', 'chore: add dag'], root);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env.HOME = originalHome;
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(testHome, { recursive: true, force: true });
+  });
+
+  describe('add', () => {
+    test('CLI round-trip: exit 0, JSON path under getWorktreeRoot(), parseable, branch checked out', () => {
+      const result = runCli(['worktree', 'add', 't1', '--json'], root);
+      expect(result.exitCode).toBe(0);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.path.startsWith(getWorktreeRoot() + path.sep)).toBe(true);
+      expect(parsed.path).toBe(getWorktreePath(root, null, 't1'));
+
+      const roundTrip = parseWorktreePath(parsed.path);
+      expect(roundTrip).not.toBeNull();
+      expect(roundTrip.epic).toBe('t1');
+
+      expect(parsed.branch).toBe('t1');
+      expect(parsed.branch_created).toBe(true);
+      expect(runGit(['branch', '--show-current'], parsed.path).trim()).toBe('t1');
+    });
+
+    test('existing branch is checked out, not recreated', () => {
+      runGit(['branch', 't2'], root);
+      const res = addGenericWorktree({ projectRoot: root, name: 't2' });
+      expect(res.branch_created).toBe(false);
+      expect(runGit(['branch', '--show-current'], res.path).trim()).toBe('t2');
+    });
+
+    test('missing branch is created from --from ref', () => {
+      runGit(['checkout', '-q', '-b', 'feature-base'], root);
+      fs.writeFileSync(path.join(root, 'extra.txt'), 'extra\n');
+      runGit(['add', 'extra.txt'], root);
+      runGit(['commit', '-q', '-m', 'feat: extra'], root);
+      runGit(['checkout', '-q', 'main'], root);
+
+      const res = addGenericWorktree({ projectRoot: root, name: 't3', from: 'feature-base' });
+      expect(res.branch_created).toBe(true);
+      expect(fs.existsSync(path.join(res.path, 'extra.txt'))).toBe(true);
+    });
+  });
+
+  describe('list', () => {
+    test('annotates all four kinds: base, epic, generic, external', () => {
+      new Coordinator(root, DEFAULT_SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+      addGenericWorktree({ projectRoot: root, name: 'experiment' });
+      const extPath = path.join(testHome, 'external-wt');
+      runGit(['worktree', 'add', '-b', 'ext-branch', extPath], root);
+
+      const result = listWorktrees({ projectRoot: root });
+      expect(result.count).toBe(4);
+
+      const byKind = {};
+      for (const wt of result.worktrees) byKind[wt.kind] = wt;
+      expect(Object.keys(byKind).sort()).toEqual(['base', 'epic', 'external', 'generic']);
+
+      expect(byKind.base.path).toBe(root);
+
+      expect(byKind.epic.path).toBe(getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a'));
+      expect(byKind.epic.epic).toBe('epic-a');
+      expect(byKind.epic.spec_id).toBe(DEFAULT_SPEC_ID);
+
+      expect(byKind.generic.path).toBe(getWorktreePath(root, null, 'experiment'));
+      expect(byKind.generic.branch).toBe('experiment');
+      expect(byKind.generic.epic).toBeUndefined();
+
+      expect(byKind.external.path).toBe(extPath);
+    });
+  });
+
+  describe('remove', () => {
+    test('epic-marker worktree: CLI exits 1 with an arcforge cleanup redirect, tree untouched', () => {
+      new Coordinator(root, DEFAULT_SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+      const epicPath = getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a');
+
+      const result = runCli(['worktree', 'remove', epicPath], root);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('arcforge cleanup');
+      expect(fs.existsSync(epicPath)).toBe(true);
+    });
+
+    test('dirty worktree without --force: CLI exits 1, tree untouched', () => {
+      const res = addGenericWorktree({ projectRoot: root, name: 't4' });
+      fs.writeFileSync(path.join(res.path, 'dirty.txt'), 'uncommitted\n');
+
+      const result = runCli(['worktree', 'remove', 't4'], root);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--force');
+      expect(fs.existsSync(res.path)).toBe(true);
+    });
+
+    test('dirty worktree with --force: removed and pruned from git', () => {
+      const res = addGenericWorktree({ projectRoot: root, name: 't5' });
+      fs.writeFileSync(path.join(res.path, 'dirty.txt'), 'uncommitted\n');
+
+      const out = removeGenericWorktree({ projectRoot: root, target: 't5', force: true });
+      expect(out.removed).toBe(true);
+      expect(fs.existsSync(res.path)).toBe(false);
+      expect(runGit(['worktree', 'list', '--porcelain'], root)).not.toContain(res.path);
+    });
+
+    test('clean worktree removes without --force, prunes, and keeps the branch', () => {
+      const res = addGenericWorktree({ projectRoot: root, name: 't6' });
+
+      const out = removeGenericWorktree({ projectRoot: root, target: 't6' });
+      expect(out.path).toBe(res.path);
+      expect(fs.existsSync(res.path)).toBe(false);
+      expect(runGit(['worktree', 'list', '--porcelain'], root)).not.toContain(res.path);
+      expect(runGit(['branch', '--list', 't6'], root).trim()).not.toBe('');
+    });
+
+    test('refuses non-managed (external) paths', () => {
+      const extPath = path.join(testHome, 'external-wt');
+      runGit(['worktree', 'add', '-b', 'ext-branch', extPath], root);
+
+      expect(() => removeGenericWorktree({ projectRoot: root, target: extPath })).toThrow(
+        /Not an arcforge-managed worktree/,
+      );
+      expect(fs.existsSync(extPath)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Wave 1 (PR-1b). The generic tier of the two-tier worktree design (RFC: docs/plans/2026-06-11-generic-worktree-skill-rfc.md) — worktree isolation in ANY git repo, zero arcforge state required. SKILL.md rewrite follows in WT-3 (Wave 2).

## What
- New `scripts/lib/worktree-generic.js` (283 lines, zero-dep): addGenericWorktree / listWorktrees / removeGenericWorktree / runWorktreeCommand; execFileSync arrays; path via `getWorktreePath(projectRoot, null, slug)` (legacy-null hash branch — no collision with epic worktrees, invisible to coordinator sync); kind discrimination = parseWorktreePath × hasArcforgeMarker (base|epic|generic|external), NO new marker file
- Thin cli.js case (10 lines) + help entries; `remove` refuses epic-marker worktrees (→ `arcforge cleanup`) and dirty trees without --force
- S2-3 engine hardening: cleanupWorktrees now delegates to base from a worktree cwd (mergeEpics pattern) + Jest coverage

## Acceptance (adversarially reviewed & replayed: approve)
- Live smoke: add → JSON path round-trips parseWorktreePath, branch checked out; four-kind fixture annotated correctly; epic remove exit 1 with cleanup redirect; dirty/--force/prune semantics pinned by Jest CLI-subprocess tests
- npm test: Jest 75 suites / 2049 tests, hooks 273, node runners, pytest 541, observer-daemon 16 — all green