### PR TITLE
fix(learning): unify instinct keyspace to name-keyed dir (ICL-3)

### DIFF
--- a/hooks/__tests__/instinct-keyspace-migration.test.js
+++ b/hooks/__tests__/instinct-keyspace-migration.test.js
@@ -1,0 +1,140 @@
+/**
+ * ICL-3 — instinct keyspace migration wiring (hook layer).
+ *
+ * Verifies the two trigger points for the one-time, idempotent migration that
+ * relocates stale hash-keyed instinct files into the canonical name-keyed dir:
+ *   1. start.js main() (async background) — migrateInstincts(project)
+ *   2. inject-context.js loadAutoInstincts(project) — lazy migration on a
+ *      basename miss, closing the first-session window (S5-6).
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const SESSION_UTILS = '../../scripts/lib/session-utils';
+const UTILS = '../../scripts/lib/utils';
+const START = '../session-tracker/start';
+const INJECT = '../session-tracker/inject-context';
+const CONFIDENCE = '../../scripts/lib/confidence';
+
+function clearCache() {
+  for (const mod of [SESSION_UTILS, UTILS, START, INJECT, CONFIDENCE]) {
+    const resolved = require.resolve(mod);
+    delete require.cache[resolved];
+  }
+}
+
+// Build an active instinct file: leading YAML frontmatter (so it is loadable /
+// decayable) plus the embedded ```json scope block the migration reads.
+function instinctFile(candidateId, project, projectId, confidence) {
+  const scopeBlock = JSON.stringify(
+    {
+      schema_version: 1,
+      candidate_id: candidateId,
+      scope: { kind: 'project', project, project_id: projectId },
+    },
+    null,
+    2,
+  );
+  return [
+    '---',
+    `id: ${candidateId}`,
+    `confidence: ${confidence}`,
+    'trigger: migrated instinct trigger',
+    'domain: workflow',
+    '---',
+    '',
+    '```json',
+    scopeBlock,
+    '```',
+    '',
+    '## Action',
+    'do the thing',
+    '',
+  ].join('\n');
+}
+
+let testDir;
+let projectRoot;
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'icl3-hook-mig-'));
+  projectRoot = path.join(testDir, 'myproj');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  process.env.HOME = testDir;
+  process.env.CLAUDE_PROJECT_DIR = projectRoot;
+  clearCache();
+});
+
+afterEach(() => {
+  fs.rmSync(testDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  clearCache();
+});
+
+describe('start.js migrateInstincts', () => {
+  it('relocates a stale hash-keyed instinct into the name-keyed dir', () => {
+    const { getInstinctsDir } = require(SESSION_UTILS);
+    const { getProjectName } = require(UTILS);
+    const start = require(START);
+
+    const project = getProjectName(); // == 'myproj'
+    const hashDir = path.join(testDir, '.arcforge', 'instincts', 'proj-hash-zzz');
+    fs.mkdirSync(hashDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hashDir, 'cand_start.md'),
+      instinctFile('cand_start', project, 'proj-hash-zzz', 0.8),
+    );
+
+    const res = start.migrateInstincts(project);
+    assert.deepStrictEqual(res.moved, ['cand_start.md']);
+
+    const nameFile = path.join(getInstinctsDir(project), 'cand_start.md');
+    assert.ok(fs.existsSync(nameFile), 'file should be in the name-keyed dir');
+    assert.ok(
+      !fs.existsSync(path.join(hashDir, 'cand_start.md')),
+      'file should no longer be in the hash-keyed dir',
+    );
+  });
+
+  it('is a safe no-op when there is nothing to migrate', () => {
+    const start = require(START);
+    const { getProjectName } = require(UTILS);
+    const res = start.migrateInstincts(getProjectName());
+    assert.deepStrictEqual(res, { moved: [], skipped: [] });
+  });
+});
+
+describe('inject-context loadAutoInstincts — first-session window (S5-6)', () => {
+  it('lazily migrates on a basename miss, then loads the migrated instinct', () => {
+    const { getProjectName } = require(UTILS);
+    const { getInstinctsDir } = require(SESSION_UTILS);
+    const inject = require(INJECT);
+
+    const project = getProjectName();
+    // Stale file only in the hash dir; the name-keyed dir does not exist yet —
+    // exactly the state when start.js (async) has not yet run.
+    const hashDir = path.join(testDir, '.arcforge', 'instincts', 'proj-hash-www');
+    fs.mkdirSync(hashDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hashDir, 'cand_inject.md'),
+      instinctFile('cand_inject', project, 'proj-hash-www', 0.9),
+    );
+
+    const result = inject.loadAutoInstincts(project);
+
+    // The instinct was migrated and then loaded (count reflects the high-conf
+    // migrated file).
+    assert.strictEqual(result.count, 1, 'migrated instinct should be loaded');
+    assert.ok(/cand_inject/.test(result.text), 'loaded text should mention the instinct');
+
+    // And it physically moved into the name-keyed dir.
+    const nameFile = path.join(getInstinctsDir(project), 'cand_inject.md');
+    assert.ok(fs.existsSync(nameFile), 'file should be migrated to the name-keyed dir');
+  });
+});

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -33,6 +33,7 @@ const {
   getInstinctsDir,
   getGlobalInstinctsDir,
   getInstinctsGlobalIndex,
+  migrateInstinctsToNameKey,
 } = require('../../scripts/lib/session-utils');
 
 const { parseConfidenceFrontmatter, shouldAutoLoad } = require('../../scripts/lib/confidence');
@@ -43,7 +44,19 @@ const { getPendingActions, consumeAction } = require('../../scripts/lib/pending-
  * Load instincts with confidence >= AUTO_LOAD_THRESHOLD
  */
 function loadAutoInstincts(project) {
-  const projectInstincts = loadInstinctFiles(getInstinctsDir(project));
+  let projectInstincts = loadInstinctFiles(getInstinctsDir(project));
+  // First-session window (ICL-3, S5-6): start.js runs async and is skipped on
+  // source=compact, so the name-keyed dir may still be empty while stale
+  // hash-keyed instinct files exist. On a basename miss, run the idempotent,
+  // collision-safe migration once and re-resolve. No-op when already migrated.
+  if (projectInstincts.length === 0) {
+    try {
+      migrateInstinctsToNameKey(project);
+      projectInstincts = loadInstinctFiles(getInstinctsDir(project));
+    } catch {
+      // silent — never block SessionStart
+    }
+  }
   const globalInstincts = loadInstinctFiles(getGlobalInstinctsDir());
   const autoLoaded = [...projectInstincts, ...globalInstincts].filter((i) =>
     shouldAutoLoad(i.confidence),

--- a/hooks/session-tracker/start.js
+++ b/hooks/session-tracker/start.js
@@ -33,7 +33,7 @@ const {
   log,
 } = require('../../scripts/lib/utils');
 
-const { getInstinctsDir } = require('../../scripts/lib/session-utils');
+const { getInstinctsDir, migrateInstinctsToNameKey } = require('../../scripts/lib/session-utils');
 
 const { runDecayCycle } = require('../../scripts/lib/confidence');
 
@@ -87,6 +87,20 @@ function checkDaemon() {
 }
 
 /**
+ * One-time, idempotent migration of any stale hash-keyed instinct files into
+ * the canonical name-keyed dir for this project (ICL-3). Runs before decay so
+ * relocated files participate in the same session's decay cycle. Silent-catch
+ * — never blocks the session.
+ */
+function migrateInstincts(project) {
+  try {
+    return migrateInstinctsToNameKey(project);
+  } catch {
+    return { moved: [], skipped: [] };
+  }
+}
+
+/**
  * Run decay cycle on instincts.
  */
 function runDecayCycles(project) {
@@ -117,6 +131,7 @@ function main() {
 
   initializeSession();
   checkDaemon();
+  migrateInstincts(project);
   runDecayCycles(project);
 
   log('Session tracker initialized (background tasks)');
@@ -127,6 +142,7 @@ function main() {
 module.exports = {
   initializeSession,
   checkDaemon,
+  migrateInstincts,
   runDecayCycles,
 };
 

--- a/scripts/lib/learning-curator/activate.js
+++ b/scripts/lib/learning-curator/activate.js
@@ -12,7 +12,12 @@ const path = require('node:path');
 const os = require('node:os');
 const crypto = require('node:crypto');
 
-const { sanitizeFilename, atomicWriteFile, sha256Truncated } = require('../utils');
+const {
+  atomicWriteFile,
+  sha256Truncated,
+  sanitizeProjectName,
+  getProjectName,
+} = require('../utils');
 const { SANITIZER_POLICY_VERSION } = require('../sanitize-observation');
 const { appendTransitionEvent } = require('./dashboard-events');
 
@@ -27,8 +32,29 @@ const FIRST_SLICE_TARGET_KINDS = ['instinct'];
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve the instinct directory name for a candidate scope.
+ *
+ * Project-scoped instincts are keyed by the NAME slug (`scope.project`), not
+ * the hashed `scope.project_id`. `scope.project` is set at capture time from
+ * the batch manifest and equals the capture-time `getProjectName()` slug —
+ * the exact key the injection/decay side uses via `getInstinctsDir(project)`.
+ * Keying by `project_id` would write to a directory the loader never reads.
+ *
+ * Falls back to `getProjectName()` only when `scope.project` is absent
+ * (legacy candidates predating the manifest-sourced field).
+ *
+ * @param {object} scope
+ * @returns {string} directory name under `instincts/`
+ */
+function projectScopeDir(scope) {
+  if (scope.kind === 'global') return 'global';
+  const project = scope.project || getProjectName();
+  return sanitizeProjectName(project);
+}
+
+/**
  * Build the active instinct path for a candidate.
- * Project-scoped: <arcforgeRoot>/instincts/<project_id>/<candidate_id>.md
+ * Project-scoped: <arcforgeRoot>/instincts/<project>/<candidate_id>.md
  * Global-scoped: <arcforgeRoot>/instincts/global/<candidate_id>.md
  *
  * @param {string} arcforgeRoot
@@ -36,20 +62,7 @@ const FIRST_SLICE_TARGET_KINDS = ['instinct'];
  * @returns {string}
  */
 function buildActiveInstinctPath(arcforgeRoot, candidate) {
-  const scope = candidate.scope || {};
-  let scopeDir;
-  if (scope.kind === 'global') {
-    scopeDir = 'global';
-  } else {
-    // sanitize project_id for path use
-    let projectId = scope.project_id || 'unknown';
-    try {
-      projectId = sanitizeFilename(projectId);
-    } catch {
-      projectId = projectId.replace(/[^a-zA-Z0-9_-]/g, '_');
-    }
-    scopeDir = projectId;
-  }
+  const scopeDir = projectScopeDir(candidate.scope || {});
   return path.join(arcforgeRoot, 'instincts', scopeDir, `${candidate.candidate_id}.md`);
 }
 
@@ -498,11 +511,8 @@ function deactivate({
     const activationId = `act8_deact_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
     const archivedArtifactId = `aart_dis_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`;
 
-    // Determine archive destination
-    const scopeDir =
-      candidate.scope && candidate.scope.kind === 'global'
-        ? 'global'
-        : candidate.scope?.project_id || 'unknown';
+    // Determine archive destination (name-keyed, matching the active path)
+    const scopeDir = projectScopeDir(candidate.scope || {});
     const disabledDir = path.join(effectiveRoot, 'instincts', scopeDir, '.disabled');
     const archiveName = `${candidate.candidate_id}-${Date.now()}.md`;
     const archivePath = path.join(disabledDir, archiveName);

--- a/scripts/lib/session-utils.js
+++ b/scripts/lib/session-utils.js
@@ -8,6 +8,7 @@ const {
   getDateDiariesDir,
   getProjectSessionsDir,
   sanitizeSessionId,
+  sanitizeProjectName,
 } = require('./utils');
 
 function getDiaryPath(project, date, sessionId) {
@@ -491,6 +492,127 @@ function getEvolvedLogPath() {
   return path.join(getArcforgeHome(), 'evolved', 'evolved.jsonl');
 }
 
+// ─────────────────────────────────────────────
+// Instinct keyspace migration (ICL-3)
+// ─────────────────────────────────────────────
+//
+// Active instinct files were historically written under a hash-keyed
+// directory (`instincts/<project_id>/`) by Layer 8 activation, while the
+// injection/decay side resolves them under a name-keyed directory
+// (`instincts/<project>/`). The two never matched, so dashboard-activated
+// instincts could never be loaded. The keyspace is now unified to the
+// name-keyed dir. This one-time, idempotent migration relocates any
+// previously-activated instinct files from a stale (hash-keyed) project dir
+// into the canonical name-keyed dir for the current project.
+//
+// Each active instinct file embeds its source candidate scope in a fenced
+// JSON metadata block, so the correct destination is read from the file
+// itself — no hash→name mapping table is required.
+
+// Reserved entries directly under the instincts root that are NOT
+// project-scoped instinct directories (must never be migrated).
+const RESERVED_INSTINCT_ROOT_ENTRIES = new Set([
+  'global',
+  'global-index.jsonl',
+  '.last_signal',
+  '.observer.lock',
+]);
+
+/**
+ * Extract the embedded `scope.project` slug from an active instinct file.
+ * Active files written by Layer 8 carry the source candidate metadata in a
+ * fenced ```json block. Returns the sanitized project slug, or null when the
+ * file has no parseable project scope (e.g. global-scoped or malformed).
+ */
+function readInstinctProjectScope(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+  const match = content.match(/```json\s*\n([\s\S]*?)\n```/);
+  if (!match) return null;
+  try {
+    const meta = JSON.parse(match[1]);
+    const project = meta.scope?.project;
+    if (typeof project !== 'string' || !project.trim()) return null;
+    return sanitizeProjectName(project);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Migrate active instinct files belonging to `project` from any stale
+ * (hash-keyed) directory under the instincts root into the canonical
+ * name-keyed directory `instincts/<project>/`.
+ *
+ * Idempotent: files already in the name-keyed dir are left untouched, and a
+ * second invocation is a no-op. Collision-safe: if a file with the same
+ * basename already exists at the destination, the source is left in place
+ * (never overwrites an active artifact).
+ *
+ * @param {string} project — name-keyed project slug (e.g. getProjectName()).
+ * @returns {{ moved: string[], skipped: string[] }} basenames moved / skipped.
+ */
+function migrateInstinctsToNameKey(project) {
+  const result = { moved: [], skipped: [] };
+  if (typeof project !== 'string' || !project.trim()) return result;
+
+  const targetProject = sanitizeProjectName(project);
+  const root = getInstinctsRoot();
+  const destDir = getInstinctsDir(targetProject);
+
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return result; // instincts root absent — nothing to migrate
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (RESERVED_INSTINCT_ROOT_ENTRIES.has(entry.name)) continue;
+    // Already the canonical name-keyed dir for this project — nothing to move.
+    if (entry.name === targetProject) continue;
+
+    const sourceDir = path.join(root, entry.name);
+    let files;
+    try {
+      files = fs.readdirSync(sourceDir);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file.endsWith('.md')) continue;
+      const sourcePath = path.join(sourceDir, file);
+      try {
+        if (!fs.statSync(sourcePath).isFile()) continue;
+      } catch {
+        continue;
+      }
+      if (readInstinctProjectScope(sourcePath) !== targetProject) continue;
+
+      const destPath = path.join(destDir, file);
+      if (fs.existsSync(destPath)) {
+        result.skipped.push(file); // collision — never overwrite
+        continue;
+      }
+      try {
+        fs.mkdirSync(destDir, { recursive: true });
+        fs.renameSync(sourcePath, destPath);
+        result.moved.push(file);
+      } catch {
+        result.skipped.push(file);
+      }
+    }
+  }
+
+  return result;
+}
+
 module.exports = {
   getDiaryPath,
   saveDiary,
@@ -516,4 +638,6 @@ module.exports = {
   getObserverSignalFile,
   getObserverPidFile,
   getEvolvedLogPath,
+  migrateInstinctsToNameKey,
+  readInstinctProjectScope,
 };

--- a/tests/scripts/instinct-keyspace-unification.test.js
+++ b/tests/scripts/instinct-keyspace-unification.test.js
@@ -1,0 +1,408 @@
+// tests/scripts/instinct-keyspace-unification.test.js
+//
+// ICL-3: instinct keyspace unification.
+//
+// Active instinct files must be written under the NAME-keyed directory
+// (`instincts/<scope.project>/`) — the same key the injection/decay side
+// resolves via getInstinctsDir(getProjectName()) — not the hashed
+// `scope.project_id` directory the loader never reads. This suite verifies:
+//   1. temp-HOME integration: activate → name dir; deactivate → .disabled/
+//   2. one-time idempotent migration: move, collision-skip, second-run no-op
+//   3. decay touches the migrated fixture
+//   4. cross-project: dashboard activate from another cwd lands in scope.project
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+
+// ---------------------------------------------------------------------------
+// Candidate fixture (matches the shipped Layer 5 candidate shape)
+// ---------------------------------------------------------------------------
+
+function makeCandidateRecord(overrides = {}) {
+  const base = {
+    schema_version: 1,
+    candidate_id: overrides.candidate_id || `cand_test_${crypto.randomBytes(4).toString('hex')}`,
+    artifact_type: 'instinct',
+    scope: { kind: 'project', project: 'alpha-project', project_id: 'proj-hash-aaa' },
+    source: { source_type: 'layer4_llm_curator' },
+    name: 'use-edit-bash-workflow',
+    summary: 'Prefer Edit before Bash.',
+    rationale: 'Observed pattern.',
+    body: 'When editing files, prefer Edit then Bash.',
+    body_source: 'llm_curator',
+    domain: 'workflow',
+    evidence: [
+      {
+        evidence_id: 'ev-001',
+        evidence_type: 'observation',
+        relevance: 'Observed pattern.',
+        summary: 'Edit then Bash seen in session A.',
+      },
+      {
+        evidence_id: 'ev-002',
+        evidence_type: 'observation',
+        relevance: 'Second observation.',
+        summary: 'Edit then Bash seen in session B.',
+      },
+    ],
+    evidence_quality: 'low',
+    evidence_quality_metadata: { rule_version: 'v1', basis: { project_obs_count: 5 } },
+    lifecycle: { status: 'materialized', status_changed_at: '2026-05-21T00:00:00Z' },
+    // Full safety block so the fixture passes validateCandidateV1 on the
+    // dashboard appendCandidate path (the direct activate() path ignores it).
+    safety: {
+      validator_version: 'v1',
+      sanitizer_policy_version: 'v1',
+      sanitizer_module: 'scripts/lib/sanitize-observation.js',
+      raw_prompt_included: false,
+      raw_response_included: false,
+      raw_hook_payloads_included: false,
+      raw_transcripts_included: false,
+      edit_bodies_included: false,
+      skill_args_included: false,
+      secret_scan: { status: 'passed', rule_version: 'v1' },
+      activation_claim_scan: { status: 'passed' },
+      file_write_claim_scan: { status: 'passed' },
+    },
+    dedupe: { dedupe_key: 'use-edit-bash-workflow-v1', dedupe_basis: { name_hash: 'abc' } },
+    created_at: '2026-05-21T00:00:00Z',
+    updated_at: '2026-05-21T00:00:00Z',
+    ...overrides,
+  };
+  if (overrides.scope) base.scope = overrides.scope;
+  if (overrides.lifecycle) base.lifecycle = overrides.lifecycle;
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Module isolation — all os.homedir() calls redirect to tmpDir
+// ---------------------------------------------------------------------------
+
+let tmpDir;
+let homedirSpy;
+let materializeModule;
+let activate;
+let deactivate;
+let defaultActivationPolicy;
+let sessionUtils;
+const prevProjectDir = process.env.CLAUDE_PROJECT_DIR;
+
+beforeEach(() => {
+  jest.resetModules();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-icl3-'));
+  homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tmpDir);
+
+  materializeModule = require('../../scripts/lib/learning-curator/materialize');
+  ({
+    activate,
+    deactivate,
+    defaultActivationPolicy,
+  } = require('../../scripts/lib/learning-curator/activate'));
+  sessionUtils = require('../../scripts/lib/session-utils');
+});
+
+afterEach(() => {
+  homedirSpy.mockRestore();
+  jest.resetModules();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  if (prevProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = prevProjectDir;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — full materialize → activate chain producing real on-disk files
+// ---------------------------------------------------------------------------
+
+function materializeAndGet(candidateOverrides = {}) {
+  const candidate = makeCandidateRecord({
+    lifecycle: { status: 'approved', status_changed_at: '2026-05-21T00:00:00Z' },
+    ...candidateOverrides,
+  });
+  const arcforgeRoot = path.join(tmpDir, '.arcforge');
+  const result = materializeModule.materialize({
+    candidate,
+    sourceActionId: 'act_seed',
+    requestedArtifactType: 'instinct',
+    renderPolicy: materializeModule.defaultRenderPolicy(),
+    arcforgeRoot,
+  });
+  if (!result.ok) throw new Error(`Materialize failed: ${result.failure.reason}`);
+  return {
+    candidate: {
+      ...candidate,
+      lifecycle: { status: 'materialized', status_changed_at: '2026-05-21T00:00:00Z' },
+    },
+    materializationRecord: result.record,
+    arcforgeRoot,
+  };
+}
+
+function makeActivationRequest(candidateId) {
+  return {
+    schema_version: 1,
+    request_id: `req_${crypto.randomBytes(4).toString('hex')}`,
+    requested_at: new Date().toISOString(),
+    source_action_id: 'act_test_001',
+    action: 'activate',
+    candidate_id: candidateId,
+    expected_candidate_status: 'materialized',
+    target: { target_kind: 'instinct' },
+    reviewer_ack: { confirmed_behavior_change: true, saw_target_summary: true },
+  };
+}
+
+function activateCandidate(ctx) {
+  return activate({
+    candidate: ctx.candidate,
+    materializationRecord: ctx.materializationRecord,
+    activationRequest: makeActivationRequest(ctx.candidate.candidate_id),
+    activationPolicy: defaultActivationPolicy(ctx.arcforgeRoot),
+    arcforgeRoot: ctx.arcforgeRoot,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. temp-HOME integration: activate → name dir; deactivate → .disabled/
+// ---------------------------------------------------------------------------
+
+describe('activate lands in the name-keyed dir (matches injection key)', () => {
+  it('activation writes to instincts/<scope.project>/, the getInstinctsDir() key', () => {
+    const ctx = materializeAndGet();
+    const result = activateCandidate(ctx);
+    expect(result.ok).toBe(true);
+
+    const activePath = result.activeArtifacts[0].active_path;
+    // The exact directory the injection/decay side reads from.
+    const nameDir = sessionUtils.getInstinctsDir('alpha-project');
+    expect(path.dirname(activePath)).toBe(nameDir);
+    expect(fs.existsSync(activePath)).toBe(true);
+    // Must NOT use the hashed project_id directory.
+    expect(activePath).not.toContain('proj-hash-aaa');
+  });
+
+  it('deactivate archives under the same name-keyed dir .disabled/', () => {
+    const ctx = materializeAndGet();
+    const actResult = activateCandidate(ctx);
+    expect(actResult.ok).toBe(true);
+
+    const deactResult = deactivate({
+      candidate: { ...ctx.candidate, lifecycle: { status: 'activated', status_changed_at: 'x' } },
+      activationRecord: actResult.record,
+      activationRequest: {
+        ...makeActivationRequest(ctx.candidate.candidate_id),
+        action: 'deactivate',
+        expected_candidate_status: 'activated',
+      },
+      activationPolicy: defaultActivationPolicy(ctx.arcforgeRoot),
+      arcforgeRoot: ctx.arcforgeRoot,
+    });
+    expect(deactResult.ok).toBe(true);
+
+    const archivePath = deactResult.activeArtifacts[0].active_path;
+    const expectedDisabledDir = path.join(
+      sessionUtils.getInstinctsDir('alpha-project'),
+      '.disabled',
+    );
+    expect(path.dirname(archivePath)).toBe(expectedDisabledDir);
+    expect(fs.existsSync(archivePath)).toBe(true);
+    expect(archivePath).not.toContain('proj-hash-aaa');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. one-time idempotent migration: move, collision-skip, second-run no-op
+// ---------------------------------------------------------------------------
+
+describe('migrateInstinctsToNameKey — hash dir → name dir', () => {
+  // Seed an active instinct file inside a stale hash-keyed dir by writing the
+  // real materialized draft (which embeds scope) under instincts/<project_id>/.
+  function seedHashKeyedInstinct(candidateId, project, projectId) {
+    const ctx = materializeAndGet({
+      candidate_id: candidateId,
+      scope: { kind: 'project', project, project_id: projectId },
+    });
+    const draftPath = ctx.materializationRecord.draft_artifacts[0].draft_path;
+    const draftContent = fs.readFileSync(draftPath, 'utf8');
+    const hashDir = path.join(tmpDir, '.arcforge', 'instincts', projectId);
+    fs.mkdirSync(hashDir, { recursive: true });
+    const filePath = path.join(hashDir, `${candidateId}.md`);
+    fs.writeFileSync(filePath, draftContent);
+    return { filePath, draftContent };
+  }
+
+  it('moves a stale hash-keyed instinct into the name-keyed dir', () => {
+    const { filePath } = seedHashKeyedInstinct('cand_mig_1', 'alpha-project', 'proj-hash-aaa');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const res = sessionUtils.migrateInstinctsToNameKey('alpha-project');
+
+    expect(res.moved).toContain('cand_mig_1.md');
+    // Old location gone, new name-keyed location present.
+    expect(fs.existsSync(filePath)).toBe(false);
+    const nameDirFile = path.join(sessionUtils.getInstinctsDir('alpha-project'), 'cand_mig_1.md');
+    expect(fs.existsSync(nameDirFile)).toBe(true);
+  });
+
+  it('skips files belonging to a different project (per-file scope match)', () => {
+    seedHashKeyedInstinct('cand_other', 'beta-project', 'proj-hash-bbb');
+
+    const res = sessionUtils.migrateInstinctsToNameKey('alpha-project');
+
+    expect(res.moved).not.toContain('cand_other.md');
+    // beta's file stays put in its hash dir; alpha's name dir does not gain it.
+    const betaHashFile = path.join(
+      tmpDir,
+      '.arcforge',
+      'instincts',
+      'proj-hash-bbb',
+      'cand_other.md',
+    );
+    expect(fs.existsSync(betaHashFile)).toBe(true);
+  });
+
+  it('collision-skip: never overwrites an existing name-keyed file', () => {
+    seedHashKeyedInstinct('cand_collide', 'alpha-project', 'proj-hash-aaa');
+    // Pre-existing file at the destination with sentinel content.
+    const nameDir = sessionUtils.getInstinctsDir('alpha-project');
+    fs.mkdirSync(nameDir, { recursive: true });
+    const destFile = path.join(nameDir, 'cand_collide.md');
+    fs.writeFileSync(destFile, 'SENTINEL — must not be overwritten');
+
+    const res = sessionUtils.migrateInstinctsToNameKey('alpha-project');
+
+    expect(res.skipped).toContain('cand_collide.md');
+    expect(res.moved).not.toContain('cand_collide.md');
+    // Destination content preserved; stale source preserved (not destroyed).
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('SENTINEL — must not be overwritten');
+    const staleSource = path.join(
+      tmpDir,
+      '.arcforge',
+      'instincts',
+      'proj-hash-aaa',
+      'cand_collide.md',
+    );
+    expect(fs.existsSync(staleSource)).toBe(true);
+  });
+
+  it('idempotent: a second invocation is a no-op', () => {
+    seedHashKeyedInstinct('cand_idem', 'alpha-project', 'proj-hash-aaa');
+
+    const first = sessionUtils.migrateInstinctsToNameKey('alpha-project');
+    expect(first.moved).toContain('cand_idem.md');
+
+    const second = sessionUtils.migrateInstinctsToNameKey('alpha-project');
+    expect(second.moved).toEqual([]);
+    expect(second.skipped).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. decay touches the migrated fixture
+// ---------------------------------------------------------------------------
+
+describe('decay cycle reaches migrated instincts', () => {
+  it('runDecayCycle on the name-keyed dir sees the migrated file', () => {
+    // Decay reads leading YAML frontmatter (confidence + last_confirmed);
+    // migration reads the embedded ```json scope block from the body. A file
+    // can satisfy both: YAML frontmatter first, then the scope JSON block.
+    const staleDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+    const scopeBlock = JSON.stringify(
+      {
+        schema_version: 1,
+        candidate_id: 'cand_decay',
+        scope: { kind: 'project', project: 'alpha-project', project_id: 'proj-hash-aaa' },
+      },
+      null,
+      2,
+    );
+    const fileContent = [
+      '---',
+      'id: cand_decay',
+      'confidence: 0.8',
+      'trigger: stale instinct',
+      'domain: workflow',
+      `last_confirmed: ${staleDate}`,
+      '---',
+      '',
+      '```json',
+      scopeBlock,
+      '```',
+      '',
+      '## Action',
+      'do the thing',
+      '',
+    ].join('\n');
+
+    const hashDir = path.join(tmpDir, '.arcforge', 'instincts', 'proj-hash-aaa');
+    fs.mkdirSync(hashDir, { recursive: true });
+    fs.writeFileSync(path.join(hashDir, 'cand_decay.md'), fileContent);
+
+    const moveRes = sessionUtils.migrateInstinctsToNameKey('alpha-project');
+    expect(moveRes.moved).toContain('cand_decay.md');
+
+    const { runDecayCycle } = require('../../scripts/lib/confidence');
+    const decayResult = runDecayCycle(sessionUtils.getInstinctsDir('alpha-project'));
+
+    // The migrated file must be reachable by decay (decayed or archived).
+    const touched = [...decayResult.decayed, ...decayResult.archived];
+    expect(touched).toContain('cand_decay.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. cross-project: dashboard activate from another cwd → scope.project dir
+// ---------------------------------------------------------------------------
+
+describe('cross-project activation is keyed by candidate scope, not cwd', () => {
+  it('dashboard activate from a different cwd lands in scope.project dir', () => {
+    // Launcher cwd / CLAUDE_PROJECT_DIR points at an UNRELATED project.
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/some-other-cwd-project';
+
+    jest.resetModules();
+    const dashboard = require('../../scripts/lib/learning-dashboard');
+    const { appendCandidate } = require('../../scripts/lib/learning-curator/queue-writer');
+    const {
+      appendTransitionEvent,
+    } = require('../../scripts/lib/learning-curator/dashboard-events');
+
+    // The candidate belongs to 'gamma-project' (its captured scope.project),
+    // which is NOT the current cwd basename.
+    const candidate = makeCandidateRecord({
+      candidate_id: `cand_xproj_${crypto.randomBytes(4).toString('hex')}`,
+      scope: { kind: 'project', project: 'gamma-project', project_id: 'proj-hash-ggg' },
+    });
+    appendCandidate(candidate);
+    appendTransitionEvent(candidate.candidate_id, 'approve', 'approved');
+
+    const matResult = dashboard.handleDashboardAction({
+      action: 'materialize',
+      candidate_id: candidate.candidate_id,
+    });
+    expect(matResult.accepted).toBe(true);
+
+    const actResult = dashboard.handleDashboardAction({
+      action: 'activate',
+      candidate_id: candidate.candidate_id,
+      safety_ack: {
+        reviewer_saw_behavior_change_warning: true,
+        reviewer_saw_target_path_summary: true,
+      },
+    });
+    expect(actResult.accepted).toBe(true);
+
+    // File must land in gamma-project (candidate scope), NOT the cwd project.
+    const gammaDir = path.join(tmpDir, '.arcforge', 'instincts', 'gamma-project');
+    const files = fs.existsSync(gammaDir)
+      ? fs.readdirSync(gammaDir).filter((f) => f.endsWith('.md'))
+      : [];
+    expect(files).toContain(`${candidate.candidate_id}.md`);
+
+    // And explicitly NOT in a cwd-named dir or the hashed project_id dir.
+    const cwdDir = path.join(tmpDir, '.arcforge', 'instincts', 'some-other-cwd-project');
+    expect(fs.existsSync(cwdDir)).toBe(false);
+    const hashDir = path.join(tmpDir, '.arcforge', 'instincts', 'proj-hash-ggg');
+    expect(fs.existsSync(hashDir)).toBe(false);
+  });
+});

--- a/tests/scripts/learning-curator-activate.test.js
+++ b/tests/scripts/learning-curator-activate.test.js
@@ -337,16 +337,40 @@ describe('L8-5: reject non-instinct target_kind in first slice', () => {
 // ---------------------------------------------------------------------------
 
 describe('L8-6: active path computation', () => {
-  it('project-scoped candidate → instincts/<project_id>/<candidate_id>.md', () => {
+  it('project-scoped candidate → instincts/<project>/<candidate_id>.md (name-keyed, ICL-3)', () => {
     const candidate = makeCandidateRecord({
       scope: { kind: 'project', project: 'my-project', project_id: 'proj-xyz' },
     });
     const arcforgeRoot = path.join(tmpDir, '.arcforge');
     const activePath = buildActiveInstinctPath(arcforgeRoot, candidate);
     expect(activePath).toContain('instincts');
-    expect(activePath).toContain('proj-xyz');
+    // Keyed by the NAME slug (scope.project), which equals the injection-side
+    // getInstinctsDir() key — NOT the hashed project_id the loader never reads.
+    expect(activePath).toContain('my-project');
+    expect(activePath).not.toContain('proj-xyz');
     expect(activePath).toContain(candidate.candidate_id);
     expect(activePath).toMatch(/\.md$/);
+  });
+
+  it('falls back to getProjectName() only when scope.project is absent (ICL-3)', () => {
+    const prevDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/legacy-fallback-proj';
+    try {
+      jest.resetModules();
+      const {
+        buildActiveInstinctPath: build,
+      } = require('../../scripts/lib/learning-curator/activate');
+      const candidate = makeCandidateRecord({
+        scope: { kind: 'project', project_id: 'proj-legacy' },
+      });
+      const arcforgeRoot = path.join(tmpDir, '.arcforge');
+      const activePath = build(arcforgeRoot, candidate);
+      expect(activePath).toContain('legacy-fallback-proj');
+      expect(activePath).not.toContain('proj-legacy');
+    } finally {
+      if (prevDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+      else process.env.CLAUDE_PROJECT_DIR = prevDir;
+    }
   });
 
   it('global-scoped candidate → instincts/global/<candidate_id>.md', () => {

--- a/tests/scripts/learning-dashboard.test.js
+++ b/tests/scripts/learning-dashboard.test.js
@@ -1111,9 +1111,11 @@ describe('DH-6: deactivate action calls deactivate.js module', () => {
     });
     expect(actResult.accepted).toBe(true);
 
-    // Verify active file exists before deactivate
+    // Verify active file exists before deactivate. Active instinct files are
+    // keyed by the NAME slug (scope.project) — the injection-side key — not the
+    // hashed scope.project_id (ICL-3 keyspace unification).
     const instinctsBase = path.join(tmpDir, '.arcforge', 'instincts');
-    const scopeDir = record.scope.project_id || 'unknown';
+    const scopeDir = record.scope.project || 'unknown';
     const activePath = path.join(instinctsBase, scopeDir, `${record.candidate_id}.md`);
     expect(fs.existsSync(activePath)).toBe(true);
 


### PR DESCRIPTION
Wave 2 (PR-2e). Unifies instinct storage to name-keyed getInstinctsDir(); project name source = candidate.scope.project (equals the injection-side key — dashboard is HOME-global so launcher cwd would misfile cross-project candidates); fallback getProjectName() only when scope.project absent; one-time idempotent lazy migration (hash→name, collision skip) from start.js main() AND lazily from inject-context on basename miss (closes the first-session window, S5-6). ActivationRecords not rewritten (append-only). Cross-project fixture: dashboard activate from another cwd lands in scope.project dir. Prerequisite for ICL-4 (Wave 3 loadAutoInstincts wiring).