### PR TITLE
fix(cli): loop task prompts see real specs; spawn timeout + env hygiene (AF-4, AF-10)

### DIFF
--- a/scripts/cli/dag-commands.js
+++ b/scripts/cli/dag-commands.js
@@ -191,8 +191,26 @@ function runLoop(args, { projectRoot, specFlag }) {
     process.exit(1);
   }
 
+  const taskTimeout = args.options['task-timeout']
+    ? parseInt(args.options['task-timeout'], 10)
+    : null;
+  if (args.options['task-timeout'] && (Number.isNaN(taskTimeout) || taskTimeout < 1)) {
+    console.error('Error: --task-timeout must be a positive integer (seconds)');
+    process.exit(1);
+  }
+
   const epic = args.options.epic || null;
-  const loopOptions = { pattern, maxRuns, maxCost, epic, projectRoot, specId: resolved };
+  const loopOptions = {
+    pattern,
+    maxRuns,
+    maxCost,
+    epic,
+    projectRoot,
+    specId: resolved,
+    taskTimeoutMs: taskTimeout ? taskTimeout * 1000 : null,
+    permissionMode: args.options['permission-mode'] || null,
+    allowedTools: args.options['allowed-tools'] || null,
+  };
   if (pattern === 'dag') {
     runDag(loopOptions);
   } else {

--- a/scripts/cli/help.js
+++ b/scripts/cli/help.js
@@ -68,11 +68,15 @@ COMMANDS:
       --example    Show complete example
 
   loop [--pattern sequential|dag] [--max-runs N] [--max-cost N] [--epic <id>] [--spec-id <id>]
+       [--task-timeout N] [--permission-mode <mode>] [--allowed-tools <tools>]
       Run autonomous cross-session execution loop.
-      --pattern    Execution pattern: sequential (default) or dag
-      --epic       Scope loop to a single epic (auto-detected in worktrees)
-      --max-runs   Maximum iterations (default: 50)
-      --max-cost   Maximum cost in dollars (default: unlimited)
+      --pattern          Execution pattern: sequential (default) or dag
+      --epic             Scope loop to a single epic (auto-detected in worktrees)
+      --max-runs         Maximum iterations (default: 50)
+      --max-cost         Maximum cost in dollars (default: unlimited)
+      --task-timeout     Per-session timeout in seconds (default: 600)
+      --permission-mode  Pass --permission-mode through to spawned claude sessions
+      --allowed-tools    Pass --allowed-tools through to spawned claude sessions
 
   eval list                          List eval scenarios
   eval run <name> [--k N] [--model]  Run eval trials

--- a/scripts/lib/loop-session.js
+++ b/scripts/lib/loop-session.js
@@ -9,6 +9,71 @@
 const { execFile } = require('node:child_process');
 const { CLAUDE_MAX_BUFFER, execCommand } = require('./utils');
 
+/** Default per-session timeout. Override with the --task-timeout loop flag. */
+const DEFAULT_TASK_TIMEOUT_MS = 600000;
+
+/**
+ * Guidance appended to failures that look like a permission stall.
+ * Headless `claude -p` cannot answer interactive permission prompts, so a
+ * session blocked on one runs silently until the task timeout kills it.
+ */
+const PERMISSION_STALL_GUIDANCE =
+  '[loop] Headless sessions cannot answer interactive permission prompts — a session ' +
+  'blocked on one stalls until the task timeout kills it. Re-run with --permission-mode ' +
+  'and/or --allowed-tools (see "Headless Permissions" in the arc-looping skill).';
+
+/**
+ * Build the argv for a spawned `claude -p` session.
+ * Permission posture is strictly caller-controlled via pass-through flags:
+ * no code path may append --dangerously-skip-permissions automatically.
+ * @param {Object} [options] - Spawn options
+ * @param {string} [options.permissionMode] - Value for --permission-mode
+ * @param {string} [options.allowedTools] - Value for --allowed-tools
+ * @returns {string[]} Argument array for the claude CLI
+ */
+function buildClaudeArgs(options = {}) {
+  const args = ['-p', '--output-format', 'json', '--no-session-persistence'];
+  if (options.permissionMode) {
+    args.push('--permission-mode', options.permissionMode);
+  }
+  if (options.allowedTools) {
+    args.push('--allowed-tools', options.allowedTools);
+  }
+  return args;
+}
+
+/**
+ * Build the child environment for loop-spawned sessions.
+ * Spawn env hygiene: autonomous loop sessions always run unattended — an
+ * inherited ARCFORGE_MODE=attended (from a `.arcforge-attended` marker
+ * export or a shell export) must never leak into them, or unattended
+ * sessions would pass attended-only gates. ARCFORGE_SPAWNED marks the
+ * session as loop-spawned so SessionStart consumers (e.g. the
+ * pending-action relay) can skip it instead of consuming user-bound state.
+ * @returns {Object} Environment for the spawned claude process
+ */
+function buildSpawnEnv() {
+  return { ...process.env, ARCFORGE_MODE: '', ARCFORGE_SPAWNED: 'loop' };
+}
+
+/**
+ * Append headless-permissions guidance to failures that look like a
+ * permission stall: a timeout kill (the stall signature in headless runs)
+ * or stderr that mentions permissions. Mutates the result in place.
+ * @param {{ exitCode: number, stderr: string, error?: Error }} result
+ * @returns {Object} The same result, with guidance appended on a stall
+ */
+function appendStallGuidance(result) {
+  if (result.exitCode === 0) return result;
+  const err = result.error;
+  const timedOut = Boolean(err && (err.killed || err.signal || err.code === 'ETIMEDOUT'));
+  const stderr = result.stderr || '';
+  if (timedOut || /permission/i.test(stderr)) {
+    result.stderr = `${stderr}\n${PERMISSION_STALL_GUIDANCE}`.trim();
+  }
+  return result;
+}
+
 /**
  * Extract cost data from a Claude JSON response, replacing stdout with the text result.
  * Mutates the result object in place.
@@ -35,20 +100,21 @@ function extractCost(result) {
  * Uses JSON output to capture cost data for --max-cost budget tracking.
  * @param {string} prompt - Task prompt
  * @param {string} projectRoot - Project root directory
+ * @param {Object} [options] - Spawn options
+ * @param {number} [options.taskTimeoutMs] - Per-session timeout in ms
+ * @param {string} [options.permissionMode] - Value for --permission-mode
+ * @param {string} [options.allowedTools] - Value for --allowed-tools
  * @returns {{ exitCode: number, stdout: string, stderr: string, costUsd: number }}
  */
-function spawnSession(prompt, projectRoot) {
-  const result = execCommand(
-    'claude',
-    ['-p', '--output-format', 'json', '--no-session-persistence'],
-    {
-      input: prompt,
-      cwd: projectRoot,
-      timeout: 600000,
-      maxBuffer: CLAUDE_MAX_BUFFER,
-    },
-  );
-  return extractCost(result);
+function spawnSession(prompt, projectRoot, options = {}) {
+  const result = execCommand('claude', buildClaudeArgs(options), {
+    input: prompt,
+    cwd: projectRoot,
+    timeout: options.taskTimeoutMs || DEFAULT_TASK_TIMEOUT_MS,
+    maxBuffer: CLAUDE_MAX_BUFFER,
+    env: buildSpawnEnv(),
+  });
+  return extractCost(appendStallGuidance(result));
 }
 
 /**
@@ -56,17 +122,24 @@ function spawnSession(prompt, projectRoot) {
  * Returns a Promise with the same shape as spawnSession.
  * @param {string} prompt - Task prompt
  * @param {string} projectRoot - Project root directory
+ * @param {Object} [options] - Spawn options (same as spawnSession)
  * @returns {Promise<{ exitCode: number, stdout: string, stderr: string, costUsd: number }>}
  */
-function spawnSessionAsync(prompt, projectRoot) {
+function spawnSessionAsync(prompt, projectRoot, options = {}) {
   return new Promise((resolve) => {
     const child = execFile(
       'claude',
-      ['-p', '--output-format', 'json', '--no-session-persistence'],
-      { cwd: projectRoot, timeout: 600000, maxBuffer: CLAUDE_MAX_BUFFER },
+      buildClaudeArgs(options),
+      {
+        cwd: projectRoot,
+        timeout: options.taskTimeoutMs || DEFAULT_TASK_TIMEOUT_MS,
+        maxBuffer: CLAUDE_MAX_BUFFER,
+        env: buildSpawnEnv(),
+      },
       (error, stdout, stderr) => {
         const exitCode = error ? (error.status ?? 1) : 0;
-        resolve(extractCost({ stdout: stdout || '', stderr: stderr || '', exitCode }));
+        const result = { stdout: stdout || '', stderr: stderr || '', exitCode, error };
+        resolve(extractCost(appendStallGuidance(result)));
       },
     );
     if (child.stdin) {
@@ -77,6 +150,11 @@ function spawnSessionAsync(prompt, projectRoot) {
 }
 
 module.exports = {
+  DEFAULT_TASK_TIMEOUT_MS,
+  PERMISSION_STALL_GUIDANCE,
+  buildClaudeArgs,
+  buildSpawnEnv,
+  appendStallGuidance,
   extractCost,
   spawnSession,
   spawnSessionAsync,

--- a/scripts/loop.js
+++ b/scripts/loop.js
@@ -23,6 +23,12 @@ const { spawnSession, spawnSessionAsync } = require('./lib/loop-session');
 const { loadLoopState, saveLoopState, recordError, finalizeLoop } = require('./lib/loop-state');
 const { isStalled, isRetryStorm, checkStopConditions, printSummary } = require('./lib/loop-state');
 const { Feature } = require('./lib/models');
+const {
+  detectPackageManager,
+  getDefaultTestCommand,
+  getPmRunCommand,
+  hasScript,
+} = require('./lib/package-manager');
 const { getTimestamp, readFileSafe } = require('./lib/utils');
 
 const MAX_RETRIES = 1;
@@ -38,6 +44,9 @@ function parseLoopArgs(args) {
     maxRuns: 50,
     maxCost: null,
     epic: null,
+    taskTimeoutMs: null,
+    permissionMode: null,
+    allowedTools: null,
     projectRoot: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
   };
 
@@ -66,6 +75,21 @@ function parseLoopArgs(args) {
         break;
       case '--epic':
         options.epic = args[++i];
+        break;
+      case '--task-timeout': {
+        const seconds = parseInt(args[++i], 10);
+        if (Number.isNaN(seconds) || seconds < 1) {
+          console.error('Error: --task-timeout must be a positive integer (seconds)');
+          process.exit(1);
+        }
+        options.taskTimeoutMs = seconds * 1000;
+        break;
+      }
+      case '--permission-mode':
+        options.permissionMode = args[++i];
+        break;
+      case '--allowed-tools':
+        options.allowedTools = args[++i];
         break;
       case '--help':
       case '-h':
@@ -97,6 +121,9 @@ OPTIONS:
   --max-runs N               Maximum iterations (default: 50)
   --max-cost N               Maximum cost in dollars (default: unlimited)
   --epic <id>                Scope loop to a single epic (safe for parallel loops)
+  --task-timeout N           Per-session timeout in seconds (default: 600)
+  --permission-mode <mode>   Pass --permission-mode through to spawned claude sessions
+  --allowed-tools <tools>    Pass --allowed-tools through to spawned claude sessions
   --help, -h                 Show this help
 
 PATTERNS:
@@ -150,6 +177,80 @@ function resolveEpicScope(epic, projectRoot) {
 }
 
 /**
+ * Resolve an epic's spec_path to a spawn-cwd-relative path.
+ * Resolution order: spec-dir-relative (`specs/<specId>/<spec_path>`, the
+ * sdd-v2 planner convention) first, then project-root-relative. Only paths
+ * that exist on disk are emitted — a path the spawned session cannot
+ * resolve from its cwd is worse than no path at all.
+ * @param {string} specPath - Raw spec_path value from dag.yaml
+ * @param {string} projectRoot - Spawn cwd for loop sessions
+ * @param {string|null} specId - Spec id for spec-dir-relative resolution
+ * @returns {string|null} Spawn-cwd-relative path, or null when unresolvable
+ */
+function resolveSpecPath(specPath, projectRoot, specId) {
+  if (!specPath || typeof specPath !== 'string') return null;
+  const candidates = [];
+  if (specId) {
+    candidates.push(path.resolve(projectRoot, 'specs', specId, specPath));
+  }
+  candidates.push(path.resolve(projectRoot, specPath));
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return path.relative(projectRoot, candidate);
+  }
+  return null;
+}
+
+/**
+ * Build the `## Specs` lines for a task's epic.
+ * Emits the epic's spec document and the spec epic directory when they
+ * exist on disk; legacy dags without spec_path gracefully omit both.
+ * @param {Object|null} epic - Epic carrying spec_path (null → no lines)
+ * @param {Coordinator} coord - Coordinator instance (provides specId)
+ * @param {string} projectRoot - Spawn cwd for loop sessions
+ * @returns {string[]} Lines for the Specs section (may be empty)
+ */
+function buildSpecLines(epic, coord, projectRoot) {
+  if (!epic) return [];
+  const lines = [];
+  const specId = coord.specId || null;
+  const specDoc = resolveSpecPath(epic.spec_path, projectRoot, specId);
+  if (specDoc) {
+    lines.push(`Spec: ${specDoc}`);
+  }
+  if (specId) {
+    const epicDir = path.join('specs', specId, 'epics', epic.id);
+    if (fs.existsSync(path.join(projectRoot, epicDir))) {
+      lines.push(`Epic docs: ${epicDir}${path.sep}`);
+    }
+  }
+  return lines;
+}
+
+/**
+ * Build verification instructions from detected project commands.
+ * Returns [] when the project type is unknown (no package.json or
+ * pyproject.toml) — the verification block is omitted rather than
+ * prescribing commands that don't exist.
+ * @param {string} projectRoot - Project root directory
+ * @returns {string[]} Ordered instruction lines (numbering added by caller)
+ */
+function buildVerificationLines(projectRoot) {
+  let testCommand;
+  try {
+    testCommand = getDefaultTestCommand(projectRoot).join(' ');
+  } catch {
+    return [];
+  }
+  const lines = [`Run \`${testCommand}\` and verify all tests pass`];
+  if (hasScript('lint', projectRoot)) {
+    const pmName = detectPackageManager(projectRoot) || 'npm';
+    lines.push(`Run \`${getPmRunCommand('lint', pmName).join(' ')}\` and fix any issues`);
+  }
+  lines.push('Commit with format: type(scope): description');
+  return lines;
+}
+
+/**
  * Build a task context prompt for a spawned Claude session.
  * Uses coordinator.taskContext() for enriched task data.
  * @param {Object} task - Task from coordinator
@@ -161,10 +262,13 @@ function buildTaskPrompt(task, coord, projectRoot) {
   const taskType = task instanceof Feature ? 'feature' : 'epic';
   const parts = [`# Task: ${task.name}`, ``, `## Task ID: ${task.id}`, `## Type: ${taskType}`];
 
-  // Enrich with coordinator context (dependencies, parent epic, siblings)
+  // Enrich with coordinator context (dependencies, parent epic, siblings).
+  // The epic resolved here also carries spec_path for the Specs section.
+  let specEpic = taskType === 'epic' ? task : null;
   try {
     const ctx = coord.taskContext(task.id);
     if (ctx.parent_epic) {
+      if (!specEpic) specEpic = coord.dag.getTask(ctx.parent_epic.id);
       parts.push(
         `## Parent Epic: ${ctx.parent_epic.name} (${Math.round(ctx.parent_epic.progress)}% complete)`,
       );
@@ -191,19 +295,17 @@ function buildTaskPrompt(task, coord, projectRoot) {
     `Commit your changes with a conventional commit message.`,
     ``,
     `## Project Root: ${projectRoot}`,
-    ``,
-    `## Verification`,
-    ``,
-    `After implementation:`,
-    `1. Run \`npm test\` and verify all tests pass`,
-    `2. Run \`npm run lint\` and fix any issues`,
-    `3. Commit with format: type(scope): description`,
   );
 
-  // Try to read the epic/feature spec if available
-  const epicDir = path.join(projectRoot, 'epics');
-  if (fs.existsSync(epicDir)) {
-    parts.push(``, `## Specs`, `Read specs from: ${epicDir}`);
+  const verification = buildVerificationLines(projectRoot);
+  if (verification.length > 0) {
+    parts.push(``, `## Verification`, ``, `After implementation:`);
+    parts.push(...verification.map((line, idx) => `${idx + 1}. ${line}`));
+  }
+
+  const specLines = buildSpecLines(specEpic, coord, projectRoot);
+  if (specLines.length > 0) {
+    parts.push(``, `## Specs`, ...specLines);
   }
 
   return parts.join('\n');
@@ -214,15 +316,16 @@ function buildTaskPrompt(task, coord, projectRoot) {
  * @param {Object} task - Task from coordinator
  * @param {Coordinator} coord - Coordinator instance
  * @param {Object} state - Loop state
- * @param {string} projectRoot - Project root directory
+ * @param {Object} options - Loop options (projectRoot + spawn pass-through)
  * @returns {boolean} Whether the task succeeded
  */
-function runTask(task, coord, state, projectRoot) {
+function runTask(task, coord, state, options) {
+  const { projectRoot } = options;
   const taskType = task instanceof Feature ? 'feature' : 'epic';
   console.log(`[loop] Iteration ${state.iteration}: Running ${taskType} ${task.id} — ${task.name}`);
 
   const prompt = buildTaskPrompt(task, coord, projectRoot);
-  let result = spawnSession(prompt, projectRoot);
+  let result = spawnSession(prompt, projectRoot, options);
   state.total_cost += result.costUsd;
 
   if (result.exitCode !== 0) {
@@ -230,7 +333,7 @@ function runTask(task, coord, state, projectRoot) {
     recordError(state, task.id, result.stderr, 1);
 
     // Retry once
-    result = spawnSession(prompt, projectRoot);
+    result = spawnSession(prompt, projectRoot, options);
     state.total_cost += result.costUsd;
     if (result.exitCode !== 0) {
       console.log(`[loop] Task ${task.id} failed after retry — blocking`);
@@ -318,7 +421,7 @@ function runSequential(options) {
       break;
     }
 
-    const success = runTask(task, coord, state, projectRoot);
+    const success = runTask(task, coord, state, options);
     saveLoopState(state, projectRoot);
 
     if (!success) {
@@ -368,7 +471,7 @@ async function runDag(options) {
         prompt: buildTaskPrompt(epicItem, coord, projectRoot),
       }));
       const spawnResults = await Promise.all(
-        taskEntries.map((entry) => spawnSessionAsync(entry.prompt, projectRoot)),
+        taskEntries.map((entry) => spawnSessionAsync(entry.prompt, projectRoot, options)),
       );
 
       // Process results sequentially (state + DAG updates are not concurrent-safe)
@@ -417,7 +520,7 @@ async function runDag(options) {
       break;
     }
 
-    const success = runTask(task, coord, state, projectRoot);
+    const success = runTask(task, coord, state, options);
     saveLoopState(state, projectRoot);
 
     if (!success) {

--- a/tests/scripts/loop-session.test.js
+++ b/tests/scripts/loop-session.test.js
@@ -1,0 +1,160 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildClaudeArgs,
+  buildSpawnEnv,
+  appendStallGuidance,
+  spawnSession,
+  spawnSessionAsync,
+  PERMISSION_STALL_GUIDANCE,
+} = require('../../scripts/lib/loop-session');
+
+describe('buildClaudeArgs', () => {
+  it('returns the headless base args by default', () => {
+    expect(buildClaudeArgs()).toEqual([
+      '-p',
+      '--output-format',
+      'json',
+      '--no-session-persistence',
+    ]);
+  });
+
+  it('passes --permission-mode through with its value', () => {
+    const args = buildClaudeArgs({ permissionMode: 'acceptEdits' });
+    const idx = args.indexOf('--permission-mode');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('acceptEdits');
+  });
+
+  it('passes --allowed-tools through with its value', () => {
+    const args = buildClaudeArgs({ allowedTools: 'Bash,Read' });
+    const idx = args.indexOf('--allowed-tools');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('Bash,Read');
+  });
+
+  it('never auto-appends --dangerously-skip-permissions on any path', () => {
+    const variants = [
+      {},
+      { permissionMode: 'default' },
+      { allowedTools: 'Bash' },
+      { permissionMode: 'acceptEdits', allowedTools: 'Bash,Read' },
+    ];
+    for (const options of variants) {
+      expect(buildClaudeArgs(options)).not.toContain('--dangerously-skip-permissions');
+    }
+  });
+});
+
+describe('buildSpawnEnv', () => {
+  let savedMode;
+  let savedSpawned;
+
+  beforeEach(() => {
+    savedMode = process.env.ARCFORGE_MODE;
+    savedSpawned = process.env.ARCFORGE_SPAWNED;
+  });
+
+  afterEach(() => {
+    if (savedMode === undefined) delete process.env.ARCFORGE_MODE;
+    else process.env.ARCFORGE_MODE = savedMode;
+    if (savedSpawned === undefined) delete process.env.ARCFORGE_SPAWNED;
+    else process.env.ARCFORGE_SPAWNED = savedSpawned;
+  });
+
+  it('clears an inherited ARCFORGE_MODE=attended so loop sessions are never attended', () => {
+    process.env.ARCFORGE_MODE = 'attended';
+    const env = buildSpawnEnv();
+    expect(env.ARCFORGE_MODE).not.toBe('attended');
+  });
+
+  it('sets the ARCFORGE_SPAWNED loop marker', () => {
+    delete process.env.ARCFORGE_SPAWNED;
+    const env = buildSpawnEnv();
+    expect(env.ARCFORGE_SPAWNED).toBe('loop');
+  });
+});
+
+describe('appendStallGuidance', () => {
+  it('leaves successful results untouched', () => {
+    const result = { exitCode: 0, stdout: 'ok', stderr: '' };
+    expect(appendStallGuidance(result).stderr).toBe('');
+  });
+
+  it('appends headless guidance when the session was killed by timeout', () => {
+    const error = Object.assign(new Error('timed out'), { killed: true, signal: 'SIGTERM' });
+    const result = { exitCode: 1, stdout: '', stderr: '', error };
+    expect(appendStallGuidance(result).stderr).toContain(PERMISSION_STALL_GUIDANCE);
+  });
+
+  it('appends headless guidance when stderr mentions permissions', () => {
+    const result = { exitCode: 1, stdout: '', stderr: 'Permission to use Bash denied' };
+    expect(appendStallGuidance(result).stderr).toContain(PERMISSION_STALL_GUIDANCE);
+  });
+
+  it('leaves unrelated failures untouched', () => {
+    const result = { exitCode: 1, stdout: '', stderr: 'syntax error' };
+    expect(appendStallGuidance(result).stderr).toBe('syntax error');
+  });
+});
+
+describe('spawn env hygiene (stub claude)', () => {
+  let binDir;
+  let savedPath;
+  let savedMode;
+  let savedSpawned;
+
+  /** Write an executable `claude` stub into binDir. */
+  function writeStub(body) {
+    const stubPath = path.join(binDir, 'claude');
+    fs.writeFileSync(stubPath, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  }
+
+  beforeEach(() => {
+    binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'loop-session-stub-'));
+    savedPath = process.env.PATH;
+    savedMode = process.env.ARCFORGE_MODE;
+    savedSpawned = process.env.ARCFORGE_SPAWNED;
+    process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+    process.env.ARCFORGE_MODE = 'attended';
+    delete process.env.ARCFORGE_SPAWNED;
+  });
+
+  afterEach(() => {
+    process.env.PATH = savedPath;
+    if (savedMode === undefined) delete process.env.ARCFORGE_MODE;
+    else process.env.ARCFORGE_MODE = savedMode;
+    if (savedSpawned === undefined) delete process.env.ARCFORGE_SPAWNED;
+    else process.env.ARCFORGE_SPAWNED = savedSpawned;
+    fs.rmSync(binDir, { recursive: true, force: true });
+  });
+
+  const ENV_ECHO_STUB =
+    'cat > /dev/null\n' +
+    'printf \'{"total_cost_usd":0.01,"result":"MODE=%s SPAWNED=%s"}\' "$ARCFORGE_MODE" "$ARCFORGE_SPAWNED"';
+
+  it('spawnSession child env never carries ARCFORGE_MODE=attended and has the spawn marker', () => {
+    writeStub(ENV_ECHO_STUB);
+    const result = spawnSession('test prompt', binDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('MODE=attended');
+    expect(result.stdout).toContain('SPAWNED=loop');
+  });
+
+  it('spawnSessionAsync child env never carries ARCFORGE_MODE=attended and has the spawn marker', async () => {
+    writeStub(ENV_ECHO_STUB);
+    const result = await spawnSessionAsync('test prompt', binDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('MODE=attended');
+    expect(result.stdout).toContain('SPAWNED=loop');
+  });
+
+  it('kills the session at taskTimeoutMs and appends headless guidance', () => {
+    writeStub('sleep 5');
+    const result = spawnSession('test prompt', binDir, { taskTimeoutMs: 250 });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(PERMISSION_STALL_GUIDANCE);
+  });
+});

--- a/tests/scripts/loop.test.js
+++ b/tests/scripts/loop.test.js
@@ -4,6 +4,7 @@ const {
   checkStopConditions,
   parseLoopArgs,
   detectWorktree,
+  buildTaskPrompt,
 } = require('../../scripts/loop');
 
 /**
@@ -298,6 +299,192 @@ describe('parseLoopArgs', () => {
     expect(result.epic).toBe('my-epic');
     expect(result.maxRuns).toBe(10);
     expect(result.maxCost).toBe(5);
+  });
+
+  it('should parse --task-timeout in seconds to taskTimeoutMs', () => {
+    const result = parseLoopArgs(['--task-timeout', '900']);
+    expect(result.taskTimeoutMs).toBe(900000);
+  });
+
+  it('should default spawn pass-through options to null', () => {
+    const result = parseLoopArgs([]);
+    expect(result.taskTimeoutMs).toBeNull();
+    expect(result.permissionMode).toBeNull();
+    expect(result.allowedTools).toBeNull();
+  });
+
+  it('should pass through --permission-mode and --allowed-tools values', () => {
+    const result = parseLoopArgs([
+      '--permission-mode',
+      'acceptEdits',
+      '--allowed-tools',
+      'Bash,Read',
+    ]);
+    expect(result.permissionMode).toBe('acceptEdits');
+    expect(result.allowedTools).toBe('Bash,Read');
+  });
+});
+
+describe('buildTaskPrompt', () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const { Coordinator } = require('../../scripts/lib/coordinator');
+
+  let tmpDir;
+  let savedPm;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'loop-prompt-'));
+    // Pin package-manager detection to lock-file resolution for determinism
+    savedPm = process.env.CLAUDE_PACKAGE_MANAGER;
+    delete process.env.CLAUDE_PACKAGE_MANAGER;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (savedPm !== undefined) process.env.CLAUDE_PACKAGE_MANAGER = savedPm;
+  });
+
+  /**
+   * Helper: write a per-spec dag.yaml fixture (sdd-v2 layout) and return a
+   * Coordinator bound to it. Mirrors tests/integration/sdd-v2-pipeline.
+   */
+  function makeSpecProject({
+    specId = 'demo-spec',
+    specPathValue = 'epics/epic-parser/epic.md',
+    createEpicDoc = true,
+    nodeProject = true,
+    lintScript = false,
+  } = {}) {
+    const specDir = path.join(tmpDir, 'specs', specId);
+    fs.mkdirSync(specDir, { recursive: true });
+    const lines = ['epics:', '  - id: epic-parser', '    name: Parser Primitives'];
+    if (specPathValue) lines.push(`    spec_path: ${specPathValue}`);
+    lines.push(
+      '    status: pending',
+      '    worktree: null',
+      '    depends_on: []',
+      '    features:',
+      '      - id: fr-parser-001',
+      '        name: parseInteger Primitive',
+      '        status: pending',
+      '        depends_on: []',
+      '',
+    );
+    fs.writeFileSync(path.join(specDir, 'dag.yaml'), lines.join('\n'));
+    if (createEpicDoc) {
+      const epicDir = path.join(specDir, 'epics', 'epic-parser');
+      fs.mkdirSync(epicDir, { recursive: true });
+      fs.writeFileSync(path.join(epicDir, 'epic.md'), '# Epic: Parser Primitives\n');
+    }
+    if (nodeProject) {
+      const scripts = lintScript ? { test: 'jest', lint: 'biome check .' } : { test: 'jest' };
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({ name: 'fixture', version: '1.0.0', scripts }),
+      );
+      // Lock file pins detectPackageManager to npm regardless of host config
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}');
+    }
+    return new Coordinator(tmpDir, specId);
+  }
+
+  it('emits a spec-dir-relative spec_path resolvable from the spawn cwd (sdd-v2 fixture convention)', () => {
+    const coord = makeSpecProject();
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    const match = prompt.match(/^Spec: (.+)$/m);
+    expect(match).not.toBeNull();
+    expect(match[1]).toBe(path.join('specs', 'demo-spec', 'epics', 'epic-parser', 'epic.md'));
+    // The emitted path must exist from the spawn cwd (projectRoot)
+    expect(fs.existsSync(path.resolve(tmpDir, match[1]))).toBe(true);
+  });
+
+  it('emits the epic docs directory when specs/<spec-id>/epics/<epic-id>/ exists', () => {
+    const coord = makeSpecProject();
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    const match = prompt.match(/^Epic docs: (.+)$/m);
+    expect(match).not.toBeNull();
+    expect(fs.existsSync(path.resolve(tmpDir, match[1]))).toBe(true);
+  });
+
+  it('resolves project-root-relative spec_path (arc-planning convention)', () => {
+    const coord = makeSpecProject({
+      specPathValue: 'specs/demo-spec/epics/epic-parser/epic.md',
+    });
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    const match = prompt.match(/^Spec: (.+)$/m);
+    expect(match).not.toBeNull();
+    expect(match[1]).toBe(path.join('specs', 'demo-spec', 'epics', 'epic-parser', 'epic.md'));
+    expect(fs.existsSync(path.resolve(tmpDir, match[1]))).toBe(true);
+  });
+
+  it('resolves the parent epic spec source for feature tasks via taskContext', () => {
+    const coord = makeSpecProject();
+    const prompt = buildTaskPrompt(coord.dag.getTask('fr-parser-001'), coord, tmpDir);
+
+    const match = prompt.match(/^Spec: (.+)$/m);
+    expect(match).not.toBeNull();
+    expect(fs.existsSync(path.resolve(tmpDir, match[1]))).toBe(true);
+  });
+
+  it('omits the Specs section for legacy dags without spec_path', () => {
+    const coord = makeSpecProject({ specPathValue: null, createEpicDoc: false });
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    expect(prompt).not.toContain('Spec:');
+    expect(prompt).not.toContain('## Specs');
+  });
+
+  it('omits spec_path entries that do not exist on disk', () => {
+    const coord = makeSpecProject({ createEpicDoc: false });
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    expect(prompt).not.toContain('Spec:');
+  });
+
+  it('uses the detected test command for Node projects', () => {
+    const coord = makeSpecProject();
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    expect(prompt).toContain('Run `npm test` and verify all tests pass');
+  });
+
+  it('emits a pytest verification line for pyproject projects', () => {
+    const coord = makeSpecProject({ nodeProject: false });
+    fs.writeFileSync(path.join(tmpDir, 'pyproject.toml'), '[project]\nname = "fixture"\n');
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    expect(prompt).toContain('Run `pytest tests/ -v` and verify all tests pass');
+    expect(prompt).not.toContain('npm test');
+  });
+
+  it('omits the verification block when the project type is unknown', () => {
+    const coord = makeSpecProject({ nodeProject: false });
+    const prompt = buildTaskPrompt(coord.dag.getTask('epic-parser'), coord, tmpDir);
+
+    expect(prompt).not.toContain('## Verification');
+  });
+
+  it('emits the lint line only when package.json has a lint script', () => {
+    const withLint = makeSpecProject({ lintScript: true });
+    const promptWithLint = buildTaskPrompt(withLint.dag.getTask('epic-parser'), withLint, tmpDir);
+    expect(promptWithLint).toContain('Run `npm run lint` and fix any issues');
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'fixture', version: '1.0.0', scripts: { test: 'jest' } }),
+    );
+    const withoutLint = new Coordinator(tmpDir, 'demo-spec');
+    const promptNoLint = buildTaskPrompt(
+      withoutLint.dag.getTask('epic-parser'),
+      withoutLint,
+      tmpDir,
+    );
+    expect(promptNoLint).not.toContain('npm run lint');
   });
 });
 


### PR DESCRIPTION
Wave 1 (PR-1e). Unattended loop sessions finally see their specs and correct test commands; long runs stop dying silently.

## What
- AF-4: buildTaskPrompt derives real spec paths via dag.yaml `spec_path` / `specs/<spec-id>/epics/` (existence-validated) and uses package-manager.js detection instead of hardcoded npm
- AF-10: `--task-timeout` flag; optional permission-mode pass-through; spawn env hygiene — ARCFORGE_MODE no longer leaks into loop-spawned sessions, ARCFORGE_SPAWNED marker set (the S7 pending-action-relay seam)
- Spawn-layer edits live in `scripts/lib/loop-session.js` per the CORE-2 revision note; parseLoopArgs stays in loop.js (AF-8 owned)

## Review
Adversarially replayed: approve — every hunk traces to AF-4/AF-10 or plan-sanctioned wiring (dag-commands/help growth is CORE-1-budgeted)