### PR TITLE
fix(hooks): replace dead expression matchers — the guard layer fires for the first time

### DIFF
--- a/docs/plans/2026-06-11-capability-seam-fix-implementation-plan.md
+++ b/docs/plans/2026-06-11-capability-seam-fix-implementation-plan.md
@@ -4,6 +4,8 @@
 > 本文件是唯一執行依據。所有先前查證事實（`/tmp/arcforge-audit-items.json`、`/tmp/arcforge-goal-analyses.json`、`/tmp/arcforge-capability-first-blueprint.md`）已吸收；七大情境走查發現的每一條 seam 均已併入對應任務（以【S*-*】標註）。實作者依波次執行，遇停止條件即上報，不得自行繞道。
 
 > **執行狀態（2026-06-12）**：Wave 0 全數完成並合併 — CORE-1 (#64)、CORE-2 (#69)、AF-1 (#65)、AF-2 (#66)、RV-1 (#67)、WT-1 (#68)。RV-1 spike 結論：`decision:block` 與 `additionalContext` 均達模型（v2.1.172，含 Task-subagent 輪）；helper 採 additionalContext 形態，RV-3/RV-5/ICL-10 解凍。CORE-2 的 ≤450 門檻經停止條件上報後由 owner 修訂為 (b)+(c) 方案、≤467（見該任務的修訂註記）。
+>
+> **MATCHER TRIAGE hotfix（2026-06-12，branch `fix/hooks-matcher-triage`）**：RV-2 的 6-cell A/B 證實 expression matcher（`tool == "..."` / `&& tool_input... matches ...`）在 Claude Code v2.1.173 上從未觸發 — matcher 是對 tool name 的 regex，無 expression 語法。guard 層（arc-guard G2/G3、sdd-ledger-guard、sdd-ratify-guard、arc-remind）的 hooks.json matcher 已全數換成 plain tool-name（`Bash`/`Edit`/`Write`）；四個 hook 的 main.js 原本即在 tool_name 上自我把關，無需改動。quality-check 的 matcher 由 RV-2 分支自行修（hunk 保持互斥）。Wave 2.1（guard package）必須以本分支為基底。
 
 ---
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -133,7 +133,7 @@ main();
 {
   "PostToolUse": [
     {
-      "matcher": "tool == \"Edit\"",
+      "matcher": "Edit",
       "hooks": [
         {
           "type": "command",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -43,7 +43,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "tool == \"Bash\"",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
@@ -52,7 +52,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Edit\"",
+        "matcher": "Edit",
         "hooks": [
           {
             "type": "command",
@@ -61,7 +61,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Write\"",
+        "matcher": "Write",
         "hooks": [
           {
             "type": "command",
@@ -70,7 +70,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Edit\"",
+        "matcher": "Edit",
         "hooks": [
           {
             "type": "command",
@@ -79,7 +79,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Write\"",
+        "matcher": "Write",
         "hooks": [
           {
             "type": "command",
@@ -88,7 +88,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Bash\"",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
@@ -137,7 +137,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Bash\"",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
@@ -146,7 +146,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Edit\"",
+        "matcher": "Edit",
         "hooks": [
           {
             "type": "command",
@@ -155,7 +155,7 @@
         ]
       },
       {
-        "matcher": "tool == \"Write\"",
+        "matcher": "Write",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Wave 1 hotfix (must merge before Wave 2.1 builds on arc-guard). RV-2's stop condition exposed that every `tool == "..."` expression matcher in hooks.json has been a silent no-op since arcforge's initial commit: official docs (code.claude.com/docs/en/hooks.md) define the matcher field as tool-name-only (exact / pipe-list / regex) — no expression syntax has ever existed. Live A/B on v2.1.173 confirmed.

## What
- hooks.json: arc-guard (3 entries → "Bash"/"Edit"/"Write"), sdd-ledger-guard ("Edit"/"Write"), sdd-ratify-guard ("Bash"), arc-remind ("Bash"/"Edit"/"Write"). Structure preserved — the sdd-ratify-guard fold into arc-guard remains Wave 2.1's task
- quality-check's entry deliberately untouched (owned by #75's branch; disjoint hunks, both merge cleanly in either order)
- Verified each hook's main.js self-gates on stdin tool_name (they now receive tools the matcher previously filtered)
- hooks/README.md example fixed (was teaching the dead grammar); plan doc annotated

## Proof the guard layer is alive (live smokes, claude -p --plugin-dir)
- Temp repo with .arcforge-epic marker: `git merge` → **arc-guard G2 deny fired** (first time ever)
- arc-remind nudge fired

## User-facing note for release
- Installed copies need the next version bump to receive this (plugin cache). After it lands, users will SEE guards and reminders that previously never appeared — worth a CHANGELOG callout