### PR TITLE
feat(cli): CLI output-shape manifest + contract test (SRH-2)

### DIFF
--- a/scripts/lib/cli-manifest.js
+++ b/scripts/lib/cli-manifest.js
@@ -1,0 +1,275 @@
+/**
+ * cli-manifest.js — frozen contract for the arcforge CLI surface.
+ *
+ * This is the single shared source of truth for two structural defenses
+ * against the "broken seam" defect class (a doc or downstream consumer
+ * promising a CLI flag/field the engine never emits):
+ *   - SRH-3 deterministic pipeline smoke reads it to assert the seam chain.
+ *   - SRH-4 doc-reference linter reads `flags` (R2) and the `--json` field
+ *     promises (R3) — it is FORBIDDEN a second copy of this data.
+ *
+ * The contract test (tests/node/test-cli-manifest.js) enforces this file
+ * BIDIRECTIONALLY against the live CLI:
+ *   1. Label parity: the top-level keys here ≡ cli.js's `switch (args.command)`
+ *      case labels (both directions, exhaustively). A downstream package that
+ *      adds a subcommand without updating this manifest turns the test RED —
+ *      by design.
+ *   2. Shape parity: for every command whose `output` is non-null, the test
+ *      runs the live `<cmd> --json` in a deterministic fixture and asserts the
+ *      key skeleton (keys + nested keys + array-element keys; values ignored)
+ *      matches `output` EXACTLY — no missing keys, no extra keys.
+ *
+ * `output: null` means "shape deliberately not pinned by the live contract
+ * test", NOT "shape unknown". A command is null'd when the contract test
+ * cannot produce a deterministic live `--json` AND do a FULL key-set
+ * comparison without machinery that belongs to another task:
+ *   - spawns/serves/is interactive (loop, ratify, research, eval dashboards)
+ *   - reads global ~/.arcforge state (learn, obsidian, eval list)
+ *   - needs a fake HOME + populated worktrees to exercise (expand, merge,
+ *     cleanup, sync) — that fixture machinery is SRH-3's explicit charter
+ *     (mkdtemp repo + fake HOME), so pinning a shape here that this test
+ *     cannot live-verify would be worse than null (looks verified, isn't).
+ *
+ * Pinning a shape MUST NOT require changing cli.js output — that belongs to a
+ * capability package, not this contract.
+ *
+ * Skeleton conventions for the `output` value (matching the comparator in
+ * the contract test):
+ *   - an object literal describes an object's keys
+ *   - a one-element array `[ <shape> ]` describes a non-empty array whose
+ *     elements all match `<shape>`
+ *   - an empty array `[]` describes an array whose element shape is not
+ *     pinned (e.g. always-empty in the fixture, or heterogeneous values)
+ *   - `null` as a leaf value pins only the key's presence, not a sub-shape
+ *     (the live value may legitimately be null or a scalar)
+ */
+
+const CLI_MANIFEST = {
+  status: {
+    flags: ['--blocked', '--json', '--spec-id'],
+    output: {
+      epics: [
+        {
+          id: null,
+          name: null,
+          status: null,
+          progress: null,
+          worktree: null,
+          path: null,
+          features: [{ id: null, name: null, status: null }],
+        },
+      ],
+      blocked: [{ task_id: null, reason: null }],
+    },
+  },
+
+  next: {
+    flags: ['--json', '--spec-id'],
+    output: { id: null, name: null, type: null },
+  },
+
+  complete: {
+    flags: ['--json', '--spec-id'],
+    output: { success: null, task_id: null },
+  },
+
+  block: {
+    flags: ['--json', '--spec-id'],
+    output: { success: null, task_id: null },
+  },
+
+  parallel: {
+    flags: ['--json', '--spec-id'],
+    output: { count: null, epics: [{ id: null, name: null }] },
+  },
+
+  // Needs a fake HOME + ready epic to create real worktrees → SRH-3 charter.
+  expand: {
+    flags: ['--epic', '--project-setup', '--verify', '--verify-cmd', '--json', '--spec-id'],
+    output: null,
+  },
+
+  // Needs populated worktrees to merge → SRH-3 charter.
+  merge: {
+    flags: ['--base', '--json', '--spec-id'],
+    output: null,
+  },
+
+  // Needs populated worktrees to remove → SRH-3 charter.
+  cleanup: {
+    flags: ['--json', '--spec-id'],
+    output: null,
+  },
+
+  // Data-moving directions need a fake HOME + worktree context → SRH-3 charter.
+  sync: {
+    flags: ['--direction', '--json', '--spec-id'],
+    output: null,
+  },
+
+  reboot: {
+    flags: ['--json', '--spec-id'],
+    output: {
+      // null when no task is in flight; the object shape when one exists.
+      // The contract fixture always has a current task, so the object shape
+      // is what gets live-verified.
+      current_task: { id: null, name: null, type: null, status: null },
+      remaining_count: null,
+      completed_count: null,
+      blocked_count: null,
+      project_goal: null,
+      research_files: [],
+    },
+  },
+
+  // Spawns claude sessions — no JSON contract.
+  loop: {
+    flags: [
+      '--pattern',
+      '--max-runs',
+      '--max-cost',
+      '--epic',
+      '--spec-id',
+      '--task-timeout',
+      '--permission-mode',
+      '--allowed-tools',
+    ],
+    output: null,
+  },
+
+  worktree: {
+    flags: ['--branch', '--from', '--setup', '--force', '--json'],
+    subcommands: {
+      add: { flags: ['--branch', '--from', '--setup'] },
+      list: {
+        flags: ['--json'],
+        output: { count: null, worktrees: [{ path: null, branch: null, head: null, kind: null }] },
+      },
+      remove: { flags: ['--force'] },
+    },
+    // The top-level `worktree` command itself has no single --json shape;
+    // the pinned shape lives on the `list` subcommand.
+    output: null,
+  },
+
+  // `schema --json` is a deterministic serialization of the dag.yaml schema
+  // definition (scripts/lib/dag-schema.js). Fully pinnable — drift in either
+  // direction (engine adds a schema field, or this manifest goes stale) is the
+  // RED the contract test exists to produce. SRH-3 lists dag-schema among the
+  // seven seams; SRH-4 R3 verifies doc field-promises against it.
+  schema: {
+    flags: ['--json', '--example'],
+    output: {
+      epics: {
+        type: null,
+        description: null,
+        items: {
+          id: { type: null, required: null, description: null },
+          name: { type: null, required: null, description: null },
+          status: { type: null, required: null, enum: [null], default: null, description: null },
+          spec_path: { type: null, required: null, description: null },
+          worktree: { type: null, required: null, description: null },
+          depends_on: { type: null, items: null, required: null, default: [], description: null },
+          features: {
+            type: null,
+            required: null,
+            default: [],
+            description: null,
+            items: {
+              id: { type: null, required: null, description: null },
+              name: { type: null, required: null, description: null },
+              status: {
+                type: null,
+                required: null,
+                enum: [null],
+                default: null,
+                description: null,
+              },
+              source_requirement: { type: null, required: null, description: null },
+              depends_on: {
+                type: null,
+                items: null,
+                required: null,
+                default: [],
+                description: null,
+              },
+            },
+          },
+        },
+      },
+      blocked: {
+        type: null,
+        required: null,
+        description: null,
+        items: {
+          task_id: { type: null, required: null, description: null },
+          reason: { type: null, required: null, description: null },
+          blocked_at: { type: null, required: null, description: null },
+          attempts: {
+            type: null,
+            required: null,
+            default: [],
+            description: null,
+            items: {
+              action: { type: null, description: null },
+              attempt_at: { type: null, description: null },
+              result: { type: null, description: null },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  // eval list reads project evals/; subcommands spawn/serve → no JSON contract.
+  eval: {
+    flags: [
+      '--k',
+      '--model',
+      '--no-isolate',
+      '--plugin-dir',
+      '--max-turns',
+      '--since',
+      '--top',
+      '--port',
+      '--skill-file',
+      '--interleave',
+    ],
+    output: null,
+  },
+
+  // Reads global ~/.arcforge learning state → not deterministic here.
+  learn: {
+    flags: ['--project', '--global', '--json', '--port'],
+    output: null,
+  },
+
+  // Serves an HTTP dashboard → no JSON contract.
+  research: {
+    flags: ['--results', '--config', '--port'],
+    output: null,
+  },
+
+  // Reads global ~/.arcforge vault registry → not deterministic here.
+  obsidian: {
+    flags: [
+      '--path',
+      '--name',
+      '--default',
+      '--preset',
+      '--scope',
+      '--search-preferred',
+      '--qmd-collection',
+      '--json',
+    ],
+    output: null,
+  },
+
+  // Interactive informed-confirm flow → no JSON contract.
+  ratify: {
+    flags: [],
+    output: null,
+  },
+};
+
+module.exports = { CLI_MANIFEST };

--- a/tests/node/test-cli-manifest.js
+++ b/tests/node/test-cli-manifest.js
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * Contract test for scripts/lib/cli-manifest.js.
+ *
+ * Two structural defenses, both enforced BIDIRECTIONALLY:
+ *
+ *   1. Label parity — the manifest's top-level keys must exactly match the
+ *      `switch (args.command)` case labels in cli.js. A command added to one
+ *      side but not the other turns this RED. This is the defense against a
+ *      downstream package adding a subcommand without updating the manifest
+ *      that SRH-3/SRH-4 share.
+ *
+ *   2. Shape parity — for every command whose manifest `output` is non-null,
+ *      run the live `<cmd> --json` in a deterministic git+dag fixture, reduce
+ *      both the live output and the manifest shape to a key skeleton (keys +
+ *      nested keys + array-element keys; values ignored), and assert exact set
+ *      equality. No missing keys, no extra keys.
+ *
+ * Per the SRH-2 stop condition: a command whose live --json is environment
+ * dependent / unpinnable is `output: null` in the manifest and skipped by the
+ * shape layer here — never silently downgraded to a subset comparison.
+ */
+
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
+const CLI_PATH = path.join(SCRIPT_DIR, 'cli.js');
+const CLI_SOURCE = fs.readFileSync(CLI_PATH, 'utf8');
+const { CLI_MANIFEST } = require(path.join(SCRIPT_DIR, 'lib/cli-manifest'));
+
+console.log('Testing cli-manifest.js contract...\n');
+
+// ---------------------------------------------------------------------------
+// Layer 1: label parity (manifest top-level keys ≡ cli.js switch case labels)
+// ---------------------------------------------------------------------------
+
+function extractCaseLabels(source) {
+  const match = source.match(/switch \(args\.command\) \{([\s\S]*?)\n {2}\}/);
+  if (!match) throw new Error('Could not locate the command switch block in cli.js');
+  return [...match[1].matchAll(/case '([^']+)':/g)].map((m) => m[1]);
+}
+
+console.log('  Layer 1: label parity (both directions)...');
+const caseLabels = extractCaseLabels(CLI_SOURCE).sort();
+const manifestKeys = Object.keys(CLI_MANIFEST).sort();
+
+assert.ok(caseLabels.length > 0, 'expected to find switch case labels in cli.js');
+
+const missingFromManifest = caseLabels.filter((c) => !manifestKeys.includes(c));
+const extraInManifest = manifestKeys.filter((k) => !caseLabels.includes(k));
+
+assert.deepStrictEqual(
+  missingFromManifest,
+  [],
+  `cli.js has command(s) absent from CLI_MANIFEST: ${missingFromManifest.join(', ')}`,
+);
+assert.deepStrictEqual(
+  extraInManifest,
+  [],
+  `CLI_MANIFEST has key(s) with no cli.js command: ${extraInManifest.join(', ')}`,
+);
+assert.deepStrictEqual(manifestKeys, caseLabels);
+console.log(`    ✓ ${caseLabels.length} command labels match exactly (both directions)`);
+
+// ---------------------------------------------------------------------------
+// Skeleton reduction: a value → its shape, dropping all leaf values.
+//   object   → { key: skeleton(value), ... }
+//   array    → [] if empty, else [ skeleton(merged-element) ]
+//   scalar   → null  (leaf marker; presence of the key is all that's pinned)
+// ---------------------------------------------------------------------------
+
+function skeleton(value) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [];
+    // Merge every element's keys so a non-uniform array still yields the union
+    // skeleton — exact equality then catches any element that adds/drops a key.
+    return [value.map(skeleton).reduce(mergeSkeleton)];
+  }
+  if (value !== null && typeof value === 'object') {
+    const out = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = skeleton(value[key]);
+    }
+    return out;
+  }
+  return null;
+}
+
+function mergeSkeleton(a, b) {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length === 0) return b;
+    if (b.length === 0) return a;
+    return [mergeSkeleton(a[0], b[0])];
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const out = {};
+    for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+      out[key] = key in a && key in b ? mergeSkeleton(a[key], b[key]) : (a[key] ?? b[key]);
+    }
+    return out;
+  }
+  return a;
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function stableStringify(value) {
+  return JSON.stringify(sortKeysDeep(value), null, 2);
+}
+
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (isPlainObject(value)) {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = sortKeysDeep(value[key]);
+    return out;
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fixture: a git repo with a per-spec dag.yaml. CLAUDE_PROJECT_DIR
+// points here so the coordinator commands resolve the single spec.
+// ---------------------------------------------------------------------------
+
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-manifest-test-'));
+const dagDir = path.join(testDir, 'specs', 'test-spec');
+const dagPath = path.join(dagDir, 'dag.yaml');
+
+function runCli(argArray, options = {}) {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...argArray], {
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: testDir },
+      cwd: testDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...options,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || err.message,
+      exitCode: err.status || 1,
+    };
+  }
+}
+
+function writeDag(yaml) {
+  fs.mkdirSync(dagDir, { recursive: true });
+  fs.writeFileSync(dagPath, yaml);
+  execFileSync('git', ['add', '-A'], { cwd: testDir, stdio: 'pipe' });
+  execFileSync('git', ['commit', '-m', 'dag', '--allow-empty'], { cwd: testDir, stdio: 'pipe' });
+}
+
+execFileSync('git', ['init'], { cwd: testDir, stdio: 'pipe' });
+execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: testDir, stdio: 'pipe' });
+execFileSync('git', ['config', 'user.name', 'Test'], { cwd: testDir, stdio: 'pipe' });
+
+// Two epics: epic-001 in_progress (one done + one pending feature), epic-002
+// pending and ready once epic-001 completes. Variants of this dag drive each
+// probe so every pinned array is non-empty when its command is exercised.
+function dag({ epic001Status, feat001Status, feat002Status, epic002Status, feat00201Status }) {
+  return `epics:
+  - id: epic-001
+    name: Test Epic
+    status: ${epic001Status}
+    spec_path: docs/spec.md
+    worktree: null
+    depends_on: []
+    features:
+      - id: feat-001
+        name: Feature 1
+        status: ${feat001Status}
+        depends_on: []
+      - id: feat-002
+        name: Feature 2
+        status: ${feat002Status}
+        depends_on: []
+  - id: epic-002
+    name: Second Epic
+    status: ${epic002Status}
+    spec_path: docs/spec2.md
+    worktree: null
+    depends_on:
+      - epic-001
+    features:
+      - id: feat-002-01
+        name: Feature 2.1
+        status: ${feat00201Status}
+        depends_on: []
+`;
+}
+
+const IN_PROGRESS_DAG = dag({
+  epic001Status: 'in_progress',
+  feat001Status: 'completed',
+  feat002Status: 'pending',
+  epic002Status: 'pending',
+  feat00201Status: 'pending',
+});
+
+// epic-001 fully complete → epic-002 becomes a ready parallel candidate, and
+// `next` resolves to the epic (type: epic). Used by parallel/next.
+const EPIC001_DONE_DAG = dag({
+  epic001Status: 'completed',
+  feat001Status: 'completed',
+  feat002Status: 'completed',
+  epic002Status: 'pending',
+  feat00201Status: 'pending',
+});
+
+// ---------------------------------------------------------------------------
+// Layer 2: shape parity for every command with a non-null pinned output.
+//
+// Each probe is order-independent: `setup` (re)writes the dag and runs any
+// state-mutating pre-commands so that the live `<cmd> --json` it then runs has
+// every pinned array non-empty (element keys derivable).
+// ---------------------------------------------------------------------------
+
+const liveProbes = [
+  {
+    command: 'status',
+    // Block a feature so `blocked` is non-empty alongside the epics list.
+    setup: () => {
+      writeDag(IN_PROGRESS_DAG);
+      runCli(['block', 'feat-002', 'waiting on review']);
+    },
+    argsFn: () => ['status', '--json'],
+  },
+  {
+    command: 'next',
+    setup: () => writeDag(IN_PROGRESS_DAG),
+    argsFn: () => ['next', '--json'],
+  },
+  {
+    command: 'complete',
+    setup: () => writeDag(IN_PROGRESS_DAG),
+    argsFn: () => ['complete', 'feat-002', '--json'],
+  },
+  {
+    command: 'block',
+    setup: () => writeDag(IN_PROGRESS_DAG),
+    argsFn: () => ['block', 'feat-002', 'waiting', '--json'],
+  },
+  {
+    command: 'parallel',
+    // epic-002 ready → epics array non-empty.
+    setup: () => writeDag(EPIC001_DONE_DAG),
+    argsFn: () => ['parallel', '--json'],
+  },
+  {
+    command: 'reboot',
+    setup: () => writeDag(IN_PROGRESS_DAG),
+    argsFn: () => ['reboot', '--json'],
+  },
+  {
+    command: 'schema',
+    setup: () => {},
+    argsFn: () => ['schema', '--json'],
+  },
+  {
+    command: 'worktree',
+    // The pinned shape lives on the `list` subcommand; this base-only fixture
+    // yields a single kind:base entry with no conditional epic/spec_id keys.
+    setup: () => {},
+    argsFn: () => ['worktree', 'list', '--json'],
+    manifestShapeFor: (entry) => entry.subcommands.list.output,
+  },
+];
+
+console.log('  Layer 2: shape parity (live --json vs manifest, pinned commands)...');
+
+// Guard: the set of commands the manifest pins (output !== null, or a pinned
+// subcommand output) must equal the set we live-probe — no pinned shape is
+// allowed to go un-exercised, and no probe is allowed without a pinned shape.
+const pinnedCommands = manifestKeys.filter((cmd) => {
+  const entry = CLI_MANIFEST[cmd];
+  if (entry.output !== null) return true;
+  if (entry.subcommands) {
+    return Object.values(entry.subcommands).some((s) => s.output != null);
+  }
+  return false;
+});
+const probedCommands = liveProbes.map((p) => p.command).sort();
+assert.deepStrictEqual(
+  probedCommands,
+  pinnedCommands.sort(),
+  `every pinned command must be live-probed: pinned=${pinnedCommands} probed=${probedCommands}`,
+);
+
+for (const probe of liveProbes) {
+  const entry = CLI_MANIFEST[probe.command];
+  const manifestShape = probe.manifestShapeFor ? probe.manifestShapeFor(entry) : entry.output;
+  const expected = stableStringify(skeleton(manifestShape));
+
+  probe.setup();
+  const result = runCli(probe.argsFn());
+  assert.strictEqual(
+    result.exitCode,
+    0,
+    `live '${probe.command}' --json exited ${result.exitCode}: ${result.stderr || ''}`,
+  );
+
+  let live;
+  try {
+    live = JSON.parse(result.stdout);
+  } catch (err) {
+    throw new Error(`live '${probe.command}' --json was not valid JSON: ${err.message}`);
+  }
+  const actual = stableStringify(skeleton(live));
+
+  assert.strictEqual(
+    actual,
+    expected,
+    `shape mismatch for '${probe.command}':\n--- manifest ---\n${expected}\n--- live ---\n${actual}`,
+  );
+  console.log(`    ✓ ${probe.command} live --json shape matches manifest`);
+}
+
+// Cleanup
+fs.rmSync(testDir, { recursive: true, force: true });
+
+console.log('\n✅ All cli-manifest contract tests passed!\n');


### PR DESCRIPTION
Wave 2 (PR-2h). New scripts/lib/cli-manifest.js freezing each subcommand's flags + --json shape; contract test compares case labels and live --json both ways; unstable commands → output:null. Structural defense against the broken-seam defect class — feeds SRH-3 smoke + SRH-4 doc-reference linter (Wave 3).