### PR TITLE
fix(cli): coordinator reboot derives a real handover context (SRH-1)

### DIFF
--- a/scripts/lib/coordinator-core.js
+++ b/scripts/lib/coordinator-core.js
@@ -20,6 +20,8 @@ const { withLock } = require('./locking');
 const { objectToYaml } = require('./dag-schema');
 const { getWorktreePath, parseWorktreePath } = require('./worktree-paths');
 const { readArcforgeMarker } = require('./marker');
+const { parseSpecHeader } = require('./sdd-spec-header');
+const { readFileSafe } = require('./utils');
 
 /**
  * Coordinator class - manages DAG operations for a single spec
@@ -283,7 +285,15 @@ class Coordinator {
   }
 
   /**
-   * Reboot context - get summary for new session
+   * Reboot context - post-compaction handover summary for a new session.
+   *
+   * Counts are kept cheap and additive (rebootAllSpecs aggregates them
+   * across specs). The remaining fields are derived from data the
+   * Coordinator already scopes: `project_goal` from the spec header,
+   * `current_task` via the existing nextTask priority (in-progress
+   * feature > ready feature > ready epic), `research_files` from the
+   * spec directory's documentation artifacts.
+   *
    * @returns {Object} Context summary
    */
   rebootContext() {
@@ -300,14 +310,72 @@ class Coordinator {
       }
     }
 
+    const next = this.nextTask();
+
     return {
-      current_task: null,
+      current_task: next
+        ? {
+            id: next.id,
+            name: next.name,
+            type: next instanceof Feature ? 'feature' : 'epic',
+            status: next.status,
+          }
+        : null,
       remaining_count: remaining,
       completed_count: completed,
       blocked_count: this.dag.blocked.length,
-      project_goal: 'Build a skill-based autonomous agent toolkit',
-      research_files: [],
+      project_goal: this._projectGoalFromSpec(),
+      research_files: this._enumerateResearchFiles(),
     };
+  }
+
+  /**
+   * Derive the project goal from the spec header (`specs/<id>/spec.xml`
+   * `<title>`). Returns null when the spec id is unresolved, spec.xml is
+   * absent, or the header carries no title — reboot must stay useful for
+   * dag-only projects, so a missing goal degrades to null rather than
+   * throwing (title is a required header field; its absence is a spec
+   * problem the validator reports, not a reboot failure).
+   *
+   * @returns {string|null}
+   */
+  _projectGoalFromSpec() {
+    if (!this.specId) return null;
+    const specXmlPath = path.join(this.projectRoot, 'specs', this.specId, 'spec.xml');
+    const content = readFileSafe(specXmlPath);
+    if (!content) return null;
+    const header = parseSpecHeader(content);
+    return header?.title ? header.title : null;
+  }
+
+  /**
+   * Enumerate handover reading material in the spec directory: top-level
+   * documentation artifacts (vision.md, spec.xml, decisions.yml) plus
+   * `details/*.xml`, as paths relative to the project root. dag.yaml is
+   * excluded — it is live state the reboot output already summarizes,
+   * not research. Empty array when the spec id is unresolved or no
+   * artifacts exist.
+   *
+   * @returns {string[]}
+   */
+  _enumerateResearchFiles() {
+    if (!this.specId) return [];
+    const specDir = path.join(this.projectRoot, 'specs', this.specId);
+    const files = [];
+    for (const name of ['vision.md', 'spec.xml', 'decisions.yml']) {
+      if (fs.existsSync(path.join(specDir, name))) {
+        files.push(path.relative(this.projectRoot, path.join(specDir, name)));
+      }
+    }
+    const detailsDir = path.join(specDir, 'details');
+    if (fs.existsSync(detailsDir)) {
+      for (const entry of fs.readdirSync(detailsDir).sort()) {
+        if (entry.endsWith('.xml')) {
+          files.push(path.relative(this.projectRoot, path.join(detailsDir, entry)));
+        }
+      }
+    }
+    return files;
   }
 
   // ==================== Private Methods ====================

--- a/tests/scripts/coordinator-per-spec.test.js
+++ b/tests/scripts/coordinator-per-spec.test.js
@@ -34,6 +34,25 @@ function simpleEpic(id, status = TaskStatus.PENDING) {
   };
 }
 
+function writeSpecXml(root, specId, title) {
+  const dir = path.join(root, 'specs', specId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'spec.xml'),
+    [
+      '<spec>',
+      '  <overview>',
+      `    <spec_id>${specId}</spec_id>`,
+      '    <spec_version>1</spec_version>',
+      '    <status>active</status>',
+      `    <title>${title}</title>`,
+      '    <description>Fixture spec</description>',
+      '  </overview>',
+      '</spec>',
+    ].join('\n'),
+  );
+}
+
 describe('Coordinator constructor — lazy dagPath resolution', () => {
   let root;
   beforeEach(() => {
@@ -119,6 +138,100 @@ describe('rebootAllSpecs', () => {
     expect(Object.keys(result.specs).sort()).toEqual(['spec-a', 'spec-b']);
     expect(result.totals.completed_count).toBe(1);
     expect(result.totals.remaining_count).toBe(2);
+  });
+
+  test('per-spec entries carry spec-derived handover fields without changing totals shape', () => {
+    writeSpec(root, 'spec-a', [
+      {
+        ...simpleEpic('epic-1', TaskStatus.IN_PROGRESS),
+        features: [{ id: 'f-1', name: 'f-1', status: TaskStatus.PENDING, depends_on: [] }],
+      },
+    ]);
+    writeSpecXml(root, 'spec-a', 'Goal A');
+    const result = rebootAllSpecs(root);
+    expect(result.specs['spec-a'].project_goal).toBe('Goal A');
+    expect(result.specs['spec-a'].current_task).toMatchObject({ id: 'f-1', type: 'feature' });
+    expect(result.totals).toEqual({
+      completed_count: 0,
+      remaining_count: 1,
+      blocked_count: 0,
+    });
+  });
+});
+
+describe('rebootContext — spec-derived handover', () => {
+  let root;
+  beforeEach(() => {
+    root = tmpProject();
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  test('derives project_goal from the spec.xml title', () => {
+    writeSpec(root, 'spec-a', [simpleEpic('epic-1')]);
+    writeSpecXml(root, 'spec-a', 'Ship the payments API');
+    const ctx = new Coordinator(root, 'spec-a').rebootContext();
+    expect(ctx.project_goal).toBe('Ship the payments API');
+  });
+
+  test('project_goal is null when spec.xml is absent (dag-only project)', () => {
+    writeSpec(root, 'spec-a', [simpleEpic('epic-1')]);
+    const ctx = new Coordinator(root, 'spec-a').rebootContext();
+    expect(ctx.project_goal).toBeNull();
+  });
+
+  test('project_goal is null when spec.xml has no parseable title', () => {
+    writeSpec(root, 'spec-a', [simpleEpic('epic-1')]);
+    fs.writeFileSync(
+      path.join(root, 'specs', 'spec-a', 'spec.xml'),
+      '<spec><overview><spec_id>spec-a</spec_id></overview></spec>',
+    );
+    const ctx = new Coordinator(root, 'spec-a').rebootContext();
+    expect(ctx.project_goal).toBeNull();
+  });
+
+  test('current_task surfaces the in-progress feature', () => {
+    writeSpec(root, 'spec-a', [
+      {
+        ...simpleEpic('epic-1', TaskStatus.IN_PROGRESS),
+        features: [
+          { id: 'f-1', name: 'auth', status: TaskStatus.IN_PROGRESS, depends_on: [] },
+          { id: 'f-2', name: 'tokens', status: TaskStatus.PENDING, depends_on: [] },
+        ],
+      },
+    ]);
+    const ctx = new Coordinator(root, 'spec-a').rebootContext();
+    expect(ctx.current_task).toEqual({
+      id: 'f-1',
+      name: 'auth',
+      type: 'feature',
+      status: TaskStatus.IN_PROGRESS,
+    });
+  });
+
+  test('research_files enumerates spec-dir docs and details, excluding dag.yaml', () => {
+    writeSpec(root, 'spec-a', [simpleEpic('epic-1')]);
+    writeSpecXml(root, 'spec-a', 'Ship the payments API');
+    const dir = path.join(root, 'specs', 'spec-a');
+    fs.writeFileSync(path.join(dir, 'vision.md'), '# vision');
+    fs.writeFileSync(path.join(dir, 'decisions.yml'), 'decisions: []');
+    fs.mkdirSync(path.join(dir, 'details'));
+    fs.writeFileSync(path.join(dir, 'details', 'fr-2.xml'), '<detail/>');
+    fs.writeFileSync(path.join(dir, 'details', 'fr-1.xml'), '<detail/>');
+    fs.writeFileSync(path.join(dir, 'details', 'notes.txt'), 'not xml');
+    const ctx = new Coordinator(root, 'spec-a').rebootContext();
+    expect(ctx.research_files).toEqual([
+      'specs/spec-a/vision.md',
+      'specs/spec-a/spec.xml',
+      'specs/spec-a/decisions.yml',
+      'specs/spec-a/details/fr-1.xml',
+      'specs/spec-a/details/fr-2.xml',
+    ]);
+  });
+
+  test('research_files is empty when the spec dir holds only dag.yaml', () => {
+    writeSpec(root, 'spec-a', [simpleEpic('epic-1')]);
+    const ctx = new Coordinator(root, 'spec-a').rebootContext();
+    expect(ctx.research_files).toEqual([]);
   });
 });
 

--- a/tests/scripts/coordinator.test.js
+++ b/tests/scripts/coordinator.test.js
@@ -329,6 +329,41 @@ describe('Coordinator', () => {
       expect(context.completed_count).toBeDefined();
       expect(context.blocked_count).toBeDefined();
     });
+
+    it('should surface the next actionable task as current_task', () => {
+      const coord = createCoordinator(twoEpicDag({ epic1Status: TaskStatus.IN_PROGRESS }));
+      const context = coord.rebootContext();
+      expect(context.current_task).toEqual({
+        id: 'feat-1a',
+        name: 'Setup',
+        type: 'feature',
+        status: TaskStatus.PENDING,
+      });
+    });
+
+    it('should report current_task null when nothing is actionable', () => {
+      const coord = createCoordinator(
+        twoEpicDag({
+          epic1Status: TaskStatus.COMPLETED,
+          epic2Status: TaskStatus.COMPLETED,
+          epic1Features: [
+            { id: 'feat-1a', name: 'Setup', status: TaskStatus.COMPLETED },
+            { id: 'feat-1b', name: 'Core', status: TaskStatus.COMPLETED },
+          ],
+          epic2Features: [{ id: 'feat-2a', name: 'Plugin', status: TaskStatus.COMPLETED }],
+        }),
+      );
+      expect(coord.rebootContext().current_task).toBeNull();
+    });
+
+    it('should degrade project_goal/research_files to null/[] when no spec is resolvable', () => {
+      // Injected-dag coordinator has no specId and no marker — the derived
+      // fields must degrade gracefully, never throw or invent a goal.
+      const coord = createCoordinator(twoEpicDag());
+      const context = coord.rebootContext();
+      expect(context.project_goal).toBeNull();
+      expect(context.research_files).toEqual([]);
+    });
   });
 
   describe('sync status validation', () => {


### PR DESCRIPTION
Wave 1 (PR-1i). Post-compaction recovery stops handing users arcforge's own hardcoded goal string.

## What
- rebootContext in coordinator-core.js: project_goal derived from the spec, current_task from the in-progress feature, research_files populated (spec dir documentation artifacts: vision.md, spec.xml, decisions.yml, details/*.xml — excluding live state dag.yaml and epics/** reachable via taskContext); graceful degradation when spec.xml/title absent
- Jest coverage per plan acceptance (3 files changed, replayed by reviewer)