### PR TITLE
feat(cli): loop launch blessed form, resume ergonomics, teammates dev-branch (AF-3, AF-5, AF-6)

### DIFF
--- a/agents/loop-operator.md
+++ b/agents/loop-operator.md
@@ -22,6 +22,9 @@ Read `.arcforge-loop.json` in the project root:
   "iteration": 12,
   "pattern": "sequential",
   "started_at": "...",
+  "max_runs": 50,
+  "max_cost": 10,
+  "run_id": "...",
   "completed_tasks": ["feat-001-01", ...],
   "failed_tasks": ["feat-002-03"],
   "errors": [...],
@@ -31,19 +34,26 @@ Read `.arcforge-loop.json` in the project root:
 }
 ```
 
+`max_runs`, `max_cost`, and `run_id` are persisted at run start. Use them
+as denominators: budget headroom is `max_cost - total_cost` (or "unbounded"
+when `max_cost` is null), iteration headroom is `max_runs - iteration`.
+A resumed loop carries a new `run_id`; `errors` may include entries from
+earlier runs, so weigh recent (current-`run_id`) errors most heavily.
+
 ### Step 2: Check for Problems
 
 | Problem | Detection | Severity |
 |---------|-----------|----------|
 | **Stall** | No progress across 2+ iterations | High — loop is wasting resources |
 | **Retry storm** | Same task_id appears 3+ times in errors | High — fundamental issue |
-| **Cost overrun** | total_cost exceeding expected | Medium — budget risk |
+| **Cost overrun** | total_cost approaching/exceeding `max_cost` (budget denominator) | Medium — budget risk |
+| **Iteration exhaustion** | iteration approaching `max_runs` with work remaining | Medium — loop will hit max_runs before completing |
 | **Error accumulation** | Error count growing faster than completions | Medium — degrading quality |
 | **Blocked cascade** | Multiple tasks blocked by same dependency | Medium — needs manual unblock |
 
 ### Step 3: Check DAG Status
 
-Run `node scripts/cli.js status --json` to see:
+Run `node "${ARCFORGE_ROOT}/scripts/cli.js" status --json` to see:
 - How many tasks are completed vs remaining
 - Whether blocked tasks are preventing progress
 - Whether the completion ratio matches expectations

--- a/scripts/cli/dag-commands.js
+++ b/scripts/cli/dag-commands.js
@@ -199,6 +199,13 @@ function runLoop(args, { projectRoot, specFlag }) {
     process.exit(1);
   }
 
+  // --reset archives any existing state file before this run starts, so the
+  // loop begins from a clean state. Deliberate pre-run action — never mid-run.
+  if (args.flags.reset) {
+    const { resetLoopState } = require('../lib/loop-state');
+    resetLoopState(projectRoot);
+  }
+
   const epic = args.options.epic || null;
   const loopOptions = {
     pattern,

--- a/scripts/cli/help.js
+++ b/scripts/cli/help.js
@@ -82,7 +82,7 @@ COMMANDS:
       --example    Show complete example
 
   loop [--pattern sequential|dag] [--max-runs N] [--max-cost N] [--epic <id>] [--spec-id <id>]
-       [--task-timeout N] [--permission-mode <mode>] [--allowed-tools <tools>]
+       [--task-timeout N] [--permission-mode <mode>] [--allowed-tools <tools>] [--reset]
       Run autonomous cross-session execution loop.
       --pattern          Execution pattern: sequential (default) or dag
       --epic             Scope loop to a single epic (auto-detected in worktrees)
@@ -91,6 +91,7 @@ COMMANDS:
       --task-timeout     Per-session timeout in seconds (default: 600)
       --permission-mode  Pass --permission-mode through to spawned claude sessions
       --allowed-tools    Pass --allowed-tools through to spawned claude sessions
+      --reset            Archive prior state to .arcforge-loop.archive/ and start fresh
 
   eval list                          List eval scenarios
   eval run <name> [--k N] [--model]  Run eval trials

--- a/scripts/lib/loop-state.js
+++ b/scripts/lib/loop-state.js
@@ -7,11 +7,13 @@
  * orchestration flow and delegates all state handling here.
  */
 
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 const { getTimestamp, readFileSafe } = require('./utils');
 
 const LOOP_STATE_FILE = '.arcforge-loop.json';
+const LOOP_ARCHIVE_DIR = '.arcforge-loop.archive';
 const MAX_ERRORS_KEPT = 20;
 const STALL_THRESHOLD = 2; // iterations without progress
 
@@ -58,6 +60,59 @@ function saveLoopState(state, projectRoot) {
 }
 
 /**
+ * Stamp the run configuration onto loaded state at the start of a run.
+ * Persisting pattern/max_runs/max_cost makes a resumed loop self-describing
+ * (the loop-operator can compute budget headroom without re-deriving flags).
+ * A fresh run_id scopes stall/retry-storm detection to the current run so a
+ * resumed loop is not condemned by a previous run's accumulated errors.
+ * @param {Object} state - Loop state (mutated in place)
+ * @param {Object} runConfig - Run configuration
+ * @param {string} runConfig.pattern - Execution pattern
+ * @param {number} runConfig.maxRuns - Maximum iterations for this run
+ * @param {number|null} [runConfig.maxCost] - Cost ceiling for this run
+ * @returns {Object} The same state
+ */
+function beginRun(state, { pattern, maxRuns, maxCost = null }) {
+  state.pattern = pattern;
+  state.max_runs = maxRuns;
+  state.max_cost = maxCost;
+  state.run_id = crypto.randomUUID();
+  state.run_started_iteration = state.iteration;
+  return state;
+}
+
+/**
+ * Reset loop state by archiving the current state file, then return fresh
+ * state. The archive lands at `.arcforge-loop.archive/<started_at>.json`
+ * (timestamp colons sanitized for cross-platform filenames). Resume safety
+ * (AF-2 sentinel) is unaffected: reset is a deliberate pre-run action, so
+ * the only window without a state file is before the next run starts.
+ * @param {string} projectRoot - Project root directory
+ * @returns {Object} Fresh loop state
+ */
+function resetLoopState(projectRoot) {
+  const statePath = path.join(projectRoot, LOOP_STATE_FILE);
+  const content = readFileSafe(statePath);
+  if (content) {
+    let startedAt = getTimestamp();
+    try {
+      startedAt = JSON.parse(content).started_at || startedAt;
+    } catch {
+      /* keep the fallback timestamp for unparseable archives */
+    }
+    const archiveDir = path.join(projectRoot, LOOP_ARCHIVE_DIR);
+    const archiveName = `${startedAt.replace(/[:]/g, '-')}.json`;
+    try {
+      fs.mkdirSync(archiveDir, { recursive: true });
+      fs.renameSync(statePath, path.join(archiveDir, archiveName));
+    } catch (err) {
+      throw new Error(`Failed to archive loop state at ${statePath}: ${err.message}`);
+    }
+  }
+  return loadLoopState(projectRoot);
+}
+
+/**
  * Record an error to loop state, capping at MAX_ERRORS_KEPT
  * @param {Object} state - Loop state
  * @param {string} taskId - Failing task id
@@ -65,17 +120,33 @@ function saveLoopState(state, projectRoot) {
  * @param {number} attempt - Attempt number for this task
  */
 function recordError(state, taskId, errorMsg, attempt) {
-  state.errors.push({
+  const entry = {
     task_id: taskId,
     iteration: state.iteration,
     error: errorMsg.slice(0, 500),
     timestamp: getTimestamp(),
     attempt,
-  });
+  };
+  // Stamp the current run so stall/retry-storm detection can scope to it.
+  if (state.run_id) entry.run_id = state.run_id;
+  state.errors.push(entry);
   // Cap errors to prevent unbounded growth in long runs
   if (state.errors.length > MAX_ERRORS_KEPT) {
     state.errors = state.errors.slice(-MAX_ERRORS_KEPT);
   }
+}
+
+/**
+ * Errors scoped to the current run when run_id is set; otherwise the full
+ * list (legacy state has no run_id and keeps its original whole-state
+ * semantics). Errors stamped by an earlier run are excluded once run_id is
+ * present, so a resumed loop starts its safety counters from zero.
+ * @param {Object} state - Loop state
+ * @returns {Array} Errors belonging to the current run
+ */
+function currentRunErrors(state) {
+  if (!state.run_id) return state.errors;
+  return state.errors.filter((e) => e.run_id === state.run_id);
 }
 
 /**
@@ -99,10 +170,16 @@ function finalizeLoop(state, maxRuns, projectRoot) {
  * @returns {boolean} Whether the loop is stalled
  */
 function isStalled(state) {
+  const errors = currentRunErrors(state);
   if (!state.last_progress_at) {
-    return state.iteration >= STALL_THRESHOLD;
+    // Run-scoped: count iterations since this run began so a resumed loop
+    // (cumulative `iteration` already high) is not flagged stalled on entry.
+    const iterations = state.run_id
+      ? state.iteration - (state.run_started_iteration || 0)
+      : state.iteration;
+    return iterations >= STALL_THRESHOLD;
   }
-  const recentErrors = state.errors.filter((e) => e.timestamp > state.last_progress_at);
+  const recentErrors = errors.filter((e) => e.timestamp > state.last_progress_at);
   return recentErrors.length >= STALL_THRESHOLD;
 }
 
@@ -112,9 +189,10 @@ function isStalled(state) {
  * @returns {boolean} Whether a retry storm is detected
  */
 function isRetryStorm(state) {
-  if (state.errors.length < 3) return false;
+  const errors = currentRunErrors(state);
+  if (errors.length < 3) return false;
 
-  const recentErrors = state.errors.slice(-6);
+  const recentErrors = errors.slice(-6);
   const taskCounts = {};
   for (const err of recentErrors) {
     taskCounts[err.task_id] = (taskCounts[err.task_id] || 0) + 1;
@@ -160,8 +238,12 @@ function printSummary(state) {
 }
 
 module.exports = {
+  LOOP_STATE_FILE,
+  LOOP_ARCHIVE_DIR,
   loadLoopState,
   saveLoopState,
+  beginRun,
+  resetLoopState,
   recordError,
   finalizeLoop,
   isStalled,

--- a/scripts/loop.js
+++ b/scripts/loop.js
@@ -20,7 +20,13 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { Coordinator } = require('./lib/coordinator');
 const { spawnSession, spawnSessionAsync } = require('./lib/loop-session');
-const { loadLoopState, saveLoopState, recordError, finalizeLoop } = require('./lib/loop-state');
+const {
+  loadLoopState,
+  saveLoopState,
+  beginRun,
+  recordError,
+  finalizeLoop,
+} = require('./lib/loop-state');
 const { isStalled, isRetryStorm, checkStopConditions, printSummary } = require('./lib/loop-state');
 const { Feature } = require('./lib/models');
 const {
@@ -397,7 +403,7 @@ function tryCreateCoordinator(projectRoot, state, specId = null) {
 function runSequential(options) {
   const { projectRoot, maxRuns, maxCost, epic } = options;
   const state = loadLoopState(projectRoot);
-  state.pattern = 'sequential';
+  beginRun(state, { pattern: 'sequential', maxRuns, maxCost });
   const epicScope = resolveEpicScope(epic, projectRoot);
 
   console.log(`[loop] Starting sequential loop (max ${maxRuns} runs)`);
@@ -443,7 +449,7 @@ function runSequential(options) {
 async function runDag(options) {
   const { projectRoot, maxRuns, maxCost, epic } = options;
   const state = loadLoopState(projectRoot);
-  state.pattern = 'dag';
+  beginRun(state, { pattern: 'dag', maxRuns, maxCost });
   const epicScope = resolveEpicScope(epic, projectRoot);
 
   console.log(`[loop] Starting DAG loop (max ${maxRuns} runs)`);

--- a/skills/arc-dispatching-teammates/SKILL.md
+++ b/skills/arc-dispatching-teammates/SKILL.md
@@ -7,9 +7,9 @@ description: Use when specs/<spec-id>/dag.yaml has 2+ ready epics and the lead i
 
 ## Overview
 
-Dispatch one Claude Code **agent teammate** per ready epic. Lead stays present, messages teammates via SendMessage, intervenes on blockers. Teammates implement inside isolated worktrees and merge back to a short-lived dev branch — intermediate noise (retries, fix-forward commits) is fine; the deliverable is stability at HEAD, not clean history. The user decides promotion afterward.
+Dispatch one Claude Code **agent teammate** per ready epic. Lead stays present, messages teammates via SendMessage, intervenes on blockers. Teammates implement inside isolated worktrees and merge back to a short-lived dev branch — intermediate noise (retries, fix-forward commits) is fine.
 
-**Core principle:** Teammates are the arcforge-supported substrate for lead-present multi-epic parallelism. Manual "open N Claude windows" is a fallback, not the default. Don't over-protect the dev branch, don't pre-identify conflicts — let runtime handle runtime.
+**Core principle:** Teammates are the arcforge-supported substrate for lead-present multi-epic parallelism. Manual "open N Claude windows" is a fallback, not the default. Don't pre-identify conflicts — let runtime handle runtime.
 
 ## When to Use
 
@@ -32,6 +32,7 @@ Dispatch one Claude Code **agent teammate** per ready epic. Lead stays present, 
 2. **Single spec.** Cross-spec ready epics → report blocked, user picks with `--spec-id <id>`.
 3. **Agent tool supports `team_name` and `name`.** If dispatch errors with "unknown parameter team_name", report blocked.
 4. **Lead is in project root**, not a worktree. Move to base worktree if `.arcforge-epic` is in cwd.
+5. **On a dev branch, not `main`/`master`.** Teammates merge back to the lead's branch. If on `main`/`master`, create one first: `git switch -c dispatch/<spec-id>-$(date +%Y-%m-%d)`. If the user named a branch, or the lead is already off the default, use that — never override an explicit choice.
 
 Precondition failure = hard fail. Do not silently fall back to arc-looping or manual juggling.
 
@@ -39,12 +40,12 @@ Precondition failure = hard fail. Do not silently fall back to arc-looping or ma
 
 1. **Identify ready epics.** From `arcforge status --json`, collect every epic with `status: pending` and `worktree: null`. Call this set R.
 
-2. **Cap team size at 5.** If `|R| > 5`, take the first 5 as the initial team and queue the rest. ≤5 teammates is Anthropic's documented best practice; beyond 5 coordination overhead exceeds benefit.
+2. **Cap team size at 5 (default).** If `|R| > 5`, take the first 5 as the initial team and queue the rest. ≤5 teammates is Anthropic's documented best practice; beyond 5 coordination overhead exceeds benefit. Honor a higher cap only when the user explicitly asks for one.
 
 3. **`TeamCreate` BEFORE any Agent dispatch.** Use a descriptive name like `dispatch-<project>-<timestamp>`. Per [Agent Teams docs](https://code.claude.com/docs/en/agent-teams), passing `team_name` to Agent does NOT auto-create — it triggers a state-sync bug.
 
 4. **Expand worktrees and dispatch teammates in parallel.** For each epic in the initial 5:
-   - `node scripts/cli.js expand --epic <epic-id>` from the project root — creates the canonical worktree and stamps `.arcforge-epic`. Per-epic, not batch.
+   - `node "${ARCFORGE_ROOT}/scripts/cli.js" expand --epic <epic-id>` from the project root — creates the canonical worktree and stamps `.arcforge-epic`. Per-epic, not batch.
    - Read the absolute worktree path from `arcforge status --json`; do not reconstruct it.
    - Dispatch via Agent with `team_name=<team>`, `name=worker-<epic-id>`, spawn prompt from `references/spawn-prompt-template.md`.
 
@@ -66,7 +67,7 @@ Precondition failure = hard fail. Do not silently fall back to arc-looping or ma
 7. **Retry loop (on rejection).** Up to **3 retries per epic** (max 4 total attempts). On rejection:
    - Shut down the rejected teammate's session (reclaim the pane).
    - Formulate feedback naming the failed criterion, quoting spec text verbatim, stating current-vs-required behavior.
-   - `node scripts/cli.js expand --epic <epic-id>` — fresh worktree, fix-forward from current dev HEAD.
+   - `node "${ARCFORGE_ROOT}/scripts/cli.js" expand --epic <epic-id>` — fresh worktree, fix-forward from current dev HEAD.
    - Dispatch `worker-<epic-id>-retry<N>` using `references/spawn-prompt-template.md` with a prepended `## Previous Attempt Feedback` section (cumulative).
    - Track retry count in session memory. Retry 3 also fails → mark **permanently failed**, record reason for Step 8.
 
@@ -75,7 +76,7 @@ Precondition failure = hard fail. Do not silently fall back to arc-looping or ma
 8. **Wrap up (three actions, in order).** When every epic reaches a terminal state:
 
    - **8a.** Emit the Final Report (format below). The dev branch IS the deliverable — do NOT auto-merge to main or revert failed epics. Those are user decisions.
-   - **8b.** Clean up **accepted** worktrees from the project root: `node scripts/cli.js cleanup <accepted-epic-id-1> <accepted-epic-id-2> ...`. The merge commits are already on the dev branch; the worktrees are orphaned scaffolding. **Skip** permanently failed epics — the user may need their worktree to debug. Do NOT call cleanup from inside a teammate's worktree — per Agent Teams docs, teammates should not run cleanup.
+   - **8b.** Clean up **accepted** worktrees from the project root: `node "${ARCFORGE_ROOT}/scripts/cli.js" cleanup <accepted-epic-id-1> <accepted-epic-id-2> ...`. The merge commits are already on the dev branch; the worktrees are orphaned scaffolding. **Skip** permanently failed epics — the user may need their worktree to debug. Do NOT call cleanup from inside a teammate's worktree — per Agent Teams docs, teammates should not run cleanup.
    - **8c.** Shut down any remaining teammates (most already down from Steps 6/7), then call `TeamDelete`. See `references/wrap-up-sequence.md` for ordering and failure handling.
 
 ## Spawn Prompt Template
@@ -92,9 +93,10 @@ Rationalizations observed in baseline testing. If you catch yourself saying any 
 - **"`arc-dispatching-parallel` already covers this."** No — that skill is feature-level inside one worktree. This is epic-level across worktrees.
 - **"Let me spawn 8 teammates since there are 8 ready epics."** Cap at 5. Queue the rest. Continuous dispatch.
 - **"Worktrees already exist, so I'll just dispatch."** Fine — skip the expand step for epics whose worktree is non-null. Do not re-expand.
+- **"I'm on `main`, dispatching from here is fine."** No — teammates merge back to the lead's branch. Create a dev branch first (Precondition 5).
 - **"Parallel burst hit `Failed to create teammate pane` — downscale the team."** No. You hit GH #40168. Retry the failed spawns sequentially. See `references/tmux-timing-race.md`.
 - **"I need to tell teammates which shared files to avoid."** No. Let conflicts happen; arc-finishing-epic escalates them via the Merge Conflict (Multi-Teammate) path. Static prediction is over-engineering.
-- **"Pin arcforge version: `ARCFORGE_ROOT=... node "${ARCFORGE_ROOT}/scripts/cli.js"`."** POSIX footgun — `"${VAR}"` expands before the inline assignment. Use plain `node scripts/cli.js ...`.
+- **"Pin arcforge version inline: `ARCFORGE_ROOT=... node "${ARCFORGE_ROOT}/scripts/cli.js"`."** POSIX footgun — `"${VAR}"` expands before the inline assignment, resolving to the *old* value. `export ARCFORGE_ROOT=...` on its own line first, then the blessed form.
 - **"I already know what this epic does — I'll skip the spec-reviewer and just map test names to ACs."** This is the qmd baseline failure verbatim. The lead's prior context is precisely what makes inline acceptance unreliable. Always dispatch `arcforge:spec-reviewer` per Step 6; it has fresh context and cannot rationalize.
 - **"The teammate already ran tests green — running verifier is redundant."** Same mistake. The verifier runs from an empty context; "redundant" is the rationalization that skips the gate. Dispatch `arcforge:verifier` per Step 6.
 - **"I'll close tmux panes manually later, skip `TeamDelete`."** Without TeamDelete, panes orphan and the team's runtime state lingers across sessions. Step 8c is not optional.
@@ -117,41 +119,7 @@ Use this after every dispatched epic has reached a terminal state (accepted
 or permanently failed). This is the user-facing hand-off — they read this
 and decide what to do with the dev branch.
 
-```
-🏁 Dispatch session complete
-
-Dev branch: <branch-name> (current HEAD is the deliverable)
-
-Epics:
-  ✅ epic-yaml-output  — accepted on attempt 1
-       spec-reviewer: PASS (10/10 ACs verified)
-       verifier:      PASS (42/42 tests, exit 0)
-  ✅ epic-stats        — accepted on attempt 2 (retry 1)
-       Attempt 1 rejected: getStats() missing perCollection breakdown
-       (fr-stats-001 AC #5). Retry fixed it.
-       spec-reviewer: PASS (5/5 ACs)
-       verifier:      PASS (38/38 tests, exit 0)
-  ❌ epic-history      — permanently failed after 4 attempts (3 retries)
-       Final rejection: query_history migration fails on existing DBs.
-       Last spec-reviewer: FAIL (fr-hist-002 AC #3)
-       Worktree: <absolute-path> (retained for debugging)
-
-Spec defects recorded for follow-up:
-  - epic-history, epic-bookmark: spec references src/db.ts but codebase
-    convention is src/store.ts — override-accepted, spec needs revision
-  - (or: none observed)
-
-Cleanup performed:
-  - Accepted worktrees removed: epic-yaml-output, epic-stats
-  - Team torn down (TeamDelete)
-  - Failed worktrees retained: epic-history
-
-Next actions you may consider:
-  - Inspect dev branch HEAD: git log --oneline <branch-name>
-  - Promote successful work: merge/cherry-pick to main
-  - Debug the failed epic: /arc-debugging on epic-history
-  - Discard the session: git branch -D <branch-name>
-```
+See `references/wrap-up-sequence.md` (§8a) for the full Final Report example.
 
 Each accepted epic MUST show subagent evidence (spec-reviewer + verifier PASS). Missing = Step 6 was skipped. Failed epics show the last subagent FAIL and are NOT auto-cleaned. "Next actions" lists user options — you don't execute them.
 

--- a/skills/arc-dispatching-teammates/SKILL.md
+++ b/skills/arc-dispatching-teammates/SKILL.md
@@ -75,7 +75,7 @@ Precondition failure = hard fail. Do not silently fall back to arc-looping or ma
 
 8. **Wrap up (three actions, in order).** When every epic reaches a terminal state:
 
-   - **8a.** Emit the Final Report (format below). The dev branch IS the deliverable — do NOT auto-merge to main or revert failed epics. Those are user decisions.
+   - **8a.** Emit the Final Report (format in `references/wrap-up-sequence.md` §8a). The dev branch IS the deliverable — do NOT auto-merge to main or revert failed epics. Those are user decisions.
    - **8b.** Clean up **accepted** worktrees from the project root: `node "${ARCFORGE_ROOT}/scripts/cli.js" cleanup <accepted-epic-id-1> <accepted-epic-id-2> ...`. The merge commits are already on the dev branch; the worktrees are orphaned scaffolding. **Skip** permanently failed epics — the user may need their worktree to debug. Do NOT call cleanup from inside a teammate's worktree — per Agent Teams docs, teammates should not run cleanup.
    - **8c.** Shut down any remaining teammates (most already down from Steps 6/7), then call `TeamDelete`. See `references/wrap-up-sequence.md` for ordering and failure handling.
 

--- a/skills/arc-dispatching-teammates/references/acceptance-and-retry.md
+++ b/skills/arc-dispatching-teammates/references/acceptance-and-retry.md
@@ -169,7 +169,7 @@ defect (not an implementation defect):
    spec defect wastes a teammate cycle on something they can't fix
    without a spec revision.
 3. **Record the spec defect.** Add it to the Final Report's "Spec
-   defects" section (see SKILL.md Final Report template) so the user
+   defects" section (see `references/wrap-up-sequence.md` §8a) so the user
    can fix the spec post-dispatch.
 4. **Retry counter does NOT increment.** Same as merge-conflict
    arbitration: spec defects are arbitration flows, not acceptance
@@ -339,7 +339,7 @@ as no feedback.
 
 ### Fresh worktree via `cli.js expand`
 
-On rejection, call `node scripts/cli.js expand --epic <epic-id>`. The
+On rejection, call `node "${ARCFORGE_ROOT}/scripts/cli.js" expand --epic <epic-id>`. The
 CLI creates a new worktree at the canonical path. The new worktree's
 starting commit is the current dev-branch HEAD — which already
 contains the rejected attempt's merge commits.

--- a/skills/arc-dispatching-teammates/references/wrap-up-sequence.md
+++ b/skills/arc-dispatching-teammates/references/wrap-up-sequence.md
@@ -23,39 +23,63 @@ things:
 
 ## 8a — Emit the Final Report
 
-Use the format in SKILL.md's "Final Report" completion block.
-
-**Required evidence per accepted epic:**
-
-```
-  ✅ epic-<id>  — accepted on attempt <N>
-       spec-reviewer: PASS (<X>/<Y> ACs verified)
-       verifier:      PASS (<X>/<Y> tests, exit 0)
-```
-
-**Missing evidence = you skipped Step 6.** The evidence lines are not
-optional decoration — they are the self-audit that catches inline
-rationalization. If you cannot fill them in with concrete numbers
-from a subagent report, you did not dispatch the subagent.
-
-**For failed epics:**
+This is the user-facing hand-off, emitted after every dispatched epic
+reaches a terminal state (accepted or permanently failed). Use this full
+format:
 
 ```
-  ❌ epic-<id>  — permanently failed after <N> attempts
-       Final rejection: <specific reason>
-       Last spec-reviewer: FAIL (<criterion>)
-       Worktree retained for debugging: <absolute path>
+🏁 Dispatch session complete
+
+Dev branch: <branch-name> (current HEAD is the deliverable)
+
+Epics:
+  ✅ epic-yaml-output  — accepted on attempt 1
+       spec-reviewer: PASS (10/10 ACs verified)
+       verifier:      PASS (42/42 tests, exit 0)
+  ✅ epic-stats        — accepted on attempt 2 (retry 1)
+       Attempt 1 rejected: getStats() missing perCollection breakdown
+       (fr-stats-001 AC #5). Retry fixed it.
+       spec-reviewer: PASS (5/5 ACs)
+       verifier:      PASS (38/38 tests, exit 0)
+  ❌ epic-history      — permanently failed after 4 attempts (3 retries)
+       Final rejection: query_history migration fails on existing DBs.
+       Last spec-reviewer: FAIL (fr-hist-002 AC #3)
+       Worktree: <absolute-path> (retained for debugging)
+
+Spec defects recorded for follow-up:
+  - epic-history, epic-bookmark: spec references src/db.ts but codebase
+    convention is src/store.ts — override-accepted, spec needs revision
+  - (or: none observed)
+
+Cleanup performed:
+  - Accepted worktrees removed: epic-yaml-output, epic-stats
+  - Team torn down (TeamDelete)
+  - Failed worktrees retained: epic-history
+
+Next actions you may consider:
+  - Inspect dev branch HEAD: git log --oneline <branch-name>
+  - Promote successful work: merge/cherry-pick to main
+  - Debug the failed epic: /arc-debugging on epic-history
+  - Discard the session: git branch -D <branch-name>
 ```
 
-Include the worktree path for failed epics so the user can cd into it
-without needing to derive the canonical path themselves.
+**Required evidence per accepted epic** — `spec-reviewer: PASS (<X>/<Y>
+ACs verified)` and `verifier: PASS (<X>/<Y> tests, exit 0)`. The evidence
+lines are not optional decoration — they are the self-audit that catches
+inline rationalization. **Missing evidence = you skipped Step 6.** If you
+cannot fill them in with concrete numbers from a subagent report, you did
+not dispatch the subagent.
+
+**For failed epics**, include the worktree path so the user can cd into it
+without needing to derive the canonical path themselves. "Next actions"
+lists user options — you don't execute them.
 
 ## 8b — Clean up accepted worktrees
 
 From the project root (NOT from inside a teammate's worktree):
 
 ```bash
-node scripts/cli.js cleanup <epic-id-1> <epic-id-2> ...
+node "${ARCFORGE_ROOT}/scripts/cli.js" cleanup <epic-id-1> <epic-id-2> ...
 ```
 
 Pass only epic IDs whose acceptance check passed. The CLI's
@@ -92,7 +116,7 @@ branch. The final report already tells them which worktrees were
 retained and where.
 
 If the user later decides to discard a failed epic, they can run
-cleanup manually — `node scripts/cli.js cleanup <failed-epic-id>`
+cleanup manually — `node "${ARCFORGE_ROOT}/scripts/cli.js" cleanup <failed-epic-id>`
 from the project root.
 
 ## 8c — Shut down teammates, then `TeamDelete`

--- a/skills/arc-looping/SKILL.md
+++ b/skills/arc-looping/SKILL.md
@@ -39,7 +39,7 @@ digraph when_to_use {
 ### Sequential (Default — Safest)
 
 ```
-node scripts/loop.js --pattern sequential --max-runs 20
+node "${ARCFORGE_ROOT}/scripts/cli.js" loop --pattern sequential --max-runs 20
 ```
 
 - One task at a time
@@ -49,7 +49,7 @@ node scripts/loop.js --pattern sequential --max-runs 20
 ### DAG (Parallel-aware)
 
 ```
-node scripts/loop.js --pattern dag --max-runs 20
+node "${ARCFORGE_ROOT}/scripts/cli.js" loop --pattern dag --max-runs 20
 ```
 
 - Uses `parallelTasks()` to find independent epics
@@ -76,7 +76,7 @@ If you are in a worktree (`.arcforge-epic` exists), the loop auto-detects both t
 
 For scoped single-epic execution, use `--epic`:
 ```bash
-node scripts/cli.js loop --epic epic-001 --pattern sequential --max-runs 20
+node "${ARCFORGE_ROOT}/scripts/cli.js" loop --epic epic-001 --pattern sequential --max-runs 20
 ```
 
 ### During Execution
@@ -124,29 +124,38 @@ It reads `.arcforge-loop.json` and reports:
   "iteration": 12,
   "pattern": "sequential",
   "started_at": "2026-03-17T22:00:00Z",
+  "max_runs": 20,
+  "max_cost": 10,
+  "run_id": "a1b2c3d4-...",
   "completed_tasks": ["feat-001-01", "feat-001-02"],
   "failed_tasks": ["feat-002-03"],
-  "errors": [{"task_id": "...", "error": "...", "timestamp": "..."}],
+  "errors": [{"task_id": "...", "error": "...", "timestamp": "...", "run_id": "..."}],
   "total_cost": 0,
   "last_progress_at": "2026-03-17T23:15:00Z",
   "status": "running"
 }
 ```
 
+`pattern`, `max_runs`, `max_cost`, and a fresh `run_id` are stamped at the
+start of each run. Stall and retry-storm detection count only the current
+run's errors, so resuming a loop is not penalized by a previous run's
+failures. `--reset` archives the prior state to
+`.arcforge-loop.archive/<started_at>.json` and starts fresh.
+
 ## CLI Usage
 
 ```bash
 # Sequential — safest
-node scripts/cli.js loop --pattern sequential --max-runs 20
+node "${ARCFORGE_ROOT}/scripts/cli.js" loop --pattern sequential --max-runs 20
 
 # DAG — parallel-aware
-node scripts/cli.js loop --pattern dag --max-runs 50
+node "${ARCFORGE_ROOT}/scripts/cli.js" loop --pattern dag --max-runs 50
 
 # With cost limit
-node scripts/cli.js loop --max-cost 10 --max-runs 100
+node "${ARCFORGE_ROOT}/scripts/cli.js" loop --max-cost 10 --max-runs 100
 
 # Scoped to one epic (safe for parallel execution)
-node scripts/cli.js loop --epic epic-001 --pattern sequential --max-runs 20
+node "${ARCFORGE_ROOT}/scripts/cli.js" loop --epic epic-001 --pattern sequential --max-runs 20
 ```
 
 ## Red Flags

--- a/skills/arc-researching/SKILL.md
+++ b/skills/arc-researching/SKILL.md
@@ -104,7 +104,7 @@ The contract author decides at lock time, not the loop at runtime. If Trials is 
 3. If the baseline crashes or produces no metric, STOP. Tell the human to fix the evaluation environment. Do not debug infrastructure — it is outside scope.
 4. Extract the baseline metric value
 5. Log baseline to `results.tsv` with status `baseline` — do NOT commit results.tsv (keep it untracked so experiment history survives resets)
-6. Start the dashboard: `node scripts/cli.js research dashboard --results results.tsv --config research-config.md`
+6. Start the dashboard: `node "${ARCFORGE_ROOT}/scripts/cli.js" research dashboard --results results.tsv --config research-config.md`
 7. Tell the human: "Dashboard running at http://localhost:3000 — monitor progress there."
 8. Commit the baseline state (but NOT results.tsv)
 

--- a/tests/scripts/loop-state.test.js
+++ b/tests/scripts/loop-state.test.js
@@ -4,11 +4,16 @@ const path = require('node:path');
 const {
   loadLoopState,
   saveLoopState,
+  beginRun,
+  resetLoopState,
   recordError,
   finalizeLoop,
+  isStalled,
+  isRetryStorm,
 } = require('../../scripts/lib/loop-state');
 
 const LOOP_STATE_FILE = '.arcforge-loop.json';
+const LOOP_ARCHIVE_DIR = '.arcforge-loop.archive';
 
 describe('loop-state', () => {
   let tmpDir;
@@ -113,6 +118,117 @@ describe('loop-state', () => {
       finalizeLoop(state, 50, tmpDir);
       expect(state.status).toBe('max_runs');
       expect(loadLoopState(tmpDir).status).toBe('max_runs');
+    });
+  });
+
+  describe('beginRun', () => {
+    it('persists pattern, max_runs, max_cost, and a fresh run_id', () => {
+      const state = loadLoopState(tmpDir);
+      beginRun(state, { pattern: 'dag', maxRuns: 30, maxCost: 12 });
+      expect(state.pattern).toBe('dag');
+      expect(state.max_runs).toBe(30);
+      expect(state.max_cost).toBe(12);
+      expect(typeof state.run_id).toBe('string');
+      expect(state.run_id.length).toBeGreaterThan(0);
+    });
+
+    it('defaults max_cost to null and records the run-start iteration', () => {
+      const state = loadLoopState(tmpDir);
+      state.iteration = 7;
+      beginRun(state, { pattern: 'sequential', maxRuns: 20 });
+      expect(state.max_cost).toBeNull();
+      expect(state.run_started_iteration).toBe(7);
+    });
+
+    it('assigns a new run_id on each run (resume gets its own scope)', () => {
+      const state = loadLoopState(tmpDir);
+      beginRun(state, { pattern: 'sequential', maxRuns: 20 });
+      const first = state.run_id;
+      beginRun(state, { pattern: 'sequential', maxRuns: 20 });
+      expect(state.run_id).not.toBe(first);
+    });
+  });
+
+  describe('recordError run_id stamping', () => {
+    it('stamps the current run_id onto each error entry', () => {
+      const state = loadLoopState(tmpDir);
+      beginRun(state, { pattern: 'sequential', maxRuns: 20 });
+      recordError(state, 'task-1', 'boom', 1);
+      expect(state.errors[0].run_id).toBe(state.run_id);
+    });
+
+    it('omits run_id on legacy state with no active run', () => {
+      const state = loadLoopState(tmpDir);
+      recordError(state, 'task-1', 'boom', 1);
+      expect(state.errors[0].run_id).toBeUndefined();
+    });
+  });
+
+  describe('run-scoped safety detection', () => {
+    it('isRetryStorm ignores errors from a previous run', () => {
+      const state = loadLoopState(tmpDir);
+      // Three task-1 failures belong to a prior run.
+      state.errors = [
+        { task_id: 'task-1', error: 'x', timestamp: 't1', attempt: 1, run_id: 'run-old' },
+        { task_id: 'task-1', error: 'x', timestamp: 't2', attempt: 1, run_id: 'run-old' },
+        { task_id: 'task-1', error: 'x', timestamp: 't3', attempt: 1, run_id: 'run-old' },
+      ];
+      beginRun(state, { pattern: 'sequential', maxRuns: 20 });
+      // No current-run errors → not a storm despite the prior run's failures.
+      expect(isRetryStorm(state)).toBe(false);
+    });
+
+    it('isRetryStorm fires on a storm within the current run only', () => {
+      const state = loadLoopState(tmpDir);
+      beginRun(state, { pattern: 'sequential', maxRuns: 20 });
+      for (let i = 0; i < 3; i++) recordError(state, 'task-1', 'x', 1);
+      expect(isRetryStorm(state)).toBe(true);
+    });
+
+    it('isStalled does not flag a resumed run on entry despite high cumulative iteration', () => {
+      const state = loadLoopState(tmpDir);
+      // Simulate a resume: 30 cumulative iterations, no progress ever, but a
+      // brand-new run that has not iterated yet.
+      state.iteration = 30;
+      state.last_progress_at = null;
+      beginRun(state, { pattern: 'sequential', maxRuns: 50 });
+      expect(isStalled(state)).toBe(false);
+    });
+
+    it('isStalled flags the current run once it accrues no-progress iterations', () => {
+      const state = loadLoopState(tmpDir);
+      state.iteration = 30;
+      state.last_progress_at = null;
+      beginRun(state, { pattern: 'sequential', maxRuns: 50 });
+      // Two iterations into the new run with still no progress → stalled.
+      state.iteration = 32;
+      expect(isStalled(state)).toBe(true);
+    });
+  });
+
+  describe('resetLoopState', () => {
+    it('archives the existing state to .arcforge-loop.archive/<started_at>.json', () => {
+      const state = loadLoopState(tmpDir);
+      state.started_at = '2026-03-17T22:00:00Z';
+      state.iteration = 9;
+      saveLoopState(state, tmpDir);
+
+      const fresh = resetLoopState(tmpDir);
+      expect(fresh.iteration).toBe(0);
+      expect(fresh.status).toBe('running');
+
+      const archivePath = path.join(tmpDir, LOOP_ARCHIVE_DIR, '2026-03-17T22-00-00Z.json');
+      expect(fs.existsSync(archivePath)).toBe(true);
+      const archived = JSON.parse(fs.readFileSync(archivePath, 'utf8'));
+      expect(archived.iteration).toBe(9);
+      // Live state file is gone after archive (loadLoopState would re-init).
+      expect(fs.existsSync(path.join(tmpDir, LOOP_STATE_FILE))).toBe(false);
+    });
+
+    it('is a no-op returning fresh state when no state file exists', () => {
+      const fresh = resetLoopState(tmpDir);
+      expect(fresh.iteration).toBe(0);
+      expect(fs.existsSync(path.join(tmpDir, LOOP_ARCHIVE_DIR))).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Wave 2 (PR-2c). All three loop-layer tasks, one agent (avoids cross-agent conflict on loop.js/loop-state.js).

## What
- AF-3: arc-looping (7 calls), loop-operator.md, arc-researching → blessed `node "${ARCFORGE_ROOT}/scripts/cli.js"` form; cli.js loop is the front door. (S4-6 survive-parent-exit is AF-13's overnight-doc deliverable — correctly deferred, not authored here.)
- AF-5: loop state persists pattern/max_runs/max_cost/run_id; recordError stamps run_id; isStalled/isRetryStorm count only the current run; --reset archives to .arcforge-loop.archive/<started_at>.json; loop-operator budget denominator + iteration headroom
- AF-6: conditional `git switch -c dispatch/<spec-id>-<date>` on main/master (respects user-expressed branch); new red flag; line-97 red flag bans only inline assignment; blessed form in references/ too; cap-5 default + user override

## Word-ceiling resolution (owner decision)
AF-6's mandated content pushed arc-dispatching-teammates to 1834 words (ceiling <1800). Per owner decision, the 174-word Final Report **example** was relocated to references/wrap-up-sequence.md §8a (with a one-line pointer + cross-reference cleanup); load-bearing prose stayed in SKILL.md. Now **1669 words** (131 margin). This respects the ceiling's intent rather than raising it.

## Acceptance
- pytest test_skill_arc_dispatching_teammates.py: 12 passed (incl. word_count_within_tier); cross-reference test passes
- npm test all 5 runners green (Jest 2079, hooks, node, pytest 543, observer-daemon 16)
- SKILL.md behavioral edits → eval deferred to AF-14 (Wave 6)