### PR TITLE
fix(hooks): quality-check fires on Write + Edit via plain matcher; console scan narrowed (RV-2)

### DIFF
--- a/hooks/__tests__/e2e-hooks.test.js
+++ b/hooks/__tests__/e2e-hooks.test.js
@@ -378,6 +378,44 @@ describe('E2E: quality-check/main.js', () => {
     const result = runNodeHook(scriptPath, input);
     assert.strictEqual(result.exitCode, 0);
   });
+
+  it('should detect console.log in Write-created JS file', () => {
+    // Write tool: the file exists on disk by the time PostToolUse fires
+    const content = 'function foo() {\n  console.log("debug");\n  return 42;\n}\n';
+    const jsFile = path.join(testDir, 'written.js');
+    fs.writeFileSync(jsFile, content);
+
+    const input = makeToolUseInput('PostToolUse', 'Write', { file_path: jsFile, content });
+    const result = runNodeHook(scriptPath, input);
+
+    assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+
+    const parsed = JSON.parse(result.stdout);
+    assert.ok(
+      parsed.systemMessage,
+      `Should output systemMessage. stdout: "${result.stdout.trim()}"`,
+    );
+    assert.ok(
+      parsed.systemMessage.includes('console'),
+      `systemMessage should mention console. Got: "${parsed.systemMessage}"`,
+    );
+  });
+
+  it('should NOT emit output for Write-created file with only console.error', () => {
+    const content = 'function fail(msg) {\n  console.error("Error: " + msg);\n}\n';
+    const jsFile = path.join(testDir, 'cli-errors.js');
+    fs.writeFileSync(jsFile, content);
+
+    const input = makeToolUseInput('PostToolUse', 'Write', { file_path: jsFile, content });
+    const result = runNodeHook(scriptPath, input);
+
+    assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+    assert.strictEqual(
+      result.stdout.trim(),
+      '',
+      `console.error-only file should produce no output. Got: "${result.stdout.trim()}"`,
+    );
+  });
 });
 
 // ─────────────────────────────────────────────

--- a/hooks/__tests__/quality-check.test.js
+++ b/hooks/__tests__/quality-check.test.js
@@ -30,16 +30,22 @@ describe('quality-check: checkConsoleLogs', () => {
     assert.strictEqual(result[0].line, 2);
   });
 
-  it('should detect console.warn, console.error, console.debug, console.info', () => {
+  it('should detect console.debug and console.info', () => {
     const { checkConsoleLogs } = require('../quality-check/main');
     const filePath = path.join(testDir, 'test.js');
-    fs.writeFileSync(
-      filePath,
-      'console.warn("w");\nconsole.error("e");\nconsole.debug("d");\nconsole.info("i");\n',
-    );
+    fs.writeFileSync(filePath, 'console.debug("d");\nconsole.info("i");\n');
 
     const result = checkConsoleLogs(filePath);
-    assert.strictEqual(result.length, 4);
+    assert.strictEqual(result.length, 2);
+  });
+
+  it('should NOT flag console.warn or console.error (prescribed CLI error layer)', () => {
+    const { checkConsoleLogs } = require('../quality-check/main');
+    const filePath = path.join(testDir, 'test.js');
+    fs.writeFileSync(filePath, 'console.warn("w");\nconsole.error("e");\n');
+
+    const result = checkConsoleLogs(filePath);
+    assert.strictEqual(result.length, 0);
   });
 
   it('should skip lines starting with //', () => {
@@ -100,5 +106,34 @@ describe('quality-check: checkConsoleLogs', () => {
       result[0].content.length <= 60,
       `Content should be <= 60 chars, got ${result[0].content.length}`,
     );
+  });
+});
+
+describe('quality-check: hooks.json registration', () => {
+  const hooksJsonPath = path.join(__dirname, '..', 'hooks.json');
+
+  it('should parse hooks.json and register quality-check for both Edit and Write', () => {
+    const config = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
+    const postToolUse = config.hooks.PostToolUse;
+    assert.ok(Array.isArray(postToolUse), 'PostToolUse should be an array');
+
+    const qualityCheckEntries = postToolUse.filter((entry) =>
+      entry.hooks.some((h) => h.command.includes('quality-check/main.js')),
+    );
+    assert.strictEqual(
+      qualityCheckEntries.length,
+      2,
+      `Expected exactly 2 quality-check matchers, got ${qualityCheckEntries.length}`,
+    );
+
+    const matchers = qualityCheckEntries.map((entry) => entry.matcher);
+    for (const tool of ['Edit', 'Write']) {
+      const matcher = matchers.find((m) => m.includes(`tool == "${tool}"`));
+      assert.ok(matcher, `Should have a matcher for tool == "${tool}". Got: ${matchers}`);
+      assert.ok(
+        matcher.includes('tool_input.file_path matches "\\\\.(ts|tsx|js|jsx)$"'),
+        `${tool} matcher should gate on ts/tsx/js/jsx file_path. Got: ${matcher}`,
+      );
+    }
   });
 });

--- a/hooks/__tests__/quality-check.test.js
+++ b/hooks/__tests__/quality-check.test.js
@@ -112,7 +112,7 @@ describe('quality-check: checkConsoleLogs', () => {
 describe('quality-check: hooks.json registration', () => {
   const hooksJsonPath = path.join(__dirname, '..', 'hooks.json');
 
-  it('should parse hooks.json and register quality-check for both Edit and Write', () => {
+  it('should parse hooks.json and register quality-check once with plain "Edit|Write" matcher', () => {
     const config = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
     const postToolUse = config.hooks.PostToolUse;
     assert.ok(Array.isArray(postToolUse), 'PostToolUse should be an array');
@@ -122,18 +122,16 @@ describe('quality-check: hooks.json registration', () => {
     );
     assert.strictEqual(
       qualityCheckEntries.length,
-      2,
-      `Expected exactly 2 quality-check matchers, got ${qualityCheckEntries.length}`,
+      1,
+      `Expected exactly 1 quality-check entry, got ${qualityCheckEntries.length}`,
     );
 
-    const matchers = qualityCheckEntries.map((entry) => entry.matcher);
-    for (const tool of ['Edit', 'Write']) {
-      const matcher = matchers.find((m) => m.includes(`tool == "${tool}"`));
-      assert.ok(matcher, `Should have a matcher for tool == "${tool}". Got: ${matchers}`);
-      assert.ok(
-        matcher.includes('tool_input.file_path matches "\\\\.(ts|tsx|js|jsx)$"'),
-        `${tool} matcher should gate on ts/tsx/js/jsx file_path. Got: ${matcher}`,
-      );
-    }
+    // Plain tool-name regex — the only matcher syntax verified to fire on
+    // PostToolUse (v2.1.173). The ts/tsx/js/jsx gate lives in main.js.
+    assert.strictEqual(
+      qualityCheckEntries[0].matcher,
+      'Edit|Write',
+      `Matcher must be the plain tool-name regex "Edit|Write". Got: ${qualityCheckEntries[0].matcher}`,
+    );
   });
 });

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -118,6 +118,15 @@
         ]
       },
       {
+        "matcher": "tool == \"Write\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/quality-check/main.js\""
+          }
+        ]
+      },
+      {
         "matcher": ".*",
         "hooks": [
           {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -109,16 +109,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/quality-check/main.js\""
-          }
-        ]
-      },
-      {
-        "matcher": "tool == \"Write\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/hooks/quality-check/main.js
+++ b/hooks/quality-check/main.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
- * Quality check orchestrator for PostToolUse (Edit tool)
+ * Quality check orchestrator for PostToolUse (Edit and Write tools)
  *
- * Runs automatically after editing TypeScript/JavaScript files:
+ * Runs automatically after Edit/Write of TypeScript/JavaScript files:
  * 1. Auto-format with Prettier (if available)
  * 2. Type-check with TypeScript (if available)
- * 3. Warn about console.log statements
+ * 3. Warn about console.log/debug/info statements
+ *    (console.warn/error are intentionally NOT flagged — they are the
+ *    prescribed CLI error-output layer; see coding standards)
  *
  * Warnings output via systemMessage (user-visible)
  * Prettier auto-formats files in-place
@@ -27,7 +29,8 @@ const { runPrettier } = require('./prettier');
 const { runTypeCheck } = require('./typescript');
 
 /**
- * Check for console.log statements in a file
+ * Check for console.log/debug/info statements in a file.
+ * console.warn/error are excluded: they are the prescribed CLI error layer.
  */
 function checkConsoleLogs(filePath) {
   const content = readFileSafe(filePath);
@@ -42,7 +45,7 @@ function checkConsoleLogs(filePath) {
     // Skip commented lines
     if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
 
-    if (/\bconsole\.(log|warn|error|debug|info)\s*\(/.test(line)) {
+    if (/\bconsole\.(log|debug|info)\s*\(/.test(line)) {
       matches.push({ line: i + 1, content: trimmed.slice(0, 60) });
     }
   }


### PR DESCRIPTION
Wave 1 (PR-1f). Two commits: the spec change set, then the owner-approved matcher correction after a stop condition fired and exposed a repo-wide discovery (see the sibling matcher-triage PR #76).

## What
- hooks.json: quality-check registered ONCE under PostToolUse with plain matcher `"Edit|Write"` — the spec-prescribed expression matcher (`tool == "Write" && tool_input.file_path matches ...`) was proven dead by a 6-cell live A/B on v2.1.173 (expression matchers never fire; the matcher field is a tool-name regex per official docs). The ts/tsx/js/jsx gate already lives in main.js (early-exit)
- console.* scan narrowed to log/debug/info — stops flagging console.error, the repo's own prescribed CLI pattern
- Registration test pins the single entry; live smoke evidence in both project-settings and --plugin-dir contexts (fires on .ts Write with finding; early-exits on .md)

## Merge note
- Plugin code is cached by version — the fix reaches installed copies only after the next version bump
- Disjoint hunks with #76 (it deliberately leaves this entry untouched); both merge cleanly in either order