### PR TITLE
fix(cli): finishing-epic real branch names + conflict abort in base checkout (WT-4, WT-5)

### DIFF
--- a/hooks/__tests__/arc-guard.test.js
+++ b/hooks/__tests__/arc-guard.test.js
@@ -101,6 +101,53 @@ describe('arc-guard evaluate', () => {
     }
   });
 
+  // WT-5: arc-finishing-epic's conflict recovery now runs `finish-epic.js merge
+  // --abort`, which the coordinator executes against the BASE worktree via
+  // `git -C <base> merge --abort` (execFileSync, not the Bash tool — so it never
+  // reaches this hook in production). These two cases pin the regex so that even
+  // if such a command were typed into the Bash tool from a worktree, the `-C
+  // <path>` form of conflict-recovery is NOT matched (the --abort/--continue
+  // lookahead still applies through the `-C` operand).
+  it('does NOT block `git -C <base> merge --abort` (WT-5 conflict recovery)', () => {
+    const { GIT_MERGE_RE } = require('../arc-guard/main');
+    assert.strictEqual(
+      GIT_MERGE_RE.test('git -C /home/u/.arcforge/worktrees/proj-abc-base merge --abort'),
+      false,
+      'the -C form of conflict-recovery must not match GIT_MERGE_RE',
+    );
+    const { evaluate } = require('../arc-guard/main');
+    assert.strictEqual(
+      evaluate({
+        tool_name: 'Bash',
+        tool_input: { command: 'git -C /home/u/.arcforge/worktrees/proj-abc-base merge --abort' },
+        cwd: wt(),
+      }),
+      null,
+      'should allow `git -C <base> merge --abort` from a worktree',
+    );
+  });
+
+  it('does NOT block `git -C <base> merge --continue` (WT-5 conflict recovery)', () => {
+    const { GIT_MERGE_RE } = require('../arc-guard/main');
+    assert.strictEqual(
+      GIT_MERGE_RE.test('git -C /home/u/.arcforge/worktrees/proj-abc-base merge --continue'),
+      false,
+      'the -C form of --continue must not match GIT_MERGE_RE',
+    );
+    const { evaluate } = require('../arc-guard/main');
+    assert.strictEqual(
+      evaluate({
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git -C /home/u/.arcforge/worktrees/proj-abc-base merge --continue',
+        },
+        cwd: wt(),
+      }),
+      null,
+      'should allow `git -C <base> merge --continue` from a worktree',
+    );
+  });
+
   it('still blocks a real merge with flags (`git merge --no-ff main`)', () => {
     const { evaluate } = require('../arc-guard/main');
     assert.ok(

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -9,7 +9,7 @@
  *   block <task_id> <reason>        Mark task as blocked
  *   parallel                        Get parallelizable epics
  *   expand [--epic <id>] [--project-setup] [--verify] [--verify-cmd "..."]  Create worktrees
- *   merge [epic_ids...] [--base branch]     Merge epics to base
+ *   merge [epic_ids...] [--base branch] [--abort]  Merge epics to base (--abort recovers a conflict)
  *   cleanup [epic_ids...]           Remove worktrees for completed epics
  *   sync [--direction from-base|to-base|both|scan]  Sync state
  *   reboot                          Get context for new session

--- a/scripts/cli/dag-commands.js
+++ b/scripts/cli/dag-commands.js
@@ -114,6 +114,15 @@ function runExpand(args, { projectRoot, asJson, specFlag }) {
 function runMerge(args, { projectRoot, asJson, specFlag }) {
   const resolved = resolveMergeOrCleanupSpec(projectRoot, specFlag, args.positional, 'merge');
   const coord = new Coordinator(projectRoot, resolved);
+  // --abort: recover from a conflicted epic merge. The half-merged state lives
+  // in the BASE checkout (mergeEpics checks the base branch out there before
+  // merging), so abortMerge delegates to the base worktree and runs
+  // `git merge --abort` there — even when invoked from the epic worktree cwd.
+  if (args.flags.abort) {
+    const result = coord.abortMerge();
+    output(result, asJson);
+    return;
+  }
   const merged = coord.mergeEpics({
     baseBranch: args.options.base,
     epicIds: args.positional.length > 0 ? args.positional : undefined,

--- a/scripts/cli/help.js
+++ b/scripts/cli/help.js
@@ -45,10 +45,12 @@ COMMANDS:
       --verify         Run tests after creation
       --verify-cmd     Custom test command (default: auto-detect)
 
-  merge [epic_ids...] [--base branch] [--spec-id <id>]
+  merge [epic_ids...] [--base branch] [--abort] [--spec-id <id>]
       Merge completed epics to base branch. Without --spec-id, positional
       epic ids are reverse-looked-up across specs.
       --base           Target branch (default: current)
+      --abort          Abort an in-progress merge in the base checkout
+                       (conflict recovery; runs even from a worktree cwd)
 
   cleanup [epic_ids...] [--spec-id <id>]
       Remove worktrees for completed epics.

--- a/scripts/lib/coordinator-worktree-ops.js
+++ b/scripts/lib/coordinator-worktree-ops.js
@@ -257,6 +257,43 @@ module.exports = {
   },
 
   /**
+   * Abort an in-progress merge in the BASE checkout.
+   *
+   * A merge conflict during epic finishing leaves the BASE checkout (not the
+   * worktree) in a half-merged state — `mergeEpics` checks out the base branch
+   * in the base worktree before merging, so the unmerged index lives there. The
+   * agent that hit the conflict is in the epic worktree, so this method finds the
+   * base worktree (same delegation as mergeEpics) and runs `git merge --abort`
+   * there, returning the base to a clean state on its current branch.
+   *
+   * Idempotent-friendly: if there is no merge to abort, git's `MERGE_HEAD`
+   * check yields exit 128; we surface that as a no-op result rather than a
+   * throw, so calling --abort when already clean is safe.
+   *
+   * @returns {{ aborted: boolean, base: string }} aborted=false when there was
+   *   no merge in progress
+   */
+  abortMerge() {
+    const basePath = this._findBaseWorktree();
+    if (!basePath) {
+      throw new Error('Base worktree not found via git worktree list');
+    }
+
+    const result = this._runGit(['merge', '--abort'], basePath);
+    if (result.exitCode === 0) {
+      return { aborted: true, base: basePath };
+    }
+
+    // `git merge --abort` exits non-zero (128) when there is no merge to abort
+    // ("fatal: There is no merge to abort"). That is the no-op case, not an
+    // error — report it as such. Any other failure is a real git error.
+    if (/no merge to abort/i.test(result.stderr)) {
+      return { aborted: false, base: basePath };
+    }
+    throw new Error(`Failed to abort merge in ${basePath}: ${result.stderr.trim()}`);
+  },
+
+  /**
    * Clean up worktrees for completed epics
    * @param {Object} options - Cleanup options
    * @param {string[]} [options.epicIds] - Specific epic IDs to clean

--- a/skills/arc-finishing-epic/SKILL.md
+++ b/skills/arc-finishing-epic/SKILL.md
@@ -93,25 +93,49 @@ Which option?
 
 #### Option 1: Merge Locally
 
+**Migrate before you destroy.** Capture the epic branch and base path while you
+are still inside the worktree, merge the epic out, then move to the base
+checkout *before* cleaning up — running cleanup or `git branch -d` from the
+worktree is a silent no-op (the worktree's local dag carries `worktree: null`),
+and you cannot delete a worktree you are standing inside.
+
 **Use coordinator merge (NOT git merge directly):**
 
 ```bash
-# Merge via coordinator (auto-detects epic + base)
+# Capture the live epic branch (the engine names it <spec-id>/<epic-id>) and the
+# base worktree path from the marker — BEFORE anything is removed.
+EPIC_BRANCH="$(git branch --show-current)"
+BASE_WORKTREE="$(grep '^base_worktree:' .arcforge-epic | sed 's/^base_worktree:[[:space:]]*//')"
+
+# Merge via coordinator (auto-detects epic + base). Safe to run from the worktree.
 node "${SKILL_ROOT}/scripts/finish-epic.js" merge
 
-# Clean up merged worktrees
+# Move to the base checkout so cleanup, status, and branch -d all act on the
+# base dag and you are not standing in the directory about to be removed.
+cd "$BASE_WORKTREE"
+
+# Clean up merged worktrees (delegates to base; removes the epic worktree).
 node "${SKILL_ROOT}/scripts/finish-epic.js" cleanup
+
+# Look up the (now null) path for the completion format, then delete the merged
+# branch. `-d` is the honest, safe delete — it refuses if the branch was not
+# fully merged, which is exactly the guard you want.
+node "${SKILL_ROOT}/scripts/finish-epic.js" status --json
+git branch -d "$EPIC_BRANCH"
 ```
 
 **If the merge produces a conflict** (coordinator returns non-zero, or `git status` shows unmerged paths), STOP before resolving. Go to **Step 4.1: Merge Conflict Handling** below. Do NOT auto-resolve, hand-edit conflict markers, or retry blindly.
 
-Report completion format when done.
+**If `git branch -d` refuses** ("not fully merged"), STOP — do NOT force with `-D`. A refusal means the merge did not actually land; investigate before destroying the branch.
+
+Report completion format when done — and only claim the branch is deleted after `git branch -d` actually succeeded.
 
 #### Option 2: Push and Create PR
 
 ```bash
-# Push branch
-git push -u origin <epic-name>
+# Push the current epic branch (engine names it <spec-id>/<epic-id>)
+EPIC_BRANCH="$(git branch --show-current)"
+git push -u origin "$EPIC_BRANCH"
 
 # Create PR
 gh pr create --title "feat: <Epic Title>" --body "$(cat <<'EOF'
@@ -129,12 +153,15 @@ Keep worktree until PR merged.
 #### Option 3: Keep As-Is
 
 ```bash
+# Resolve the current epic branch (engine names it <spec-id>/<epic-id>)
+EPIC_BRANCH="$(git branch --show-current)"
+
 # Push for backup
-git push -u origin <epic-name>
+git push -u origin "$EPIC_BRANCH"
 
 # Tag completion state
-git tag -a epic/<epic-name>-complete -m "Epic complete, all tests pass"
-git push origin epic/<epic-name>-complete
+git tag -a "epic/${EPIC_BRANCH}-complete" -m "Epic complete, all tests pass"
+git push origin "epic/${EPIC_BRANCH}-complete"
 ```
 
 Report: "Keeping epic <name>. Worktree preserved."
@@ -155,32 +182,57 @@ Wait for exact confirmation.
 
 If confirmed:
 ```bash
+# Capture identifiers from the marker BEFORE destroying anything. `block` and
+# `cleanup` take the epic *id*; `git branch -D` takes the live branch name
+# (engine: <spec-id>/<epic-id>); cleanup + branch -D must run from the base.
+EPIC_ID="$(grep '^epic:' .arcforge-epic | sed 's/^epic:[[:space:]]*//')"
+EPIC_BRANCH="$(git branch --show-current)"
+BASE_WORKTREE="$(grep '^base_worktree:' .arcforge-epic | sed 's/^base_worktree:[[:space:]]*//')"
+
 # Update DAG and sync BEFORE destroying the worktree.
 # The per-spec dag.yaml lives in the base worktree (specs/<spec-id>/dag.yaml);
 # the current worktree carries only the .arcforge-epic marker, which the
 # coordinator uses to reconnect to that dag and push local status back.
 if [ -f .arcforge-epic ]; then
-  node "${SKILL_ROOT}/scripts/finish-epic.js" block <epic-name> "Cancelled by user"
+  node "${SKILL_ROOT}/scripts/finish-epic.js" block "$EPIC_ID" "Cancelled by user"
   node "${SKILL_ROOT}/scripts/finish-epic.js" sync --direction to-base
 fi
+
+# Move to the base checkout before removing the worktree — you cannot delete a
+# worktree (or its branch) while standing inside it, and cleanup only acts on
+# the base dag.
+cd "$BASE_WORKTREE"
 
 # Delegate worktree removal to the coordinator — it derives the canonical
 # path via ${ARCFORGE_ROOT}/scripts/lib/worktree-paths.js and handles
 # force-remove of the .arcforge-epic marker. Never call `git worktree remove` by hand.
-node "${SKILL_ROOT}/scripts/finish-epic.js" cleanup <epic-name>
-git branch -D <epic-name>
+node "${SKILL_ROOT}/scripts/finish-epic.js" cleanup "$EPIC_ID"
+git branch -D "$EPIC_BRANCH"
 ```
 
 ### Step 4.1: Merge Conflict Handling (Option 1 only)
 
 A merge conflict during epic finishing means another change has landed on the base branch since your epic started. In a multi-teammate dispatch (epics dispatched via `arc-dispatching-teammates`), the conflict typically comes from another teammate's already-merged epic touching a shared file.
 
-**First, always abort to a clean state.** Do not leave a half-merged worktree:
+**First, always abort to a clean state.** The half-merged state lives in the
+**base checkout**, not your worktree — the coordinator checks the base branch
+out in the base worktree before merging. So abort through the coordinator, which
+finds the base worktree and runs the abort there even though you are in the
+epic worktree:
 
 ```bash
-git merge --abort
-git status  # expect: clean working tree on epic branch
+node "${SKILL_ROOT}/scripts/finish-epic.js" merge --abort
+
+# Verify the BASE working tree is clean again — the abort happened there, so
+# check git's working-tree state in the base, not the DAG. `git -C` keeps you in
+# the worktree while inspecting the base; expect no unmerged paths.
+BASE_WORKTREE="$(grep '^base_worktree:' .arcforge-epic | sed 's/^base_worktree:[[:space:]]*//')"
+git -C "$BASE_WORKTREE" status   # expect: no "Unmerged paths", base on its branch
 ```
+
+Do NOT run a bare `git merge --abort` from the worktree — your worktree is on
+the epic branch and has no merge in progress, so it would be a silent no-op
+while the base stays half-merged.
 
 **Then decide based on context:**
 
@@ -215,10 +267,27 @@ node "${SKILL_ROOT}/scripts/finish-epic.js" sync --direction to-base
 
 Before emitting the completion format, query the coordinator for the epic's
 absolute worktree path — don't reconstruct it from pattern knowledge, because
-the derivation rule can change and the cached value is authoritative:
+the derivation rule can change and the cached value is authoritative.
+
+**Always query `status --json` against the BASE dag, never the worktree's local
+copy.** A worktree's own dag copy carries `worktree: null` for every epic, so
+`status --json` run from a worktree cwd reports `path: null` even when the
+worktree is alive — which would wrongly print a null path for the kept-worktree
+options. Only the base dag holds the real `worktree`/`path` value.
 
 ```bash
+# Options 1 and 4: you already ran `cd "$BASE_WORKTREE"`, so the base dag is the
+# current cwd — query it directly.
 node "${SKILL_ROOT}/scripts/finish-epic.js" status --json
+
+# Options 2 and 3: the worktree is kept, so you are still inside it. Resolve the
+# base AND the spec id from the marker, then query the base dag in a subshell
+# (keeps you in the worktree for later steps). Pass --spec-id: the base has no
+# marker to pin the spec, so without it a multi-spec base returns the nested
+# `{ specs: { <id>: ... } }` shape instead of a flat `{ epics: [...] }`.
+SPEC_ID="$(grep '^spec_id:' .arcforge-epic | sed 's/^spec_id:[[:space:]]*//')"
+BASE_WORKTREE="$(grep '^base_worktree:' .arcforge-epic | sed 's/^base_worktree:[[:space:]]*//')"
+( cd "$BASE_WORKTREE" && node "${SKILL_ROOT}/scripts/finish-epic.js" status --json --spec-id "$SPEC_ID" )
 ```
 
 Extract the epic's `worktree` / `path` field from the JSON. Use that literal

--- a/tests/scripts/coordinator-abort-merge.test.js
+++ b/tests/scripts/coordinator-abort-merge.test.js
@@ -1,0 +1,140 @@
+/**
+ * Coordinator.abortMerge — conflict recovery in the BASE checkout (WT-5).
+ *
+ * When an epic merge conflicts, the half-merged state lives in the BASE
+ * worktree (mergeEpics checks the base branch out there before merging). The
+ * agent that hit the conflict is in the epic worktree, so abortMerge must find
+ * the base worktree (same delegation as mergeEpics) and run `git merge --abort`
+ * THERE — leaving the base clean — even when invoked from the worktree cwd.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const { Coordinator } = require('../../scripts/lib/coordinator');
+const { getWorktreePath } = require('../../scripts/lib/worktree-paths');
+const {
+  runGit,
+  setupRepo,
+  cleanupWorktrees,
+  DEFAULT_SPEC_ID,
+} = require('./coordinator-test-helpers');
+
+const FINISH_EPIC = path.resolve(
+  __dirname,
+  '../../skills/arc-finishing-epic/scripts/finish-epic.js',
+);
+
+function runCli(args, cwd, home) {
+  try {
+    const stdout = execFileSync('node', [FINISH_EPIC, ...args], {
+      cwd,
+      env: { ...process.env, HOME: home, CLAUDE_PROJECT_DIR: cwd },
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || err.message,
+      exitCode: err.status || 1,
+    };
+  }
+}
+
+// True when the working tree at `dir` has an in-progress merge (MERGE_HEAD).
+function hasMergeInProgress(dir) {
+  const gitDir = runGit(['rev-parse', '--git-dir'], dir).trim();
+  return fs.existsSync(path.join(dir, gitDir, 'MERGE_HEAD'));
+}
+
+describe('Coordinator.abortMerge — base-checkout conflict recovery', () => {
+  const originalHome = process.env.HOME;
+  let testHome;
+  let root;
+  let worktreePath;
+
+  beforeEach(() => {
+    const realTmp = fs.realpathSync(os.tmpdir());
+    testHome = fs.mkdtempSync(path.join(realTmp, 'abort-home-'));
+    process.env.HOME = testHome;
+    jest.spyOn(os, 'homedir').mockReturnValue(testHome);
+    root = fs.realpathSync(setupRepo({ prefix: 'abort-repo-' }));
+    runGit(['add', '.'], root);
+    runGit(['commit', '-q', '-m', 'chore: add dag'], root);
+
+    // Expand epic-a to a real worktree + marker.
+    new Coordinator(root, DEFAULT_SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+    worktreePath = getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a');
+
+    // Create a guaranteed conflict on shared.txt: epic edits it one way…
+    fs.writeFileSync(path.join(worktreePath, 'shared.txt'), 'epic side\n');
+    runGit(['add', 'shared.txt'], worktreePath);
+    runGit(['commit', '-q', '-m', 'feat: epic edits shared'], worktreePath);
+    // …and base edits the same line the other way.
+    fs.writeFileSync(path.join(root, 'shared.txt'), 'base side\n');
+    runGit(['add', 'shared.txt'], root);
+    runGit(['commit', '-q', '-m', 'chore: base edits shared'], root);
+    // Mark epic-a completed so a bare mergeEpics() picks it up.
+    new Coordinator(root, DEFAULT_SPEC_ID).completeTask('epic-a');
+  });
+
+  afterEach(() => {
+    cleanupWorktrees(root);
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(testHome, { recursive: true, force: true });
+    process.env.HOME = originalHome;
+    jest.restoreAllMocks();
+  });
+
+  test('a conflicting merge leaves the BASE half-merged, and abortMerge from the worktree cleans it', () => {
+    // Merge from the base coordinator — it conflicts on shared.txt.
+    expect(() =>
+      new Coordinator(root, DEFAULT_SPEC_ID).mergeEpics({ epicIds: ['epic-a'] }),
+    ).toThrow(/Failed to merge epic-a/);
+
+    // The half-merged state is in the BASE checkout, not the worktree.
+    expect(hasMergeInProgress(root)).toBe(true);
+
+    // Abort via a WORKTREE-cwd coordinator (the agent is in the worktree). It
+    // must delegate to the base and clean it.
+    const result = new Coordinator(worktreePath, DEFAULT_SPEC_ID).abortMerge();
+    expect(result.aborted).toBe(true);
+    expect(result.base).toBe(root);
+
+    // Base is clean again: no merge in progress and the conflicted file is
+    // restored to base's version with no unmerged-path markers. (The dag.yaml
+    // edit from completeTask is a pre-existing uncommitted change, unrelated to
+    // the merge, so we assert on the conflicted file specifically.)
+    expect(hasMergeInProgress(root)).toBe(false);
+    const status = runGit(['status', '--porcelain', 'shared.txt'], root).trim();
+    expect(status).toBe('');
+    expect(fs.readFileSync(path.join(root, 'shared.txt'), 'utf8')).toBe('base side\n');
+  });
+
+  test('abortMerge is a safe no-op when there is no merge in progress', () => {
+    // No merge started — abort should report aborted:false, not throw.
+    const result = new Coordinator(worktreePath, DEFAULT_SPEC_ID).abortMerge();
+    expect(result.aborted).toBe(false);
+    expect(result.base).toBe(root);
+    expect(hasMergeInProgress(root)).toBe(false);
+  });
+
+  test('CLI `finish-epic.js merge --abort` from the worktree cleans the base', () => {
+    // Drive the conflict, then abort via the CLI flag (the dag-commands hunk).
+    expect(() =>
+      new Coordinator(root, DEFAULT_SPEC_ID).mergeEpics({ epicIds: ['epic-a'] }),
+    ).toThrow();
+    expect(hasMergeInProgress(root)).toBe(true);
+
+    const out = runCli(['merge', '--abort', '--json'], worktreePath, testHome);
+    expect(out.exitCode).toBe(0);
+    const json = JSON.parse(out.stdout);
+    expect(json.aborted).toBe(true);
+    expect(json.base).toBe(root);
+    expect(hasMergeInProgress(root)).toBe(false);
+  });
+});

--- a/tests/scripts/finishing-epic-skill-sequence.test.js
+++ b/tests/scripts/finishing-epic-skill-sequence.test.js
@@ -1,0 +1,146 @@
+/**
+ * WT-4 / WT-5 — arc-finishing-epic skill command sequence, executed VERBATIM
+ * with cwd=worktree (not by calling Coordinator methods from base).
+ *
+ * Why a CLI-subprocess fixture instead of in-process Coordinator calls: the
+ * skill instructs the agent to run `finish-epic.js merge` / `cleanup` /
+ * `git branch -d` from inside the epic worktree. Calling the coordinator
+ * methods directly from a base-cwd Coordinator masks the very seam these
+ * tests pin — that cleanup/branch-d must move to the base first, and that the
+ * branch delete is the honest `-d`. So this fixture shells out to the real
+ * CLI at the exact cwd the skill prescribes.
+ *
+ * HOME isolation: env.HOME is overridden for every CLI subprocess so canonical
+ * worktree paths derive under a temp HOME, never the real ~/.arcforge.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const { getWorktreePath, getEpicBranchName } = require('../../scripts/lib/worktree-paths');
+const {
+  runGit,
+  setupRepo,
+  readDagFromDisk,
+  DEFAULT_SPEC_ID,
+} = require('./coordinator-test-helpers');
+
+// The skill invokes `node .../scripts/finish-epic.js <cmd>`; finish-epic.js is a
+// thin shim that requires cli.js. Run the shim to exercise the exact entry point.
+const FINISH_EPIC = path.resolve(
+  __dirname,
+  '../../skills/arc-finishing-epic/scripts/finish-epic.js',
+);
+
+function run(bin, args, cwd, env = {}) {
+  try {
+    const stdout = execFileSync(bin, args, {
+      cwd,
+      env: { ...process.env, HOME: env.HOME, CLAUDE_PROJECT_DIR: cwd, ...env },
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || err.message,
+      exitCode: err.status || 1,
+    };
+  }
+}
+
+describe('arc-finishing-epic Option 1 — verbatim skill sequence (cwd=worktree)', () => {
+  const originalHome = process.env.HOME;
+  let testHome;
+  let root;
+  let worktreePath;
+  let epicBranch;
+
+  beforeEach(() => {
+    const realTmp = fs.realpathSync(os.tmpdir());
+    testHome = fs.mkdtempSync(path.join(realTmp, 'fe-home-'));
+    // env.HOME covers CLI subprocesses; the os.homedir() spy covers in-process
+    // path derivation (Jest sandboxes process.env, so mutating it does not reach
+    // os.homedir()). Same dual override as worktree-generic.test.js.
+    process.env.HOME = testHome;
+    jest.spyOn(os, 'homedir').mockReturnValue(testHome);
+    root = fs.realpathSync(setupRepo({ prefix: 'fe-repo-' }));
+    // Commit the dag so the epic worktree carries its own local copy.
+    runGit(['add', '.'], root);
+    runGit(['commit', '-q', '-m', 'chore: add dag'], root);
+
+    // Expand epic-a → real worktree + .arcforge-epic marker, via the CLI so the
+    // marker's base_worktree / branch are exactly what production writes.
+    const expand = run('node', [FINISH_EPIC, 'expand', '--epic', 'epic-a'], root, {
+      HOME: testHome,
+    });
+    expect(expand.exitCode).toBe(0);
+
+    worktreePath = getWorktreePath(root, DEFAULT_SPEC_ID, 'epic-a');
+    epicBranch = getEpicBranchName(DEFAULT_SPEC_ID, 'epic-a');
+    expect(fs.existsSync(worktreePath)).toBe(true);
+
+    // Add a real commit on the epic branch so the merge produces a merge commit
+    // and `git branch -d` (which refuses unmerged branches) can succeed.
+    fs.writeFileSync(path.join(worktreePath, 'feature.txt'), 'epic-a work\n');
+    runGit(['add', 'feature.txt'], worktreePath);
+    runGit(['commit', '-q', '-m', 'feat: epic-a feature'], worktreePath);
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(worktreePath)) fs.rmSync(worktreePath, { recursive: true, force: true });
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(testHome, { recursive: true, force: true });
+    process.env.HOME = originalHome;
+    jest.restoreAllMocks();
+  });
+
+  test('merge (worktree cwd) → cd base → cleanup → branch -d, honest delete succeeds', () => {
+    // 1. Capture identifiers from the marker while still in the worktree
+    //    (mirrors EPIC_BRANCH / BASE_WORKTREE in the skill's Option 1).
+    const marker = fs.readFileSync(path.join(worktreePath, '.arcforge-epic'), 'utf8');
+    const baseFromMarker = marker.match(/^base_worktree:\s*(.+)$/m)[1].trim();
+    expect(baseFromMarker).toBe(root);
+    const branchInWorktree = runGit(['branch', '--show-current'], worktreePath).trim();
+    expect(branchInWorktree).toBe(epicBranch);
+
+    // 2. Merge from the WORKTREE cwd (the skill runs it here; coordinator
+    //    delegates to base internally).
+    const merge = run('node', [FINISH_EPIC, 'merge'], worktreePath, { HOME: testHome });
+    expect(merge.exitCode).toBe(0);
+
+    // 3. Cleanup from the BASE cwd (after cd "$BASE_WORKTREE").
+    const cleanup = run('node', [FINISH_EPIC, 'cleanup', '--json'], baseFromMarker, {
+      HOME: testHome,
+    });
+    expect(cleanup.exitCode).toBe(0);
+    const cleanupJson = JSON.parse(cleanup.stdout);
+    expect(cleanupJson.removed).toBe(1);
+    expect(fs.existsSync(worktreePath)).toBe(false);
+
+    // 4. Honest branch delete from the BASE cwd — `-d` succeeds because the
+    //    branch was actually merged.
+    const del = run('git', ['branch', '-d', epicBranch], baseFromMarker, { HOME: testHome });
+    expect(del.exitCode).toBe(0);
+
+    // Final state: epic completed in base dag, worktree gone, branch gone.
+    const dag = readDagFromDisk(root);
+    expect(dag.epics.find((e) => e.id === 'epic-a').status).toBe('completed');
+    expect(dag.epics.find((e) => e.id === 'epic-a').worktree).toBeNull();
+    const branches = runGit(['branch', '--list', epicBranch], root).trim();
+    expect(branches).toBe('');
+  });
+
+  test('the skill order (merge in worktree, cleanup from base) removes exactly one worktree', () => {
+    // Anchors that the verbatim sequence the skill prescribes — merge from the
+    // worktree, cd to base, then cleanup — is the correct, working order.
+    const merge = run('node', [FINISH_EPIC, 'merge'], worktreePath, { HOME: testHome });
+    expect(merge.exitCode).toBe(0);
+    const cleanup = run('node', [FINISH_EPIC, 'cleanup', '--json'], root, { HOME: testHome });
+    const json = JSON.parse(cleanup.stdout);
+    expect(json.removed).toBe(1);
+  });
+});

--- a/tests/skills/test_skill_arc_finishing_epic.py
+++ b/tests/skills/test_skill_arc_finishing_epic.py
@@ -65,3 +65,67 @@ def test_arc_finishing_epic_discard_uses_marker_guard():
     text = _read_skill()
     assert "if [ -f .arcforge-epic ]" in text
     assert "if [ -f dag.yaml ]" not in text
+
+
+def test_arc_finishing_epic_no_epic_name_git_operand():
+    """WT-4: `<epic-name>` is never used as a git operand.
+
+    The engine names epic branches `<spec-id>/<epic-id>`; the skill must
+    resolve the live branch (`git branch --show-current`) instead of pasting
+    a placeholder into a git command. Display placeholders in completion /
+    blocked formats are fine — only git operand uses are forbidden.
+    """
+    import re
+
+    text = _read_skill()
+    bad = re.compile(r"(?:git\b[^\n`]*|origin |branch -[dD] |push[^\n`]*|tag[^\n`]*)<epic-name>")
+    assert not bad.search(text), "<epic-name> must not appear as a git operand"
+    # Branch resolution is wired from the live worktree branch.
+    assert "git branch --show-current" in text
+
+
+def test_arc_finishing_epic_option1_migrate_before_destroy():
+    """WT-4: Option 1 reorders to merge → cd-to-base → cleanup → branch -d.
+
+    Cleanup and `git branch -d` must run from the base checkout (after `cd`),
+    never from the worktree (silent no-op + cannot delete the dir you stand in).
+    The branch delete is the honest `-d`, not a forced `-D`.
+    """
+    text = _read_skill()
+    # Capture base path, then cd to it before cleanup.
+    assert 'BASE_WORKTREE="$(grep' in text
+    assert 'cd "$BASE_WORKTREE"' in text
+    # Honest delete in Option 1 (full text guards against a silent switch to -D).
+    assert 'git branch -d "$EPIC_BRANCH"' in text
+
+
+def test_arc_finishing_epic_conflict_abort_via_coordinator():
+    """WT-5: conflict recovery aborts the BASE merge through the coordinator.
+
+    A bare `git merge --abort` from the worktree is a no-op (the half-merged
+    state lives in the base checkout). Step 4.1 must route the abort through
+    `finish-epic.js merge --abort`, which delegates to the base worktree.
+    """
+    text = _read_skill()
+    assert 'finish-epic.js" merge --abort' in text
+    # And it warns against the bare-git no-op trap.
+    assert "bare `git merge --abort`" in text
+
+
+def test_arc_finishing_epic_step46_resolves_path_from_base():
+    """WT-4: Step 4.6 queries the BASE dag, never the worktree's local copy.
+
+    A worktree's local dag carries `worktree: null` for every epic, so
+    `status --json` from a worktree cwd reports `path: null` — which would
+    print a null path for the kept-worktree options (2/3). The kept-options
+    branch must cd to the marker's base_worktree before querying.
+    """
+    text = _read_skill()
+    # Kept options resolve the base AND spec id, then query the base dag in a
+    # subshell. --spec-id forces the flat single-spec shape (a multi-spec base
+    # with no marker would otherwise return the nested { specs: {...} } shape).
+    assert "the BASE dag" in text
+    assert (
+        '( cd "$BASE_WORKTREE" && node "${SKILL_ROOT}/scripts/finish-epic.js"'
+        ' status --json --spec-id "$SPEC_ID" )'
+    ) in text


### PR DESCRIPTION
Wave 2 (PR-2b). WT-4: every <epic-name> git operand → current epic branch (engine branch <spec-id>/<epic-id>); Option 1/4 reordered migrate-before-destroy with cd-to-base BEFORE cleanup; fixture executes the skill command sequence verbatim with cwd=worktree (the old base-call Jest masked the seam). WT-5: new abortMerge() in coordinator-worktree-ops.js via _findBaseWorktree; cli.js merge --abort flag; SKILL.md Step 4.1 → finish-epic.js merge --abort + base cleanliness check; arc-guard regression tests pin that git -C ... merge --abort is NOT matched by GIT_MERGE_RE. cli.js merge-case hunk kept disjoint from SDD-6's new command. SKILL.md → eval WT-8.