### PR TITLE
fix(cli): register sdd-gate in CLI_MANIFEST (Wave 2 integration seam)

### DIFF
--- a/scripts/lib/cli-manifest.js
+++ b/scripts/lib/cli-manifest.js
@@ -270,6 +270,13 @@ const CLI_MANIFEST = {
     flags: [],
     output: null,
   },
+  // Stages need spec fixtures + a draft on stdin to exercise; a deterministic
+  // full-key-set live --json belongs to SRH-3's fixture charter, so output is
+  // deliberately not pinned here (see the null criterion in the header).
+  'sdd-gate': {
+    flags: ['--spec-id', '--design', '--decision-log', '--draft'],
+    output: null,
+  },
 };
 
 module.exports = { CLI_MANIFEST };


### PR DESCRIPTION
Wave 2 integration hotfix. SRH-2's contract test (#86) and SDD-6's sdd-gate command (#87) were each green alone but collided on merge — the bidirectional label-parity check found `sdd-gate` in cli.js's switch but missing from CLI_MANIFEST. **This is the broken-seam defect class SRH-2 was built to catch, working as designed on its first real integration.** Adds the entry (flags + output:null per the fixture-charter criterion). All 5 runners green.