### PR TITLE
feat(hooks): quality-check + arc-remind reach the model via RV-1 helper (RV-3, RV-5)

### DIFF
--- a/hooks/__tests__/arc-remind.test.js
+++ b/hooks/__tests__/arc-remind.test.js
@@ -367,3 +367,87 @@ describe('arc-remind freshness-aware eval-before-ship nudge', () => {
     }
   });
 });
+
+describe('arc-remind autopilot model channel (RV-5)', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const os = require('node:os');
+  const { spawnSync } = require('node:child_process');
+  const script = path.join(__dirname, '..', 'arc-remind', 'main.js');
+
+  let root;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../arc-remind/main')];
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-remind-rv5-'));
+  });
+
+  const { afterEach } = require('node:test');
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  // Each run uses a fresh session id so the per-session counters never collide.
+  function runPr(cwd) {
+    const sessionId = `rv5-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const r = spawnSync('node', [script], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        cwd,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'gh pr create --fill' },
+      }),
+      encoding: 'utf-8',
+      timeout: 15000,
+    });
+    return JSON.parse((r.stdout || '').trim());
+  }
+
+  function writeRunningSentinel(dir) {
+    fs.writeFileSync(path.join(dir, '.arcforge-loop.json'), JSON.stringify({ status: 'running' }));
+  }
+
+  it('autopilot (live sentinel in cwd) → both fields, PR-boundary nudge reaches the model', () => {
+    writeRunningSentinel(root);
+    const parsed = runPr(root);
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PostToolUse');
+    assert.ok(
+      parsed.hookSpecificOutput.additionalContext.includes('PR boundary'),
+      'model channel carries the PR-boundary nudge',
+    );
+    assert.ok(parsed.systemMessage.includes('PR boundary'), 'systemMessage still emitted');
+  });
+
+  it('attended (no sentinel) → systemMessage only, never the model channel', () => {
+    const parsed = runPr(root);
+    assert.ok(parsed.systemMessage.includes('PR boundary'), 'attended nudge is user-facing');
+    assert.ok(!('hookSpecificOutput' in parsed), 'attended must NOT reach the model channel');
+  });
+
+  it('S6-1: cwd = epic worktree whose base has a running sentinel → both fields', () => {
+    // base = the loop's project root (holds the sentinel); worktree = an epic
+    // checkout with no sentinel of its own but an .arcforge-epic marker whose
+    // base_worktree points back to base. AF-2's worktree-aware resolution checks
+    // the sentinel at base, so the autopilot nudge must reach the model.
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-remind-base-'));
+    const worktree = fs.mkdtempSync(path.join(os.tmpdir(), 'arc-remind-wt-'));
+    try {
+      writeRunningSentinel(base);
+      // The marker is parsed as YAML (parseDagYaml) — simple key: value lines.
+      fs.writeFileSync(
+        path.join(worktree, '.arcforge-epic'),
+        `epic: epic-x\nspec_id: sdd-y\nbase_worktree: ${base}\n`,
+      );
+      const parsed = runPr(worktree);
+      assert.ok(
+        parsed.hookSpecificOutput.additionalContext.includes('PR boundary'),
+        'worktree-aware: base sentinel makes the nudge reach the model',
+      );
+      assert.ok(parsed.systemMessage.includes('PR boundary'), 'systemMessage still emitted');
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+      fs.rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/e2e-hooks.test.js
+++ b/hooks/__tests__/e2e-hooks.test.js
@@ -361,16 +361,12 @@ describe('E2E: quality-check/main.js', () => {
 
     assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
 
-    // quality-check outputs systemMessage via stdout JSON
-    const parsed = JSON.parse(result.stdout);
-    assert.ok(
-      parsed.systemMessage,
-      `Should output systemMessage. stdout: "${result.stdout.trim()}"`,
-    );
-    assert.ok(
-      parsed.systemMessage.includes('console'),
-      `systemMessage should mention console. Got: "${parsed.systemMessage}"`,
-    );
+    // RV-3: console.* is model-actionable → the model channel (additionalContext),
+    // emitted as exactly one JSON object on stdout.
+    const parsed = JSON.parse(result.stdout.trim());
+    const ctx = parsed.hookSpecificOutput?.additionalContext;
+    assert.ok(ctx, `Should output additionalContext. stdout: "${result.stdout.trim()}"`);
+    assert.ok(ctx.includes('console'), `model channel should mention console. Got: "${ctx}"`);
   });
 
   it('should exit 0 on non-JS file', () => {
@@ -390,15 +386,11 @@ describe('E2E: quality-check/main.js', () => {
 
     assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
 
-    const parsed = JSON.parse(result.stdout);
-    assert.ok(
-      parsed.systemMessage,
-      `Should output systemMessage. stdout: "${result.stdout.trim()}"`,
-    );
-    assert.ok(
-      parsed.systemMessage.includes('console'),
-      `systemMessage should mention console. Got: "${parsed.systemMessage}"`,
-    );
+    // RV-3: console.* finding reaches the model via the PostToolUse model channel.
+    const parsed = JSON.parse(result.stdout.trim());
+    const ctx = parsed.hookSpecificOutput?.additionalContext;
+    assert.ok(ctx, `Should output additionalContext. stdout: "${result.stdout.trim()}"`);
+    assert.ok(ctx.includes('console'), `model channel should mention console. Got: "${ctx}"`);
   });
 
   it('should NOT emit output for Write-created file with only console.error', () => {

--- a/hooks/__tests__/quality-check.test.js
+++ b/hooks/__tests__/quality-check.test.js
@@ -109,6 +109,98 @@ describe('quality-check: checkConsoleLogs', () => {
   });
 });
 
+describe('quality-check: collectFindings buckets by audience (RV-3)', () => {
+  const originalEnv = { ...process.env };
+  let testDir;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-quality-buckets-'));
+    delete require.cache[require.resolve('../quality-check/main')];
+    delete require.cache[require.resolve('../../scripts/lib/utils')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('routes console.* findings to the model channel, never systemMessage', () => {
+    const { collectFindings } = require('../quality-check/main');
+    const file = path.join(testDir, 'app.js');
+    fs.writeFileSync(file, 'console.log("debug");\n');
+    // No prettier/typescript devDeps in the temp dir → no Formatted notice.
+    const { modelReason, systemMessage } = collectFindings(file, file, testDir);
+    assert.ok(modelReason?.includes('console.* found'), 'console finding → model');
+    assert.ok(modelReason.includes('Line 1'), 'cites the line');
+    assert.strictEqual(systemMessage, null, '`Formatted:` must never leak into systemMessage');
+  });
+
+  it('returns no findings for a clean file', () => {
+    const { collectFindings } = require('../quality-check/main');
+    const file = path.join(testDir, 'clean.js');
+    fs.writeFileSync(file, 'const x = 1;\n');
+    assert.deepStrictEqual(collectFindings(file, file, testDir), {
+      modelReason: null,
+      systemMessage: null,
+    });
+  });
+});
+
+describe('quality-check: main() channel routing (RV-3 e2e)', () => {
+  const { spawnSync } = require('node:child_process');
+  const script = path.join(__dirname, '..', 'quality-check', 'main.js');
+  let testDir;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-quality-e2e-'));
+  });
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function run(filePath) {
+    const input = {
+      cwd: testDir,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: filePath },
+    };
+    return spawnSync('node', [script], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 15000,
+    });
+  }
+
+  it('emits exactly one JSON object carrying findings in the model channel', () => {
+    const file = path.join(testDir, 'app.js');
+    fs.writeFileSync(file, 'const x = 1;\nconsole.log("oops");\n');
+    const r = run(file);
+    const out = (r.stdout || '').trim();
+    assert.ok(out, 'should produce stdout for a console.log finding');
+    // Exactly one JSON object — a parse of the whole trimmed stdout must succeed.
+    const parsed = JSON.parse(out);
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PostToolUse');
+    assert.ok(
+      parsed.hookSpecificOutput.additionalContext.includes('console.* found'),
+      'finding must reach the model via additionalContext',
+    );
+    assert.ok(
+      !('systemMessage' in parsed),
+      'no Formatted notice (no prettier devDep) → no systemMessage key',
+    );
+  });
+
+  it('stays silent for a clean file (no output, exit 0)', () => {
+    const file = path.join(testDir, 'clean.js');
+    fs.writeFileSync(file, 'const x = 1;\n');
+    const r = run(file);
+    assert.strictEqual((r.stdout || '').trim(), '', 'clean file → no output');
+    assert.strictEqual(r.status, 0, 'exit 0');
+  });
+});
+
 describe('quality-check: hooks.json registration', () => {
   const hooksJsonPath = path.join(__dirname, '..', 'hooks.json');
 

--- a/hooks/arc-remind/README.md
+++ b/hooks/arc-remind/README.md
@@ -40,13 +40,22 @@ commit is not a completion claim, a PR is. Anchoring here keeps the reminder rar
 and high-signal. Anchoring to every commit, or to every edit on `main`, would be
 a noise machine that gets the hook disabled (arcforge itself develops on `main`).
 
-## Audience: the user, not Claude
+## Audience: attended → user; autopilot → user + Claude
 
-A PostToolUse `systemMessage` is shown to the **user** (additionalContext-to-
-Claude is SessionStart / UserPromptSubmit only). This is deliberate: verification
-is human-in-the-loop, and a user-facing nudge avoids the model performatively
-running a test just to satisfy a hook. PostToolUse cannot block; this hook only
-ever reminds.
+A PostToolUse `systemMessage` is shown to the **user**. In an **attended**
+session that is the whole story: verification is human-in-the-loop, and a
+user-facing-only nudge avoids the model performatively running a test just to
+satisfy a hook. The worktree-add, main-branch and spec→dag nudges are always
+user-only for this reason.
+
+When an autonomous loop is **live** for this checkout — `loopSentinelPresent(cwd)`
+is true (worktree-aware: an epic worktree resolves to its base via the
+`.arcforge-epic` marker) — there is no human watching the systemMessage, so the
+**PR-boundary** and **eval-before-ship** nudges ADDITIONALLY reach the model over
+the PostToolUse model channel (`hookSpecificOutput.additionalContext`,
+spike-verified v2.1.172). Both fields ride a single merged JSON object; the
+`systemMessage` is still emitted so a human reviewing the transcript sees it too.
+PostToolUse cannot block; this hook only ever reminds.
 
 ## State
 

--- a/hooks/arc-remind/main.js
+++ b/hooks/arc-remind/main.js
@@ -5,9 +5,17 @@
  * Hardens discipline triggers that are otherwise pure ICL (they only fire if the
  * relevant skill happens to be loaded) into deterministically-fired nudges. A hook
  * fires regardless — that is the point of moving them here. PostToolUse cannot
- * block; this hook only ever reminds, and reminders go to the USER (a PostToolUse
- * `systemMessage` reaches the user, not Claude). That is deliberate: these are
- * human-in-the-loop nudges, not instructions for the model to perform.
+ * block; this hook only ever reminds.
+ *
+ * Audience depends on whether an autonomous loop is LIVE for this checkout
+ * (RV-5). In an ATTENDED session a human is present, so every nudge is a
+ * user-facing `systemMessage` — human-in-the-loop, not an instruction for the
+ * model to perform. When `loopSentinelPresent(cwd)` is true (a loop is driving
+ * the session, possibly inside an epic worktree resolved via its `.arcforge-epic`
+ * marker), the PR-boundary and eval-before-ship nudges ADDITIONALLY reach the
+ * model over the PostToolUse model channel (same JSON object) — there is no
+ * human watching the systemMessage, so the autopilot needs to see the gate
+ * itself. The worktree-add, main-branch and spec→dag nudges stay user-only.
  *
  * Reminders (all rare / high-signal by construction):
  *   PR boundary   `gh pr create`/`merge`  -> verify (arc-verifying) + review
@@ -36,10 +44,12 @@ const {
   parseStdinJson,
   setSessionIdFromInput,
   output,
+  outputPostToolUseFeedback,
   createSessionCounter,
   getTempDir,
   getSessionId,
 } = require('../../scripts/lib/utils');
+const { loopSentinelPresent } = require('../../scripts/lib/sdd-utils');
 
 // Common test runners — broad enough to catch the usual suspects, scoped to avoid noise.
 const TEST_CMD_RE =
@@ -288,6 +298,22 @@ function bump(name) {
   c.write(c.read() + 1);
 }
 
+/**
+ * Emit an autopilot-aware nudge (RV-5). Attended (no live loop sentinel for
+ * cwd): user-facing `systemMessage` only — unchanged behavior. Autopilot
+ * (`loopSentinelPresent(cwd)` true, worktree-aware via AF-2): ADDITIONALLY
+ * surface the same text to the model over the PostToolUse model channel, kept
+ * in the single merged JSON object the helper guarantees. systemMessage stays
+ * present in both modes.
+ */
+function emitNudge(cwd, text) {
+  if (loopSentinelPresent(cwd)) {
+    outputPostToolUseFeedback(text, { systemMessage: text });
+  } else {
+    output({ systemMessage: text });
+  }
+}
+
 function main() {
   try {
     const input = parseStdinJson(readStdinSync());
@@ -339,7 +365,7 @@ function main() {
     }
 
     if (isPrBoundary(command)) {
-      output({ systemMessage: buildReminder(command, counter('arc-remind-test-seen').read() > 0) });
+      emitNudge(cwd, buildReminder(command, counter('arc-remind-test-seen').read() > 0));
       return;
     }
 
@@ -355,7 +381,7 @@ function main() {
       counter('arc-remind-skill-ship-warned').read() === 0
     ) {
       bump('arc-remind-skill-ship-warned');
-      output({ systemMessage: buildEvalShipNudge(cwd) });
+      emitNudge(cwd, buildEvalShipNudge(cwd));
     }
   } catch {
     // Non-blocking — never crash the session.
@@ -388,6 +414,7 @@ module.exports = {
   buildEvalShipNudge,
   mainBranchNudge,
   planAfterSpecNudge,
+  emitNudge,
   TEST_CMD_RE,
   PR_BOUNDARY_RE,
   SPEC_XML_RE,

--- a/hooks/quality-check/README.md
+++ b/hooks/quality-check/README.md
@@ -11,7 +11,7 @@ Automatically runs quality checks after editing TypeScript/JavaScript files.
 ## Trigger
 
 Runs on `PostToolUse` when:
-- Tool is `Edit`
+- Tool is `Edit` or `Write` (matcher `Edit|Write`)
 - File matches `\.(ts|tsx|js|jsx)$`
 
 ## Requirements
@@ -21,15 +21,31 @@ Runs on `PostToolUse` when:
 
 ## Output
 
-- Warnings are logged to stderr (visible in Claude Code output)
-- stdin is passed through to stdout unchanged (hook chaining)
+Findings are split by audience over a single stdout JSON object:
+
+- **TypeScript errors + `console.*` findings → the model** via
+  `hookSpecificOutput.additionalContext` (spike-verified v2.1.172 — the model
+  receives it on the next turn and can fix the defect). These are actionable
+  problems the next turn should resolve.
+- **`Formatted: <file>` → the user** via `systemMessage`. Prettier already
+  rewrote the file, so this is a notice, not an action item — it never enters
+  the model channel. When model findings are also present, the formatted notice
+  is merged into the same JSON object as the model output.
+- Nothing actionable → no output.
 
 ## Examples
 
+Model channel (`additionalContext`) when type errors / console.* are found:
+
 ```
-[quality-check] Formatted: Component.tsx
-[quality-check] TypeScript errors in Component.tsx:
+TypeScript errors in Component.tsx:
   Line 42: Property 'foo' does not exist on type 'Props' (TS2339)
-[quality-check] console.* found in Component.tsx:
+console.* found in Component.tsx:
   Line 15: console.log('debug', data)...
+```
+
+User channel (`systemMessage`) when Prettier reformatted the file:
+
+```
+Formatted: Component.tsx
 ```

--- a/hooks/quality-check/main.js
+++ b/hooks/quality-check/main.js
@@ -9,8 +9,12 @@
  *    (console.warn/error are intentionally NOT flagged — they are the
  *    prescribed CLI error-output layer; see coding standards)
  *
- * Warnings output via systemMessage (user-visible)
- * Prettier auto-formats files in-place
+ * Output channels (RV-3):
+ * - TypeScript errors + console.* findings are actionable for the model →
+ *   the model-visible PostToolUse channel (additionalContext) so the next
+ *   turn can fix them.
+ * - The `Formatted:` notice is a fait accompli (Prettier already rewrote the
+ *   file) — user-visible systemMessage only, never the model channel.
  */
 
 const path = require('node:path');
@@ -18,6 +22,7 @@ const {
   readStdinSync,
   parseStdinJson,
   output,
+  outputPostToolUseFeedback,
   log,
   readFileSafe,
 } = require('../../scripts/lib/utils');
@@ -54,6 +59,56 @@ function checkConsoleLogs(filePath) {
 }
 
 /**
+ * Run the quality checks for one file and bucket their output by audience.
+ *
+ * Pure given its inputs (it does run Prettier/tsc as side effects, but returns
+ * no I/O of its own): callers decide how to emit the two channels.
+ *   - modelReason: actionable defects the next turn should fix (TypeScript
+ *     errors, console.* findings) → the model-visible PostToolUse channel.
+ *   - systemMessage: the `Formatted:` notice (Prettier already rewrote the
+ *     file) → user-visible only.
+ *
+ * @returns {{ modelReason: string|null, systemMessage: string|null }}
+ */
+function collectFindings(absolutePath, filePath, projectDir) {
+  const fileName = path.basename(filePath);
+  const pm = detectPackageManager(projectDir);
+  const modelLines = [];
+  let systemMessage = null;
+
+  // 1. Run Prettier (if available) — user-visible only (fait accompli).
+  if (pm && hasDevDependency('prettier', projectDir)) {
+    const prettierResult = runPrettier(absolutePath, pm);
+    if (prettierResult.formatted) {
+      systemMessage = `Formatted: ${fileName}`;
+    }
+  }
+
+  // 2. Run TypeScript check (for .ts/.tsx files) — model-actionable.
+  if (/\.(ts|tsx)$/.test(filePath) && pm && hasDevDependency('typescript', projectDir)) {
+    const tsResult = runTypeCheck(absolutePath, pm);
+    if (tsResult.errors && tsResult.errors.length > 0) {
+      modelLines.push(`TypeScript errors in ${fileName}:`);
+      for (const err of tsResult.errors) modelLines.push(`  ${err}`);
+    }
+  }
+
+  // 3. Check for console.log statements — model-actionable.
+  const consoleLogs = checkConsoleLogs(absolutePath);
+  if (consoleLogs.length > 0) {
+    modelLines.push(`console.* found in ${fileName}:`);
+    consoleLogs.slice(0, 15).forEach((match) => {
+      modelLines.push(`  Line ${match.line}: ${match.content}...`);
+    });
+    if (consoleLogs.length > 15) {
+      modelLines.push(`  ... and ${consoleLogs.length - 15} more`);
+    }
+  }
+
+  return { modelReason: modelLines.length > 0 ? modelLines.join('\n') : null, systemMessage };
+}
+
+/**
  * Main entry point
  */
 function main() {
@@ -71,48 +126,22 @@ function main() {
   }
 
   const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath);
-  const projectDir = process.cwd();
-  const pm = detectPackageManager(projectDir);
-  const fileName = path.basename(filePath);
-  const warnings = [];
+  const { modelReason, systemMessage } = collectFindings(absolutePath, filePath, process.cwd());
 
-  // 1. Run Prettier (if available)
-  if (pm && hasDevDependency('prettier', projectDir)) {
-    const prettierResult = runPrettier(absolutePath, pm);
-    if (prettierResult.formatted) {
-      warnings.push(`Formatted: ${fileName}`);
-    }
-  }
-
-  // 2. Run TypeScript check (for .ts/.tsx files)
-  if (/\.(ts|tsx)$/.test(filePath) && pm && hasDevDependency('typescript', projectDir)) {
-    const tsResult = runTypeCheck(absolutePath, pm);
-    if (tsResult.errors && tsResult.errors.length > 0) {
-      warnings.push(`TypeScript errors in ${fileName}:`);
-      for (const err of tsResult.errors) warnings.push(`  ${err}`);
-    }
-  }
-
-  // 3. Check for console.log statements
-  const consoleLogs = checkConsoleLogs(absolutePath);
-  if (consoleLogs.length > 0) {
-    warnings.push(`console.* found in ${fileName}:`);
-    consoleLogs.slice(0, 15).forEach((match) => {
-      warnings.push(`  Line ${match.line}: ${match.content}...`);
-    });
-    if (consoleLogs.length > 15) {
-      warnings.push(`  ... and ${consoleLogs.length - 15} more`);
-    }
-  }
-
-  if (warnings.length > 0) {
-    output({ systemMessage: warnings.join('\n') });
+  // Model-actionable findings go to the model channel (additionalContext),
+  // merging the `Formatted:` notice as a user-visible systemMessage into the
+  // same JSON object when present. The formatted-only case must NOT call the
+  // helper — it throws on an empty reason — so route it through plain output().
+  if (modelReason) {
+    outputPostToolUseFeedback(modelReason, systemMessage ? { systemMessage } : undefined);
+  } else if (systemMessage) {
+    output({ systemMessage });
   }
 
   process.exit(0);
 }
 
-module.exports = { checkConsoleLogs };
+module.exports = { checkConsoleLogs, collectFindings };
 
 try {
   if (require.main === module) main();


### PR DESCRIPTION
Wave 2 (PR-2d). RV-3: quality-check findings re-aimed at the model through the RV-1 merged helper (single stdout JSON, both fields; tsc errors + console findings → model channel, 'Formatted:' → systemMessage only); README rewritten; e2e asserts model fields; live smoke (claude --plugin-dir, deliberate type error → model self-fixes next turn). RV-5: arc-remind ADDITIONALLY emits the model channel for PR-boundary + eval nudges when loopSentinelPresent(cwd) (attended unchanged); 3 tests incl. S6-1 (marker worktree + base running sentinel → both fields). Both consume the verified helper; touch different hooks (no conflict).