### PR TITLE
feat(hooks): freshness-aware eval-before-ship nudge in arc-remind (RV-6)

### DIFF
--- a/hooks/__tests__/arc-remind.test.js
+++ b/hooks/__tests__/arc-remind.test.js
@@ -191,3 +191,179 @@ describe('arc-remind SDD spec→dag nudge', () => {
     assert.ok(msg.includes('arc-planning'));
   });
 });
+
+describe('arc-remind freshness-aware eval-before-ship nudge', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const os = require('node:os');
+  const { afterEach } = require('node:test');
+  const { clearCachedSessionId } = require('../../scripts/lib/utils');
+
+  let root;
+  let savedSessionId;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../arc-remind/main')];
+    savedSessionId = process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = `rv6-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    clearCachedSessionId();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-remind-fresh-'));
+  });
+
+  afterEach(() => {
+    try {
+      const { skillEditStatePath } = require('../arc-remind/main');
+      fs.rmSync(skillEditStatePath(), { force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    if (savedSessionId === undefined) delete process.env.CLAUDE_SESSION_ID;
+    else process.env.CLAUDE_SESSION_ID = savedSessionId;
+    clearCachedSessionId();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeSkill(name) {
+    const dir = path.join(root, 'skills', name);
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'SKILL.md');
+    fs.writeFileSync(file, '# skill\n');
+    return file;
+  }
+
+  function writeBenchmark(content) {
+    const dir = path.join(root, 'evals', 'benchmarks');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'latest.json');
+    fs.writeFileSync(file, content);
+    return file;
+  }
+
+  it('records SKILL.md paths in hook-local session state, resolved and deduped', () => {
+    const { recordSkillEdit, readSkillEdits } = require('../arc-remind/main');
+    makeSkill('arc-x');
+    recordSkillEdit('skills/arc-x/SKILL.md', root);
+    recordSkillEdit(path.join(root, 'skills', 'arc-x', 'SKILL.md'), root); // same, absolute
+    assert.deepStrictEqual(readSkillEdits(), [path.join(root, 'skills', 'arc-x', 'SKILL.md')]);
+    makeSkill('arc-y');
+    recordSkillEdit('skills/arc-y/SKILL.md', root);
+    assert.strictEqual(readSkillEdits().length, 2);
+  });
+
+  it('reads the benchmark time from latest.json `generated`', () => {
+    const { latestBenchmarkTime } = require('../arc-remind/main');
+    const iso = '2026-01-02T03:04:05.000Z';
+    writeBenchmark(JSON.stringify({ generated: iso }));
+    assert.strictEqual(latestBenchmarkTime(root), Date.parse(iso));
+  });
+
+  it('falls back to file mtime when latest.json is malformed', () => {
+    const { latestBenchmarkTime } = require('../arc-remind/main');
+    const file = writeBenchmark('{not json!!');
+    assert.strictEqual(latestBenchmarkTime(root), fs.statSync(file).mtimeMs);
+  });
+
+  it('falls back to file mtime when `generated` is missing or unparseable', () => {
+    const { latestBenchmarkTime } = require('../arc-remind/main');
+    let file = writeBenchmark(JSON.stringify({ evals: {} }));
+    assert.strictEqual(latestBenchmarkTime(root), fs.statSync(file).mtimeMs);
+    file = writeBenchmark(JSON.stringify({ generated: 'soon' }));
+    assert.strictEqual(latestBenchmarkTime(root), fs.statSync(file).mtimeMs);
+  });
+
+  it('returns null benchmark time when latest.json does not exist', () => {
+    const { latestBenchmarkTime } = require('../arc-remind/main');
+    assert.strictEqual(latestBenchmarkTime(root), null);
+  });
+
+  it('degrades byte-identically to the generic nudge when latest.json is missing', () => {
+    const { buildEvalShipNudge, evalBeforeShipNudge, recordSkillEdit } =
+      require('../arc-remind/main');
+    makeSkill('arc-x');
+    recordSkillEdit('skills/arc-x/SKILL.md', root);
+    assert.strictEqual(buildEvalShipNudge(root), evalBeforeShipNudge());
+  });
+
+  it('degrades byte-identically when no recorded skill edit is datable', () => {
+    const { buildEvalShipNudge, evalBeforeShipNudge, recordSkillEdit } =
+      require('../arc-remind/main');
+    const file = makeSkill('arc-x');
+    recordSkillEdit('skills/arc-x/SKILL.md', root);
+    fs.rmSync(file); // deleted since the edit — nothing to date the edit by
+    writeBenchmark(JSON.stringify({ generated: new Date().toISOString() }));
+    assert.strictEqual(buildEvalShipNudge(root), evalBeforeShipNudge());
+  });
+
+  it('says no newer eval result exists when the benchmark predates the edit', () => {
+    const { buildEvalShipNudge, evalBeforeShipNudge, recordSkillEdit } =
+      require('../arc-remind/main');
+    makeSkill('arc-x'); // mtime: now
+    recordSkillEdit('skills/arc-x/SKILL.md', root);
+    writeBenchmark(JSON.stringify({ generated: '2020-01-01T00:00:00.000Z' }));
+    const msg = buildEvalShipNudge(root);
+    assert.ok(msg.includes('No eval result newer'), 'should state staleness concretely');
+    assert.ok(msg.includes('arc-x'), 'should name the edited skill');
+    assert.ok(msg.includes('2020-01-01T00:00:00.000Z'), 'should cite the benchmark time');
+    assert.notStrictEqual(msg, evalBeforeShipNudge());
+  });
+
+  it('confirms fresh evidence when the benchmark postdates the edit', () => {
+    const { buildEvalShipNudge, recordSkillEdit } = require('../arc-remind/main');
+    const file = makeSkill('arc-x');
+    const past = new Date('2020-01-02T00:00:00.000Z');
+    fs.utimesSync(file, past, past); // edit predates the benchmark
+    recordSkillEdit('skills/arc-x/SKILL.md', root);
+    writeBenchmark(JSON.stringify({ generated: new Date().toISOString() }));
+    const msg = buildEvalShipNudge(root);
+    assert.ok(msg.includes('newer than your skill edit'), 'should confirm freshness');
+    assert.ok(msg.includes('arc-x'), 'should name the edited skill');
+  });
+
+  it('branches on mtime when latest.json is malformed', () => {
+    const { buildEvalShipNudge, recordSkillEdit } = require('../arc-remind/main');
+    makeSkill('arc-x'); // mtime: now
+    recordSkillEdit('skills/arc-x/SKILL.md', root);
+    const file = writeBenchmark('{not json!!');
+    const past = new Date('2020-01-01T00:00:00.000Z');
+    fs.utimesSync(file, past, past);
+    const msg = buildEvalShipNudge(root);
+    assert.ok(msg.includes('No eval result newer'), 'mtime fallback should report stale');
+  });
+
+  it('keeps the once-per-session limit through main() (e2e)', () => {
+    const { spawnSync } = require('node:child_process');
+    const script = path.join(__dirname, '..', 'arc-remind', 'main.js');
+    const sessionId = process.env.CLAUDE_SESSION_ID;
+    makeSkill('arc-x');
+    writeBenchmark(JSON.stringify({ generated: '2020-01-01T00:00:00.000Z' }));
+
+    function run(toolName, toolInput) {
+      const input = {
+        session_id: sessionId,
+        cwd: root,
+        hook_event_name: 'PostToolUse',
+        tool_name: toolName,
+        tool_input: toolInput,
+      };
+      const r = spawnSync('node', [script], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+        timeout: 15000,
+      });
+      return r.stdout || '';
+    }
+
+    try {
+      const editOut = run('Edit', { file_path: 'skills/arc-x/SKILL.md' });
+      assert.strictEqual(editOut, '', 'skill edit alone should not nudge');
+      const firstShip = run('Bash', { command: 'git commit -m x' });
+      assert.ok(firstShip.includes('No eval result newer'), 'first ship should nudge with stale');
+      const secondShip = run('Bash', { command: 'git commit -m y' });
+      assert.strictEqual(secondShip, '', 'second ship should be rate-limited');
+    } finally {
+      for (const f of fs.readdirSync(os.tmpdir())) {
+        if (f.includes(sessionId)) fs.rmSync(path.join(os.tmpdir(), f), { force: true });
+      }
+    }
+  });
+});

--- a/hooks/arc-remind/README.md
+++ b/hooks/arc-remind/README.md
@@ -11,12 +11,27 @@ Dispatches by tool; emits a user-facing `systemMessage` for these triggers:
 |---------|------|-------|
 | `gh pr create` / `gh pr merge` | Bash | verify (`arc-verifying`) + review (`arc-requesting-review`); notes whether a test ran this session |
 | `git worktree add` in an arcforge project (`specs/`) | Bash | prefer `arcforge expand` for epic worktrees (`arc-using-worktrees`) |
-| `git commit` / `push` after a SKILL.md edit (once/session) | Bash + Edit/Write | re-run the eval before shipping (`arc-writing-skills` Iron Law) |
+| `git commit` / `push` after a SKILL.md edit (once/session) | Bash + Edit/Write | freshness-aware eval-before-ship: compares `evals/benchmarks/latest.json` against the session's SKILL.md edits (`arc-writing-skills` Iron Law) |
 | first code (non-doc) edit on `main`/`master` (once/session) | Edit/Write | prefer a branch / epic worktree for feature work (`arc-executing-tasks`) |
 
 The last one is the shippable, user-facing half of eval-before-ship; the
 `ci.yml` annotation is the arcforge-repo half (the plugin is disabled here).
-Edit/Write events are observed only to track that a `SKILL.md` was edited.
+Edit/Write events are observed only to track which `SKILL.md` files were edited.
+
+## Eval-before-ship freshness
+
+The ship-a-skill nudge is evidence-based, not a slogan. At commit/push time it
+compares the mtime of the SKILL.md files edited this session against
+`evals/benchmarks/latest.json` (the `generated` ISO timestamp; file mtime when
+the JSON is malformed). Three branches:
+
+| Evidence | Message |
+|----------|---------|
+| no `latest.json` (or no datable edit) | the generic Iron Law nudge — identical to the pre-freshness behavior |
+| benchmark older than the last skill edit | stale: "no eval result newer than your skill edit exists", naming the edited skills |
+| benchmark newer than the last skill edit | fresh: evidence postdates the edit; confirm it covers the edited skills |
+
+Still once per session, still a user-facing `systemMessage`.
 
 ## Why the PR boundary
 
@@ -36,6 +51,8 @@ ever reminds.
 ## State
 
 Tracks a per-session `arc-remind-test-seen` counter (incremented when a test
-runner command is seen) so the reminder can note when no verification ran.
+runner command is seen) so the reminder can note when no verification ran, and
+a hook-local per-session JSON list of the SKILL.md paths edited this session
+(feeding the freshness comparison above).
 
 See `docs/plans/hook-hardening-design.md` for the full tier analysis.

--- a/hooks/arc-remind/main.js
+++ b/hooks/arc-remind/main.js
@@ -16,14 +16,17 @@
  *   worktree add  `git worktree add` in an arcforge project -> prefer `arcforge
  *                                            expand` for epic worktrees
  *   ship a skill  `git commit`/`push` after editing a SKILL.md (once/session)
- *                                         -> re-run the eval (arc-writing-skills
- *                                            Iron Law)
+ *                                         -> freshness-aware eval nudge: compares
+ *                                            evals/benchmarks/latest.json (`generated`,
+ *                                            mtime fallback) against the session's
+ *                                            SKILL.md edits (arc-writing-skills Iron Law)
  *   SDD stage     write `specs/<id>/spec.xml` while its `dag.yaml` is missing
  *                                         -> plan next (arc-planning); once/spec-id
  *   edit on main  first code edit on main/master (once/session) -> prefer a branch
  *
  * State: per-session counters (test-seen, skill-edited, skill-ship-warned,
- * main-warned, spec-planned-<id>) so nudges stay rare and context-aware.
+ * main-warned, spec-planned-<id>) plus a hook-local record of the SKILL.md
+ * paths edited this session, so nudges stay rare and context-aware.
  */
 
 const fs = require('node:fs');
@@ -34,6 +37,8 @@ const {
   setSessionIdFromInput,
   output,
   createSessionCounter,
+  getTempDir,
+  getSessionId,
 } = require('../../scripts/lib/utils');
 
 // Common test runners — broad enough to catch the usual suspects, scoped to avoid noise.
@@ -156,6 +161,117 @@ function evalBeforeShipNudge() {
   );
 }
 
+// ── Freshness-aware eval-before-ship ─────────────────────────────────────────
+// Hook-local session state (this hook is the only consumer of a path list, so
+// it stays here rather than growing the shared utils.js API): a JSON array of
+// the SKILL.md paths edited this session, stored beside the session counters.
+
+/** Path of the hook-local session state file recording edited SKILL.md paths. */
+function skillEditStatePath() {
+  return path.join(getTempDir(), `arcforge-arc-remind-skill-paths-${getSessionId()}`);
+}
+
+/** Record a SKILL.md edit for this session (absolute path, deduped). */
+function recordSkillEdit(filePath, cwd) {
+  try {
+    const abs = path.resolve(cwd, filePath);
+    const paths = readSkillEdits();
+    if (!paths.includes(abs)) {
+      paths.push(abs);
+      fs.writeFileSync(skillEditStatePath(), JSON.stringify(paths));
+    }
+  } catch {
+    // Non-blocking — the nudge degrades to its generic form without this state.
+  }
+}
+
+/** The SKILL.md paths recorded this session ([] when none or unreadable). */
+function readSkillEdits() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(skillEditStatePath(), 'utf8'));
+    return Array.isArray(parsed) ? parsed.filter((p) => typeof p === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Timestamp (ms) of the latest benchmark evidence in cwd, or null when none
+ * exists. Prefers latest.json's `generated` ISO field (written by the eval
+ * engine); falls back to file mtime when the JSON is malformed or `generated`
+ * is missing/unparseable.
+ */
+function latestBenchmarkTime(cwd) {
+  try {
+    const file = path.join(cwd, 'evals', 'benchmarks', 'latest.json');
+    if (!fs.existsSync(file)) return null;
+    let generated = NaN;
+    try {
+      generated = Date.parse(JSON.parse(fs.readFileSync(file, 'utf8')).generated);
+    } catch {
+      // Malformed JSON — fall through to the mtime fallback.
+    }
+    return Number.isFinite(generated) ? generated : fs.statSync(file).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/** Latest mtime (ms) across the recorded SKILL.md paths, or null when none stat. */
+function lastSkillEditTime(paths) {
+  let latest = null;
+  for (const p of paths) {
+    try {
+      const t = fs.statSync(p).mtimeMs;
+      if (latest === null || t > latest) latest = t;
+    } catch {
+      // Deleted since the edit — skip.
+    }
+  }
+  return latest;
+}
+
+/** Skill names (the SKILL.md's parent directory) for the recorded edit paths. */
+function skillNamesFromPaths(paths) {
+  return [...new Set(paths.map((p) => path.basename(path.dirname(p))))];
+}
+
+function staleEvalNudge(skillNames, benchTime) {
+  return (
+    `\n🧪 You edited ${skillNames} this session and are committing. No eval result newer ` +
+    `than your skill edit exists — evals/benchmarks/latest.json was generated ` +
+    `${new Date(benchTime).toISOString()}, before the edit. arc-writing-skills’ Iron Law: ` +
+    're-run the skill’s eval (RED → GREEN → REFACTOR) before shipping a behavioral change.\n'
+  );
+}
+
+function freshEvalNudge(skillNames, benchTime) {
+  return (
+    `\n🧪 You edited ${skillNames} this session and are committing. ` +
+    `evals/benchmarks/latest.json (generated ${new Date(benchTime).toISOString()}) is newer ` +
+    `than your skill edit — fresh eval evidence exists. Confirm it covers ${skillNames} ` +
+    'before shipping.\n'
+  );
+}
+
+/**
+ * Freshness-aware eval-before-ship nudge. Three branches:
+ *   no benchmark / no datable edit -> the generic Iron Law nudge (byte-identical
+ *                                     to the pre-freshness behavior)
+ *   benchmark older than the last SKILL.md edit -> stale: says concretely that
+ *                                     no eval result newer than the edit exists
+ *   benchmark strictly newer       -> fresh: evidence postdates the edit
+ */
+function buildEvalShipNudge(cwd) {
+  const edits = readSkillEdits();
+  const editTime = lastSkillEditTime(edits);
+  const benchTime = latestBenchmarkTime(cwd);
+  if (benchTime === null || editTime === null) return evalBeforeShipNudge();
+  const names = skillNamesFromPaths(edits).join(', ');
+  if (benchTime > editTime) return freshEvalNudge(names, benchTime);
+  return staleEvalNudge(names, benchTime);
+}
+
 function planAfterSpecNudge(specId) {
   return (
     `\n📐 \`specs/${specId}/spec.xml\` is written but there's no \`dag.yaml\` yet. ` +
@@ -183,7 +299,10 @@ function main() {
     if (tool === 'Edit' || tool === 'Write') {
       const filePath = input.tool_input?.file_path || '';
       const cwd = input.cwd || process.cwd();
-      if (isSkillFile(filePath)) bump('arc-remind-skill-edited');
+      if (isSkillFile(filePath)) {
+        bump('arc-remind-skill-edited');
+        recordSkillEdit(filePath, cwd);
+      }
 
       // SDD stage nudge: spec.xml written but its dag.yaml is missing -> plan next.
       // Once per spec-id (spec.xml is written across several edits).
@@ -236,7 +355,7 @@ function main() {
       counter('arc-remind-skill-ship-warned').read() === 0
     ) {
       bump('arc-remind-skill-ship-warned');
-      output({ systemMessage: evalBeforeShipNudge() });
+      output({ systemMessage: buildEvalShipNudge(cwd) });
     }
   } catch {
     // Non-blocking — never crash the session.
@@ -258,6 +377,15 @@ module.exports = {
   buildReminder,
   worktreeAddNudge,
   evalBeforeShipNudge,
+  skillEditStatePath,
+  recordSkillEdit,
+  readSkillEdits,
+  latestBenchmarkTime,
+  lastSkillEditTime,
+  skillNamesFromPaths,
+  staleEvalNudge,
+  freshEvalNudge,
+  buildEvalShipNudge,
   mainBranchNudge,
   planAfterSpecNudge,
   TEST_CMD_RE,


### PR DESCRIPTION
Wave 1 (PR-1j). Deterministic backstop for the Iron Law: edit a SKILL.md without re-running its benchmark and arc-remind tells you.

## What
- arc-remind compares evals/benchmarks/latest.json mtime against the session's SKILL.md edits; nudges (user-audience systemMessage) when the benchmark is stale — "fresh" = benchmark strictly newer than the last SKILL.md edit (matches AF-14's gate wording; equal timestamps count as stale)
- Hook-local state via existing getTempDir()/getSessionId() utils (read-only reuse — no shared-API change, stop condition not triggered)
- Tests in hooks/__tests__ (replayed: approve)