### PR TITLE
feat(cli): sdd-gate CLI engine — stages + stable JSON (SDD-6 engine layer)

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -45,6 +45,7 @@ const { printHelp } = require('./cli/help');
 const { runLearnCommand } = require('./cli/learn-command');
 const { runObsidianCommand } = require('./cli/obsidian-command');
 const { runRatifyCommand } = require('./cli/ratify-command');
+const { runSddGateCommand } = require('./cli/sdd-gate-command');
 
 // Parse command line arguments
 function parseArgs(args) {
@@ -184,6 +185,15 @@ async function main() {
         // arcforge ratify <spec-id> <D-id>
         // Engine B1 gate + interactive informed confirm. See scripts/cli/ratify-command.js.
         await runRatifyCommand(args.positional, projectRoot);
+        break;
+      }
+
+      case 'sdd-gate': {
+        // arcforge sdd-gate <dag|design|context|header|authorize|conflict> ...
+        // Deterministic SDD gates lifting refiner/planner inline node -e recipes.
+        // Stable JSON + exit 0/1/2; header/authorize read draft spec.xml from
+        // stdin. See scripts/cli/sdd-gate-command.js.
+        runSddGateCommand(args, projectRoot);
         break;
       }
 

--- a/scripts/cli/help.js
+++ b/scripts/cli/help.js
@@ -137,6 +137,23 @@ COMMANDS:
                                      (default port: 3334). User-friendly alternative to the
                                      inbox/inspect/accept/activate CLI flow.
 
+  sdd-gate <stage> --spec-id <id> [--design <path>] [--decision-log <path>] [--draft <path>]
+      Deterministic SDD validation gates (refiner / planner). Stable JSON;
+      exit 0 = proceed, 1 = block, 2 = usage error.
+      Stages:
+        dag        DAG completion gate (refiner Phase 1).
+        design     Design-doc validation — needs --design (refiner Phase 2).
+        context    Vision + ledger + graph gate (refiner Phase 2.5b).
+        header     Spec identity-header validation; emits parsed spec_id,
+                   spec_version, latest_delta (planner Phase 1 scope source).
+                   Reads the spec.xml <overview> from stdin (heredoc) or --draft.
+        authorize  Axis-3 mechanical authorization check (refiner Phase 6b);
+                   on block writes specs/<id>/_pending-conflict.md. Needs
+                   --design; reads the combined in-memory draft (overview +
+                   requirements + traces) from stdin or --draft.
+        conflict   Write a _pending-conflict.md from a JSON payload on stdin
+                   (refiner Phase 4 / 5.5a / 5.5b).
+
   research dashboard [--results path] [--config path] [--port N]
                                      Live research experiment dashboard (default port: 3000)
 

--- a/scripts/cli/sdd-gate-command.js
+++ b/scripts/cli/sdd-gate-command.js
@@ -1,0 +1,386 @@
+/**
+ * sdd-gate-command.js — "arcforge sdd-gate <stage> ..." implementation.
+ *
+ * Lifts the six inline `node -e` recipes in arc-refining + arc-planning into a
+ * single deterministic CLI surface. Each stage runs one SDD validator, prints
+ * stable JSON, and exits 0 (proceed) / 1 (block) / 2 (usage error).
+ *
+ * STAGES
+ *   dag        DAG completion gate (refiner Phase 1 / checkDagStatus).
+ *   design     Design-doc validation (refiner Phase 2).
+ *   context    Vision + ledger + spec↔decision graph gate (refiner Phase 2.5b).
+ *   header     Spec identity-header validation (refiner Phase 6a / planner Phase 1).
+ *              [S3-2] Emits the parsed header — spec_id, spec_version, and
+ *              latest_delta {version, iteration, added[], modified[], removed[],
+ *              renamed[]} — so arc-planning Phase 1 reads sprint scope from this
+ *              JSON instead of its own inline `node -e`.
+ *   authorize  Axis-3 mechanical authorization check (refiner Phase 6b). On block,
+ *              deterministically writes specs/<spec-id>/_pending-conflict.md and
+ *              emits axis_fired:'3' in the JSON.
+ *   conflict   Explicit conflict-marker write (refiner Phase 4 / 5.5a / 5.5b).
+ *              Reads the conflict payload as JSON on stdin.
+ *
+ * DRAFT INPUT (header, authorize)
+ *   The draft is read from stdin (heredoc) so a block leaves zero filesystem
+ *   state — eliminating the `_draft_spec.xml` disk-read contradiction.
+ *   `--draft <path>` is a fallback for callers that already have the draft on
+ *   disk. Each stage consumes a single XML stream — no multi-file protocol is
+ *   needed — but the relevant content differs:
+ *     - header reads only the <overview> block (parseSpecHeader), so the
+ *       per-spec spec.xml is the right input.
+ *     - authorize reads the <requirement>/<criterion>/<trace> elements
+ *       (mechanicalAuthorizationCheck via extractTraceEntries). In the on-disk
+ *       SDD v2 layout those live in details/*.xml, NOT in spec.xml — so the
+ *       caller MUST pipe the full in-memory combined draft (overview + every
+ *       requirement + every trace) it built in Phase 5 before the two-pass
+ *       write splits it into spec.xml + details/. extractTraceEntries is a
+ *       token-matcher, so a concatenated single stream is accepted.
+ *
+ * @module sdd-gate-command
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  checkDagStatus,
+  parseDesignDoc,
+  validateDesignDoc,
+  parseVision,
+  validateVision,
+  parseDecisionLedger,
+  getHeadLedgerContent,
+  parseDecisionLedgerContent,
+  validateDecisionLedger,
+  checkSpecDecisionGraph,
+  parseSpecHeader,
+  validateSpecHeader,
+  mechanicalAuthorizationCheck,
+  writeConflictMarker,
+} = require('../lib/sdd-utils');
+
+const STAGES = ['dag', 'design', 'context', 'header', 'authorize', 'conflict'];
+
+// Exit codes — stable contract for skill recipes and tests.
+const EXIT_PASS = 0;
+const EXIT_BLOCK = 1;
+const EXIT_USAGE = 2;
+
+/**
+ * Emit a stage result as a single JSON object on stdout and exit with the
+ * supplied code. Centralized so every stage shares one output shape.
+ */
+function emit(result, exitCode) {
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(exitCode);
+}
+
+/**
+ * Read the draft spec.xml for stages that need it. Prefers --draft <path>;
+ * otherwise reads stdin (the blessed zero-filesystem-state channel). Returns
+ * null when neither is available (caller decides how to surface the usage gap).
+ */
+function readDraft(options) {
+  if (options.draft) {
+    return fs.readFileSync(path.resolve(options.draft), 'utf8');
+  }
+  if (!process.stdin.isTTY) {
+    const stdin = fs.readFileSync(0, 'utf8');
+    if (stdin.trim() !== '') {
+      return stdin;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a path against projectRoot, returning an absolute path.
+ */
+function resolveIn(projectRoot, relOrAbs) {
+  return path.resolve(projectRoot, relOrAbs);
+}
+
+// ---------------------------------------------------------------------------
+// Stage implementations
+// ---------------------------------------------------------------------------
+
+function stageDag(specId, projectRoot) {
+  const dagPath = resolveIn(projectRoot, `specs/${specId}/dag.yaml`);
+  const status = checkDagStatus(dagPath);
+
+  if (status === null) {
+    // No dag.yaml — legal (refined but not yet planned). Proceed.
+    return emit({ stage: 'dag', status: 'pass', dag: null }, EXIT_PASS);
+  }
+  if (status.incomplete === 0) {
+    return emit({ stage: 'dag', status: 'pass', dag: status }, EXIT_PASS);
+  }
+  return emit(
+    {
+      stage: 'dag',
+      status: 'block',
+      dag: status,
+      message: `${status.incomplete} of ${status.total} epics still incomplete — complete current sprint before iterating.`,
+    },
+    EXIT_BLOCK,
+  );
+}
+
+function stageDesign(designPath, projectRoot) {
+  const abs = resolveIn(projectRoot, designPath);
+  const parsed = parseDesignDoc(abs);
+  const result = validateDesignDoc(parsed);
+  const hasError = result.issues.some((i) => i.level === 'ERROR');
+  return emit(
+    { stage: 'design', status: hasError ? 'block' : 'pass', ...result },
+    hasError ? EXIT_BLOCK : EXIT_PASS,
+  );
+}
+
+function stageContext(specId, projectRoot) {
+  // Vision gate — no-op when spec vision absent.
+  const productVisionPath = resolveIn(projectRoot, 'product/vision.md');
+  const specVisionPath = resolveIn(projectRoot, `specs/${specId}/vision.md`);
+  const productParsed = fs.existsSync(productVisionPath) ? parseVision(productVisionPath) : null;
+  const specParsed = fs.existsSync(specVisionPath) ? parseVision(specVisionPath) : null;
+  const visionResult = validateVision(productParsed, specParsed);
+  if (!visionResult.valid) {
+    return emit({ stage: 'context', status: 'block', gate: 'vision', ...visionResult }, EXIT_BLOCK);
+  }
+
+  // Ledger gate — no-op when absent.
+  const ledgerPath = resolveIn(projectRoot, `specs/${specId}/decisions.yml`);
+  const current = parseDecisionLedger(ledgerPath);
+  if (current !== null) {
+    const headContent = getHeadLedgerContent(ledgerPath, projectRoot);
+    const previous = parseDecisionLedgerContent(headContent);
+    const ledgerResult = validateDecisionLedger(current, previous);
+    if (!ledgerResult.valid) {
+      return emit(
+        { stage: 'context', status: 'block', gate: 'ledger', ...ledgerResult },
+        EXIT_BLOCK,
+      );
+    }
+  }
+
+  // Graph gate — spec↔decision↔anchor consistency. No-op when absent.
+  const specXmlPath = resolveIn(projectRoot, `specs/${specId}/spec.xml`);
+  const specXmlContent = fs.existsSync(specXmlPath) ? fs.readFileSync(specXmlPath, 'utf8') : null;
+  const graphResult = checkSpecDecisionGraph({
+    specXmlContent,
+    ledger: current,
+    productVision: productParsed,
+    specVision: specParsed,
+  });
+  if (!graphResult.valid) {
+    return emit({ stage: 'context', status: 'block', gate: 'graph', ...graphResult }, EXIT_BLOCK);
+  }
+
+  return emit({ stage: 'context', status: 'pass' }, EXIT_PASS);
+}
+
+/**
+ * [S3-2] Project the parsed header down to the fields downstream consumers
+ * (planner Phase 1 scope extraction) actually read. Keeps the JSON contract
+ * stable even if parseSpecHeader grows fields.
+ */
+function projectHeader(parsed) {
+  if (!parsed) return null;
+  const d = parsed.latest_delta;
+  return {
+    spec_id: parsed.spec_id,
+    spec_version: parsed.spec_version,
+    latest_delta: d
+      ? {
+          version: d.version,
+          iteration: d.iteration,
+          added: d.added,
+          modified: d.modified,
+          removed: d.removed,
+          renamed: d.renamed,
+        }
+      : null,
+  };
+}
+
+function stageHeader(draftXml) {
+  const parsed = parseSpecHeader(draftXml);
+  const result = validateSpecHeader(parsed);
+  const hasError = result.issues.some((i) => i.level === 'ERROR');
+  return emit(
+    {
+      stage: 'header',
+      status: hasError ? 'block' : 'pass',
+      ...result,
+      header: projectHeader(parsed),
+    },
+    hasError ? EXIT_BLOCK : EXIT_PASS,
+  );
+}
+
+function stageAuthorize(draftXml, specId, options, projectRoot) {
+  const designPath = resolveIn(projectRoot, options.design);
+  const decisionLogPath = options['decision-log']
+    ? resolveIn(projectRoot, options['decision-log'])
+    : null;
+  const ledger = parseDecisionLedger(resolveIn(projectRoot, `specs/${specId}/decisions.yml`));
+
+  const result = mechanicalAuthorizationCheck(draftXml, designPath, decisionLogPath, ledger);
+
+  if (result.valid) {
+    return emit({ stage: 'authorize', status: 'pass' }, EXIT_PASS);
+  }
+
+  // Block: deterministically write the conflict marker (refiner Phase 6b
+  // contract) so recovery state lands on disk regardless of agent behavior.
+  const conflictDescription =
+    'Mechanical authorization check failed: ' +
+    result.unauthorized_traces.map((t) => `${t.trace_value} (${t.reason})`).join('; ');
+  const conflictPath = writeConflictMarker(
+    specId,
+    {
+      axis_fired: '3',
+      conflict_description: conflictDescription,
+      candidate_resolutions: [
+        '(a) Add authorizing source to design.md for the flagged criterion.',
+        '(b) Downgrade the criterion to SHOULD/MAY citing design qualitative phrase.',
+        '(c) Remove the criterion — the axis is unbound without an authorizing source.',
+      ],
+      user_action_prompt: `Run /arc-brainstorming iterate ${specId} to resolve this conflict.`,
+    },
+    projectRoot,
+  );
+
+  return emit(
+    {
+      stage: 'authorize',
+      status: 'block',
+      axis_fired: '3',
+      unauthorized_traces: result.unauthorized_traces,
+      conflict_marker: conflictPath,
+    },
+    EXIT_BLOCK,
+  );
+}
+
+function stageConflict(payloadJson, specId, projectRoot) {
+  let payload;
+  try {
+    payload = JSON.parse(payloadJson);
+  } catch (err) {
+    return emit(
+      {
+        stage: 'conflict',
+        status: 'error',
+        message: `conflict stage expects a JSON payload on stdin: ${err.message}`,
+      },
+      EXIT_USAGE,
+    );
+  }
+  // writeConflictMarker validates required fields and throws with context on a
+  // malformed payload. Catch it here so the conflict stage honors the stable
+  // JSON + exit 2 (usage) contract rather than bubbling to cli.js's plain-text
+  // exit 1.
+  let conflictPath;
+  try {
+    conflictPath = writeConflictMarker(specId, payload, projectRoot);
+  } catch (err) {
+    return emit({ stage: 'conflict', status: 'error', message: err.message }, EXIT_USAGE);
+  }
+  return emit({ stage: 'conflict', status: 'pass', conflict_marker: conflictPath }, EXIT_PASS);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the sdd-gate command. Resolves the stage from positional[0] and the
+ * spec-id from --spec-id, then dispatches. Each stage helper calls emit(),
+ * which exits the process — so this function does not return on the happy path.
+ *
+ * @param {{ positional: string[], options: object }} args - Parsed CLI args.
+ * @param {string} projectRoot - Absolute project root.
+ */
+function runSddGateCommand(args, projectRoot) {
+  const stage = args.positional[0];
+  const options = args.options || {};
+  const specId = options['spec-id'];
+
+  if (!stage || !STAGES.includes(stage)) {
+    console.error(
+      `Usage: arcforge sdd-gate <${STAGES.join('|')}> --spec-id <id> [--design <path>] [--decision-log <path>] [--draft <path>]`,
+    );
+    process.exit(EXIT_USAGE);
+  }
+
+  // Stages keyed on a spec-id require it; design takes a --design path instead.
+  const needsSpecId = stage !== 'design';
+  if (needsSpecId && (typeof specId !== 'string' || specId.trim() === '')) {
+    console.error(`Error: sdd-gate ${stage} requires --spec-id <id>`);
+    process.exit(EXIT_USAGE);
+  }
+
+  switch (stage) {
+    case 'dag':
+      return stageDag(specId, projectRoot);
+
+    case 'design': {
+      if (!options.design) {
+        console.error('Error: sdd-gate design requires --design <path-to-design.md>');
+        process.exit(EXIT_USAGE);
+      }
+      return stageDesign(options.design, projectRoot);
+    }
+
+    case 'context':
+      return stageContext(specId, projectRoot);
+
+    case 'header': {
+      const draftXml = readDraft(options);
+      if (draftXml === null) {
+        console.error(
+          'Error: sdd-gate header reads the draft spec.xml from stdin (heredoc) or --draft <path>',
+        );
+        process.exit(EXIT_USAGE);
+      }
+      return stageHeader(draftXml);
+    }
+
+    case 'authorize': {
+      if (!options.design) {
+        console.error('Error: sdd-gate authorize requires --design <path-to-design.md>');
+        process.exit(EXIT_USAGE);
+      }
+      const draftXml = readDraft(options);
+      if (draftXml === null) {
+        console.error(
+          'Error: sdd-gate authorize reads the draft spec.xml from stdin (heredoc) or --draft <path>',
+        );
+        process.exit(EXIT_USAGE);
+      }
+      return stageAuthorize(draftXml, specId, options, projectRoot);
+    }
+
+    case 'conflict': {
+      if (process.stdin.isTTY) {
+        console.error('Error: sdd-gate conflict reads a JSON conflict payload from stdin');
+        process.exit(EXIT_USAGE);
+      }
+      const payloadJson = fs.readFileSync(0, 'utf8');
+      return stageConflict(payloadJson, specId, projectRoot);
+    }
+
+    default:
+      // Unreachable — STAGES allowlist guards above.
+      process.exit(EXIT_USAGE);
+  }
+}
+
+module.exports = {
+  runSddGateCommand,
+  STAGES,
+  EXIT_PASS,
+  EXIT_BLOCK,
+  EXIT_USAGE,
+  projectHeader,
+};

--- a/tests/node/test-sdd-gate-cli.js
+++ b/tests/node/test-sdd-gate-cli.js
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * tests/node/test-sdd-gate-cli.js — Integration tests for "arcforge sdd-gate <stage>"
+ *
+ * SDD-6 acceptance criteria (capability-seam-fix plan):
+ * - Each stage CLI fixture check: stable JSON + exit 0 (pass) / 1 (block) / 2 (usage).
+ * - unauthorized → exit 1 + marker axis_fired:'3'; authorize ratified/clean → exit 0, no marker.
+ * - [S3-2] sdd-v2 fixture's delta refs appear in the header-stage gate JSON output.
+ * - draft read from stdin (zero filesystem state on block) + --draft fallback.
+ * - dag/design/context/conflict stage behaviors.
+ */
+
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const CLI_PATH = path.resolve(__dirname, '../../scripts/cli.js');
+const V2_SPEC_XML = path.resolve(
+  __dirname,
+  '../integration/sdd-v2-pipeline/fixture/specs/demo-spec/spec.xml',
+);
+
+console.log('Testing arcforge sdd-gate CLI...\n');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-sddgate-test-'));
+}
+
+/** Run sdd-gate with optional stdin. Returns { stdout, stderr, exitCode, json }. */
+function runGate(tmpDir, args, { input } = {}) {
+  const env = { ...process.env, CLAUDE_PROJECT_DIR: tmpDir };
+  const opts = { encoding: 'utf8', env, cwd: tmpDir };
+  if (input !== undefined) opts.input = input;
+  let result;
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, 'sdd-gate', ...args], opts);
+    result = { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    result = { stdout: err.stdout || '', stderr: err.stderr || '', exitCode: err.status || 1 };
+  }
+  try {
+    result.json = JSON.parse(result.stdout);
+  } catch {
+    result.json = null;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Usage / dispatch
+// ---------------------------------------------------------------------------
+
+test('no stage → usage error exit 2', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, []);
+  assert.strictEqual(r.exitCode, 2);
+  assert.match(r.stderr, /Usage: arcforge sdd-gate/);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('unknown stage → usage error exit 2', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['bogus', '--spec-id', 'x']);
+  assert.strictEqual(r.exitCode, 2);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('stage requiring spec-id without --spec-id → exit 2', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['dag']);
+  assert.strictEqual(r.exitCode, 2);
+  assert.match(r.stderr, /requires --spec-id/);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// dag stage
+// ---------------------------------------------------------------------------
+
+test('dag: no dag.yaml → pass exit 0', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['dag', '--spec-id', 'demo']);
+  assert.strictEqual(r.exitCode, 0);
+  assert.strictEqual(r.json.stage, 'dag');
+  assert.strictEqual(r.json.status, 'pass');
+  assert.strictEqual(r.json.dag, null);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('dag: all epics completed → pass exit 0', () => {
+  const tmp = makeTmpDir();
+  fs.mkdirSync(path.join(tmp, 'specs/demo'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmp, 'specs/demo/dag.yaml'),
+    'epics:\n  - id: e1\n    status: completed\n',
+  );
+  const r = runGate(tmp, ['dag', '--spec-id', 'demo']);
+  assert.strictEqual(r.exitCode, 0);
+  assert.strictEqual(r.json.status, 'pass');
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('dag: incomplete epic → block exit 1 with incompleteEpics', () => {
+  const tmp = makeTmpDir();
+  fs.mkdirSync(path.join(tmp, 'specs/demo'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmp, 'specs/demo/dag.yaml'),
+    'epics:\n  - id: e1\n    status: completed\n  - id: e2\n    status: pending\n',
+  );
+  const r = runGate(tmp, ['dag', '--spec-id', 'demo']);
+  assert.strictEqual(r.exitCode, 1);
+  assert.strictEqual(r.json.status, 'block');
+  assert.strictEqual(r.json.dag.incomplete, 1);
+  assert.strictEqual(r.json.dag.incompleteEpics[0].id, 'e2');
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// design stage
+// ---------------------------------------------------------------------------
+
+test('design: missing file → block exit 1', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['design', '--design', 'docs/plans/x/none/design.md']);
+  assert.strictEqual(r.exitCode, 1);
+  assert.strictEqual(r.json.stage, 'design');
+  assert.strictEqual(r.json.status, 'block');
+  assert.ok(r.json.issues.some((i) => i.level === 'ERROR'));
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('design: without --design → usage error exit 2', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['design']);
+  assert.strictEqual(r.exitCode, 2);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// context stage
+// ---------------------------------------------------------------------------
+
+test('context: no vision/ledger/spec → pass (no-op) exit 0', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['context', '--spec-id', 'demo']);
+  assert.strictEqual(r.exitCode, 0);
+  assert.strictEqual(r.json.stage, 'context');
+  assert.strictEqual(r.json.status, 'pass');
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// header stage — [S3-2] delta refs in JSON
+// ---------------------------------------------------------------------------
+
+test('header: stdin draft emits parsed header with spec_id + spec_version', () => {
+  const tmp = makeTmpDir();
+  const xml = fs.readFileSync(V2_SPEC_XML, 'utf8');
+  const r = runGate(tmp, ['header', '--spec-id', 'demo-spec'], { input: xml });
+  assert.strictEqual(r.json.stage, 'header');
+  assert.ok(r.json.header, 'header projection present');
+  assert.strictEqual(r.json.header.spec_id, 'demo-spec');
+  assert.strictEqual(r.json.header.spec_version, 1);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('[S3-2] header: sdd-v2 fixture delta refs appear in gate JSON output', () => {
+  const tmp = makeTmpDir();
+  const xml = fs.readFileSync(V2_SPEC_XML, 'utf8');
+  const r = runGate(tmp, ['header', '--spec-id', 'demo-spec'], { input: xml });
+  const delta = r.json.header.latest_delta;
+  assert.ok(delta, 'latest_delta present');
+  assert.strictEqual(delta.version, '1');
+  assert.strictEqual(delta.iteration, '2026-04-17');
+  const addedRefs = delta.added.map((a) => a.ref);
+  // The fixture's delta lists six <added> refs — all must surface in JSON.
+  for (const ref of [
+    'fr-parser-001',
+    'fr-parser-002',
+    'fr-formatter-001',
+    'fr-formatter-002',
+    'fr-integration-001',
+    'fr-integration-002',
+  ]) {
+    assert.ok(addedRefs.includes(ref), `delta ref ${ref} present in JSON output`);
+  }
+  assert.ok(Array.isArray(delta.modified));
+  assert.ok(Array.isArray(delta.removed));
+  assert.ok(Array.isArray(delta.renamed));
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('header: --draft fallback reads from disk', () => {
+  const tmp = makeTmpDir();
+  const draftPath = path.join(tmp, 'draft.xml');
+  fs.copyFileSync(V2_SPEC_XML, draftPath);
+  const r = runGate(tmp, ['header', '--spec-id', 'demo-spec', '--draft', draftPath]);
+  assert.strictEqual(r.json.header.spec_id, 'demo-spec');
+  assert.strictEqual(r.json.header.latest_delta.added.length, 6);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('header: valid header + existing design_path → pass exit 0', () => {
+  const tmp = makeTmpDir();
+  fs.mkdirSync(path.join(tmp, 'docs/plans/hp/2026-06-15'), { recursive: true });
+  fs.writeFileSync(path.join(tmp, 'docs/plans/hp/2026-06-15/design.md'), 'design');
+  const xml =
+    '<spec><overview>' +
+    '<spec_id>hp</spec_id><spec_version>1</spec_version><status>active</status>' +
+    '<title>HP</title><description>d</description>' +
+    '<source><design_path>docs/plans/hp/2026-06-15/design.md</design_path>' +
+    '<design_iteration>2026-06-15</design_iteration></source>' +
+    '<scope><includes><feature id="f1">a</feature></includes>' +
+    '<excludes><reason>none</reason></excludes></scope>' +
+    '</overview></spec>';
+  const r = runGate(tmp, ['header', '--spec-id', 'hp'], { input: xml });
+  assert.strictEqual(r.exitCode, 0);
+  assert.strictEqual(r.json.status, 'pass');
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// authorize stage — unauthorized → exit 1 + axis_fired:'3' + marker write
+// ---------------------------------------------------------------------------
+
+test('authorize: unauthorized trace → exit 1 + axis_fired:3 + writes _pending-conflict.md', () => {
+  const tmp = makeTmpDir();
+  fs.mkdirSync(path.join(tmp, 'docs/plans/demo/2026-06-15'), { recursive: true });
+  fs.writeFileSync(path.join(tmp, 'docs/plans/demo/2026-06-15/design.md'), '# Design\n');
+  // Realistic combined draft: overview + the trace-bearing requirements inline,
+  // exactly the single XML stream the refiner holds in memory before the
+  // two-pass write splits it into spec.xml + details/*.xml. The traces do NOT
+  // live in <overview> — they live alongside requirements — so authorize must
+  // receive this combined stream, not the overview-only spec.xml.
+  const draft =
+    '<spec><overview><spec_id>demo</spec_id></overview>' +
+    '<requirement id="fr-x-001"><criterion id="ac1">MUST X' +
+    '<trace>D-999:60s</trace></criterion></requirement></spec>';
+  const r = runGate(
+    tmp,
+    ['authorize', '--spec-id', 'demo', '--design', 'docs/plans/demo/2026-06-15/design.md'],
+    { input: draft },
+  );
+  assert.strictEqual(r.exitCode, 1);
+  assert.strictEqual(r.json.stage, 'authorize');
+  assert.strictEqual(r.json.status, 'block');
+  assert.strictEqual(r.json.axis_fired, '3');
+  assert.strictEqual(r.json.unauthorized_traces[0].trace_value, 'D-999:60s');
+  const markerPath = path.join(tmp, 'specs/demo/_pending-conflict.md');
+  assert.ok(fs.existsSync(markerPath), '_pending-conflict.md written on block');
+  const marker = fs.readFileSync(markerPath, 'utf8');
+  assert.match(marker, /axis_fired: 3/);
+  assert.match(marker, /candidate_resolutions:/);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('authorize: clean combined draft (authorized trace) → pass exit 0, no marker written', () => {
+  const tmp = makeTmpDir();
+  fs.mkdirSync(path.join(tmp, 'docs/plans/demo/2026-06-15'), { recursive: true });
+  // Design content contains the cited section so the design-trace is authorized.
+  fs.writeFileSync(
+    path.join(tmp, 'docs/plans/demo/2026-06-15/design.md'),
+    '# Design\n\n## Architecture\nThe parser handles ints.\n',
+  );
+  const draft =
+    '<spec><overview><spec_id>demo</spec_id></overview>' +
+    '<requirement id="fr-x-001"><criterion id="ac1">MUST parse ints' +
+    '<trace>2026-06-15:Architecture</trace></criterion></requirement></spec>';
+  const r = runGate(
+    tmp,
+    ['authorize', '--spec-id', 'demo', '--design', 'docs/plans/demo/2026-06-15/design.md'],
+    { input: draft },
+  );
+  assert.strictEqual(r.exitCode, 0);
+  assert.strictEqual(r.json.status, 'pass');
+  assert.ok(
+    !fs.existsSync(path.join(tmp, 'specs/demo/_pending-conflict.md')),
+    'no marker written on pass',
+  );
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('authorize: contract — traces live with requirements, NOT in <overview>', () => {
+  // Pins the input contract: authorize must receive the combined trace-bearing
+  // draft. An overview-only stream (the on-disk SDD v2 spec.xml shape, whose
+  // requirements/traces live in details/*.xml) carries zero traces, so the
+  // mechanical check has nothing to flag and passes vacuously. This is by
+  // design — the caller (refiner Phase 6b) is responsible for piping the
+  // combined in-memory draft, not the overview-only spec.xml.
+  const tmp = makeTmpDir();
+  fs.mkdirSync(path.join(tmp, 'docs/plans/demo/2026-06-15'), { recursive: true });
+  fs.writeFileSync(path.join(tmp, 'docs/plans/demo/2026-06-15/design.md'), '# Design\n');
+  const overviewOnly =
+    '<spec><overview><spec_id>demo</spec_id></overview>' +
+    '<details><detail_file path="details/core.xml" /></details></spec>';
+  const r = runGate(
+    tmp,
+    ['authorize', '--spec-id', 'demo', '--design', 'docs/plans/demo/2026-06-15/design.md'],
+    { input: overviewOnly },
+  );
+  // No inline traces → vacuous pass. Documented contract, not a bug.
+  assert.strictEqual(r.exitCode, 0);
+  assert.strictEqual(r.json.status, 'pass');
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('authorize: without --design → usage error exit 2', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['authorize', '--spec-id', 'demo'], { input: '<spec/>' });
+  assert.strictEqual(r.exitCode, 2);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// conflict stage — explicit marker write from JSON payload on stdin
+// ---------------------------------------------------------------------------
+
+test('conflict: valid payload → writes marker, pass exit 0', () => {
+  const tmp = makeTmpDir();
+  const payload = JSON.stringify({
+    axis_fired: '1',
+    conflict_description: 'REQ-A vs REQ-B',
+    candidate_resolutions: ['(a) keep A', '(b) keep B'],
+    user_action_prompt: 'iterate demo',
+  });
+  const r = runGate(tmp, ['conflict', '--spec-id', 'demo'], { input: payload });
+  assert.strictEqual(r.exitCode, 0);
+  assert.strictEqual(r.json.stage, 'conflict');
+  assert.strictEqual(r.json.status, 'pass');
+  const markerPath = path.join(tmp, 'specs/demo/_pending-conflict.md');
+  assert.ok(fs.existsSync(markerPath));
+  assert.match(fs.readFileSync(markerPath, 'utf8'), /axis_fired: 1/);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('conflict: malformed JSON payload → usage error exit 2', () => {
+  const tmp = makeTmpDir();
+  const r = runGate(tmp, ['conflict', '--spec-id', 'demo'], { input: 'not json{' });
+  assert.strictEqual(r.exitCode, 2);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('conflict: missing required field → stable JSON + usage error exit 2', () => {
+  const tmp = makeTmpDir();
+  const payload = JSON.stringify({ axis_fired: '1' });
+  const r = runGate(tmp, ['conflict', '--spec-id', 'demo'], { input: payload });
+  assert.strictEqual(r.exitCode, 2);
+  assert.ok(r.json, 'emits stable JSON (not plain-text stderr)');
+  assert.strictEqual(r.json.stage, 'conflict');
+  assert.strictEqual(r.json.status, 'error');
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Wave 2 (PR-2f-engine; SDD-6 split per plan line 450). ENGINE LAYER ONLY — committed green, zero skill edits. New scripts/cli/sdd-gate-command.js: stages dag/design/context/header/authorize/conflict; stable JSON + exit 0/1/2; draft via stdin heredoc (+ --draft fallback, zero filesystem state on block); authorize-fail deterministically writes _pending-conflict.md; S3-2 header stage emits spec_id/spec_version/latest_delta{...} for arc-planning Phase 1. cli.js sdd-gate case kept separate from the merge case; cli.js under 700.

## Deferred to PR-2f-skill (not in this PR)
The six inline `node -e` recipe swaps in arc-refining/arc-planning go RED against pinned pytest assertions (test_skill_arc_refining/_planning) that pin the OLD function names as the spec contract — retargeting those is a spec-traceability decision belonging with the skill PR + the SDD-8 eval. Investigated and ruled out: the 'stdin draft vs multi-file output' stop did NOT fire (authorize consumes one combined XML stream; no tar protocol needed).