### PR TITLE
fix(hooks): sdd-ledger-guard on-disk baseline for uncommitted ledgers (SDD-3)

### DIFF
--- a/hooks/__tests__/sdd-ledger-guard.test.js
+++ b/hooks/__tests__/sdd-ledger-guard.test.js
@@ -398,3 +398,239 @@ describe('sdd-ledger-guard decideLedgerEdit — Task 3a forge guard', () => {
     assert.strictEqual(reason, null, 'Malformed YAML must fail-open');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests: SDD-3 — on-disk baseline fallback (closes the S8 hole for
+// untracked/uncommitted decisions.yml). When the file has no HEAD version,
+// evaluate() validates against the pre-edit on-disk content instead of
+// skipping all checks. HEAD stays authoritative when available.
+// ---------------------------------------------------------------------------
+
+describe('sdd-ledger-guard evaluate — SDD-3 on-disk baseline fallback', () => {
+  let dirs;
+
+  beforeEach(() => {
+    dirs = [];
+    delete require.cache[require.resolve('../sdd-ledger-guard/main')];
+  });
+
+  afterEach(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  /** Git repo with one seed commit — decisions.yml stays UNTRACKED unless committed. */
+  function makeGitRepo() {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'slg-sdd3-'));
+    dirs.push(cwd);
+    execFileSync('git', ['init'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd, stdio: 'pipe' });
+    fs.writeFileSync(path.join(cwd, 'README.md'), 'seed\n');
+    execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', 'seed'], { cwd, stdio: 'pipe' });
+    return cwd;
+  }
+
+  // (1) Untracked flip proposed→accepted → DENY (forge against on-disk baseline)
+  it('SDD-3: untracked file, Edit flipping proposed→accepted is denied', () => {
+    const { evaluate } = require('../sdd-ledger-guard/main');
+    const cwd = makeGitRepo();
+    const ledgerPath = path.join(cwd, 'decisions.yml');
+    fs.writeFileSync(ledgerPath, makeLedgerYaml({ status: 'proposed' }));
+
+    const reason = evaluate({
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: ledgerPath,
+        old_string: 'status: "proposed"',
+        new_string: 'status: "accepted"',
+      },
+      cwd,
+    });
+    assert.ok(reason !== null, 'Untracked proposed→accepted flip must be denied');
+    assert.ok(typeof reason === 'string' && reason.length > 0);
+  });
+
+  // (2) Untracked frozen-text mutation → DENY (the S8 hole this task closes)
+  it('SDD-3: untracked file, Edit mutating frozen decision text is denied', () => {
+    const { evaluate } = require('../sdd-ledger-guard/main');
+    const cwd = makeGitRepo();
+    const ledgerPath = path.join(cwd, 'decisions.yml');
+    fs.writeFileSync(ledgerPath, makeLedgerYaml({ decision: 'Original decision text.' }));
+
+    const reason = evaluate({
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: ledgerPath,
+        old_string: '"Original decision text."',
+        new_string: '"REWRITTEN decision text."',
+      },
+      cwd,
+    });
+    assert.ok(reason !== null, 'Untracked frozen-text mutation must be denied (S8 hole)');
+    assert.ok(/[Ii]mmutability/.test(reason), 'Deny reason should cite immutability');
+  });
+
+  // (3) Untracked legal append of a new proposed entry → ALLOW
+  it('SDD-3: untracked file, Write appending a new proposed entry is allowed', () => {
+    const { evaluate } = require('../sdd-ledger-guard/main');
+    const cwd = makeGitRepo();
+    const ledgerPath = path.join(cwd, 'decisions.yml');
+    fs.writeFileSync(ledgerPath, makeLedgerYaml({ status: 'proposed' }));
+
+    const appended = yamlSerialize([
+      {
+        'D-id': 'D-001',
+        date: '2026-06-07',
+        spec_version: 1,
+        status: 'proposed',
+        decision: 'Use YAML for decision ledger format.',
+        why: 'Human-readable, git-diffable, toolable.',
+        authorized_values: 'any',
+      },
+      {
+        'D-id': 'D-002',
+        date: '2026-06-07',
+        spec_version: 1,
+        status: 'proposed',
+        decision: 'Second proposed decision.',
+        why: 'Reason.',
+        authorized_values: 'any',
+      },
+    ]);
+    const reason = evaluate({
+      tool_name: 'Write',
+      tool_input: { file_path: ledgerPath, content: appended },
+      cwd,
+    });
+    assert.strictEqual(reason, null, 'Untracked legal append must be allowed');
+  });
+
+  // (4) Brand-new file (nothing on disk), proposed-only Write → ALLOW (previous=null preserved)
+  it('SDD-3: brand-new file, proposed-only Write is allowed', () => {
+    const { evaluate } = require('../sdd-ledger-guard/main');
+    const cwd = makeGitRepo();
+    const ledgerPath = path.join(cwd, 'decisions.yml'); // does not exist on disk
+
+    const reason = evaluate({
+      tool_name: 'Write',
+      tool_input: { file_path: ledgerPath, content: makeLedgerYaml({ status: 'proposed' }) },
+      cwd,
+    });
+    assert.strictEqual(reason, null, 'Proposed-only Write to a brand-new file must be allowed');
+  });
+
+  // (5) HEAD-tracked file → HEAD baseline wins over on-disk content
+  it('SDD-3: HEAD-tracked file uses HEAD as baseline, not on-disk content', () => {
+    const { evaluate } = require('../sdd-ledger-guard/main');
+    const cwd = makeGitRepo();
+    const ledgerPath = path.join(cwd, 'decisions.yml');
+
+    // Commit the original ledger at HEAD.
+    fs.writeFileSync(ledgerPath, makeLedgerYaml({ decision: 'Original frozen decision.' }));
+    execFileSync('git', ['add', 'decisions.yml'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', 'ledger'], { cwd, stdio: 'pipe' });
+
+    // Tamper the working tree copy (simulates a bash-level edit the hook never saw).
+    fs.writeFileSync(ledgerPath, makeLedgerYaml({ decision: 'TAMPERED frozen decision.' }));
+
+    // Write keeps the tampered text and appends a new proposed entry.
+    // Against the on-disk baseline this would be a legal append (ALLOW);
+    // against HEAD it is a frozen-text mutation (DENY). DENY proves HEAD wins.
+    const written = yamlSerialize([
+      {
+        'D-id': 'D-001',
+        date: '2026-06-07',
+        spec_version: 1,
+        status: 'proposed',
+        decision: 'TAMPERED frozen decision.',
+        why: 'Human-readable, git-diffable, toolable.',
+        authorized_values: 'any',
+      },
+      {
+        'D-id': 'D-002',
+        date: '2026-06-07',
+        spec_version: 1,
+        status: 'proposed',
+        decision: 'Second proposed decision.',
+        why: 'Reason.',
+        authorized_values: 'any',
+      },
+    ]);
+    const reason = evaluate({
+      tool_name: 'Write',
+      tool_input: { file_path: ledgerPath, content: written },
+      cwd,
+    });
+    assert.ok(reason !== null, 'HEAD-tracked file must be validated against HEAD, not on-disk');
+  });
+
+  // (6) fs error reading the on-disk baseline → ALLOW (fail-open, no crash)
+  it('SDD-3: unreadable on-disk baseline fails open (ALLOW, no crash)', () => {
+    const { evaluate } = require('../sdd-ledger-guard/main');
+    const cwd = makeGitRepo();
+    // A DIRECTORY named decisions.yml: untracked (HEAD null) and unreadable as a file.
+    fs.mkdirSync(path.join(cwd, 'decisions.yml'));
+
+    const reason = evaluate({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: path.join(cwd, 'decisions.yml'),
+        content: makeLedgerYaml({ status: 'proposed' }),
+      },
+      cwd,
+    });
+    assert.strictEqual(reason, null, 'fs error reading on-disk baseline must fail open');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire-format test: SDD-3 stdin fixture — untracked frozen-text mutation
+// produces a deny JSON through main() (the full stdin → stdout path).
+// ---------------------------------------------------------------------------
+
+describe('sdd-ledger-guard main() wire format — SDD-3 untracked baseline', () => {
+  const hookPath = require.resolve('../sdd-ledger-guard/main');
+  let dirs;
+
+  beforeEach(() => {
+    dirs = [];
+  });
+
+  afterEach(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('emits permissionDecision:deny for a frozen-field Write on an UNTRACKED ledger', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'slg-wire-sdd3-'));
+    dirs.push(cwd);
+
+    execFileSync('git', ['init'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd, stdio: 'pipe' });
+    fs.writeFileSync(path.join(cwd, 'README.md'), 'seed\n');
+    execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', 'seed'], { cwd, stdio: 'pipe' });
+
+    // Untracked decisions.yml on disk — never committed.
+    const decisionsPath = path.join(cwd, 'decisions.yml');
+    fs.writeFileSync(decisionsPath, makeLedgerYaml({ decision: 'Original frozen decision.' }));
+
+    const out = execFileSync('node', [hookPath], {
+      input: JSON.stringify({
+        tool_name: 'Write',
+        tool_input: {
+          file_path: decisionsPath,
+          content: makeLedgerYaml({ decision: 'MUTATED frozen decision.' }),
+        },
+        cwd,
+      }),
+      encoding: 'utf8',
+    }).trim();
+
+    const parsed = JSON.parse(out);
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PreToolUse');
+    assert.strictEqual(parsed.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(parsed.hookSpecificOutput.permissionDecisionReason.length > 0);
+  });
+});

--- a/hooks/sdd-ledger-guard/README.md
+++ b/hooks/sdd-ledger-guard/README.md
@@ -7,7 +7,7 @@ PreToolUse hook that enforces append-only immutability on `specs/<id>/decisions.
 Intercepts `Edit` and `Write` tool calls whose target file basename is `decisions.yml`. For each intercepted call, it:
 
 1. Computes the resulting on-disk content (Write = new content; Edit = apply old_string → new_string in memory).
-2. Fetches the current `HEAD` snapshot of the file via `getHeadLedgerContent`.
+2. Fetches the baseline: the `HEAD` snapshot via `getHeadLedgerContent` when the file is tracked; when there is no HEAD version (untracked/uncommitted ledger, non-git-repo), falls back to the pre-edit on-disk content.
 3. Parses both via `parseDecisionLedgerContent`.
 4. Runs `validateDecisionLedger(current, previous)` to enforce:
    - D-id monotonicity and uniqueness.
@@ -19,7 +19,7 @@ DENY on any violation. ALLOW on all other paths.
 ## No-Op Invariant (tested)
 
 - Target file basename is not `decisions.yml` → immediate ALLOW.
-- `decisions.yml` is absent from HEAD (new file, first append) → `previous = null` → immutability/status checks skip → ALLOW.
+- `decisions.yml` is absent from HEAD **and** absent (or unreadable) on disk — a brand-new file, first write → `previous = null` → immutability/status checks skip → ALLOW.
 - Any internal error → fail-open → ALLOW.
 
 ## Coverage Boundary
@@ -27,8 +27,9 @@ DENY on any violation. ALLOW on all other paths.
 **This hook does NOT intercept all writes to decisions.yml.** Specifically:
 
 - **Bash-level writes** (`echo >> decisions.yml`, `sed -i`, `tee`, `cat >`) bypass PreToolUse hooks entirely and are not covered.
-- **Same-session pre-commit edits**: immutability is HEAD-relative. If brainstorming appends a new entry and then edits it before the next commit, the hook sees null `previous` for the new entry and allows it (S8 limitation in `validateDecisionLedger`'s design — by construction, not a bug).
-- **Non-git-repo or detached-HEAD cwd**: `getHeadLedgerContent` returns null → previous = null → checks skip → ALLOW (fail-open, safe).
+- **Baseline priority**: HEAD wins when the file is tracked. When there is no HEAD version (untracked/uncommitted ledger — every new spec before its first commit — or non-git-repo / detached-HEAD cwd), the baseline is the pre-edit on-disk content, so append-only is enforced edit-over-edit (closes the former S8 hole for uncommitted ledgers).
+- **Residual same-session gap (HEAD-tracked files)**: because HEAD stays authoritative for tracked files, appending a new entry and then editing it before the next commit still escapes — HEAD has no `previous` for the new entry (S8 limitation in `validateDecisionLedger`'s design — by construction, not a bug).
+- **Brand-new file** (no HEAD version, nothing readable on disk): previous = null → checks skip → ALLOW (fail-open, safe).
 
 These gaps are acceptable — the hook hardens the common case (Edit/Write tool in a normal session) and is explicitly fail-open for uncertain states.
 

--- a/hooks/sdd-ledger-guard/main.js
+++ b/hooks/sdd-ledger-guard/main.js
@@ -4,7 +4,8 @@
  *
  * Intercepts Edit and Write tool calls whose target file basename is
  * `decisions.yml`, computes the resulting content, and validates it against
- * the ledger stored in HEAD via validateDecisionLedger. DENY on any
+ * a baseline ledger via validateDecisionLedger — HEAD when the file is
+ * tracked, otherwise the pre-edit on-disk content. DENY on any
  * immutability / monotonicity violation. All other paths are no-ops.
  *
  * BLOCK MECHANISM: same as arc-guard — stdout JSON
@@ -18,16 +19,20 @@
  * COVERAGE BOUNDARY (documented, not code-enforced):
  *   - Only intercepts Edit and Write tool calls. Bash-level writes
  *     (echo >>, sed -i, tee) bypass this hook entirely.
- *   - Immutability is HEAD-relative. A same-session pre-commit
- *     append-then-edit within a single session escapes the check
- *     (S8 limitation from validateDecisionLedger's doc comment).
- *   - Non-git-repo or detached-HEAD cwd → getHeadLedgerContent returns null
- *     → previous=null → immutability checks skip → ALLOW (fail-open).
+ *   - Baseline priority: HEAD when the file is tracked (binding remedy);
+ *     otherwise (untracked/uncommitted ledger, non-git-repo, detached HEAD)
+ *     the pre-edit on-disk content read in evaluate() — so every new spec's
+ *     uncommitted decisions.yml keeps append-only protection (former S8 hole).
+ *   - Residual S8 gap: for HEAD-tracked files HEAD stays authoritative, so a
+ *     same-session pre-commit append-then-edit of a not-yet-committed entry
+ *     still escapes (validateDecisionLedger's documented limitation).
+ *   - Brand-new file (no HEAD version, nothing readable on disk) →
+ *     previous=null → immutability checks skip → ALLOW (fail-open).
  */
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { readStdinSync, parseStdinJson, output } = require('../../scripts/lib/utils');
+const { readStdinSync, parseStdinJson, output, readFileSafe } = require('../../scripts/lib/utils');
 const {
   parseDecisionLedgerContent,
   validateDecisionLedger,
@@ -246,10 +251,17 @@ function evaluate(input) {
 
   if (resultingContent === null) return null; // uncertain → ALLOW
 
-  // Fetch HEAD state (null if new file / non-repo / git absent).
+  // Fetch HEAD state (null if file untracked / non-repo / git absent).
   const headContent = getHeadLedgerContent(absPath, cwd);
 
-  return decideLedgerEdit(resultingContent, headContent);
+  // SDD-3 (S8 hole): no HEAD version → fall back to the pre-edit on-disk
+  // content as the baseline, so uncommitted/untracked ledgers (every new spec
+  // before its first commit) keep append-only protection. HEAD wins when
+  // available (binding remedy). Brand-new or unreadable file → readFileSafe
+  // returns null → previous=null semantics preserved (fail-open).
+  const baselineContent = headContent !== null ? headContent : readFileSafe(absPath);
+
+  return decideLedgerEdit(resultingContent, baselineContent);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Wave 1 (PR-1d). Closes the documented S8 hole: every brand-new spec's decisions.yml sat unguarded until its first commit because immutability was HEAD-relative only.

## What
- When `getHeadLedgerContent` finds no HEAD version, fall back to validating against the current on-disk file (via `readFileSafe`); HEAD priority unchanged; previous=null semantics kept for truly new files; hook-tier fail-open preserved
- Tests in hooks/__tests__ (replayed by reviewer: 3 files changed — main.js, README, tests)