### PR TITLE
feat(learning): shared diary-capture lib + pending-ratification/loop-finished notifications (ICL-8, SDD-5)

### DIFF
--- a/hooks/__tests__/diary-enricher-e2e.test.js
+++ b/hooks/__tests__/diary-enricher-e2e.test.js
@@ -99,22 +99,16 @@ describe('E2E: diary enricher full spawn cycle', { skip: !RUN_E2E }, () => {
       const draftPath = path.join(diariesDateDir, `diary-${sessionId}-draft.md`);
       fs.writeFileSync(draftPath, STUB_DRAFT);
 
-      const { spawnDiaryEnricher } = require('../session-tracker/end');
+      const { spawnDiaryEnricher } = require('../../scripts/lib/diary-capture');
 
-      const session = {
-        project,
-        sessionId,
-        date,
-        started: '2026-04-15T10:00:00Z',
-        lastUpdated: '2026-04-15T10:05:00Z',
-        userMessages: 3,
-        toolCalls: 42,
-        filesModified: ['/tmp/example.js'],
-        userMessageContent: ['fix the auth bug', 'rerun tests', 'ship it'],
+      const transcriptData = {
+        userMessages: ['fix the auth bug', 'rerun tests', 'ship it'],
         toolsUsed: ['Read', 'Edit', 'Bash'],
+        filesModified: ['/tmp/example.js'],
+        stats: '~5 min, 3 messages, 42 tool calls, 1 files modified',
       };
 
-      spawnDiaryEnricher(draftPath, session);
+      spawnDiaryEnricher(draftPath, transcriptData, project);
 
       const enriched = await waitForEnrichment(draftPath, TIMEOUT_MS);
       const logPath = path.join(sessionsProjectDir, 'enricher.log');

--- a/hooks/__tests__/diary-enricher.test.js
+++ b/hooks/__tests__/diary-enricher.test.js
@@ -2,9 +2,12 @@
  * Diary Enricher Regression Tests
  *
  * Guards the fixes for the silent enrichment failure discovered 2026-04-15:
- * - end.js spawnDiaryEnricher used --max-turns 2 (insufficient → "Reached max turns").
- * - end.js piped enricher stderr to 'ignore' (silent failure invisible for ~30 days).
+ * - spawnDiaryEnricher used --max-turns 2 (insufficient → "Reached max turns").
+ * - it piped enricher stderr to 'ignore' (silent failure invisible for ~30 days).
  * - inject-context.js never warned about stale unenriched drafts.
+ *
+ * spawnDiaryEnricher moved to scripts/lib/diary-capture.js (ICL-8) so the Stop
+ * and PreCompact paths share one implementation.
  */
 
 const { describe, it } = require('node:test');
@@ -13,14 +16,14 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
-const END_JS = path.join(__dirname, '..', 'session-tracker', 'end.js');
+const DIARY_CAPTURE_JS = path.join(__dirname, '..', '..', 'scripts', 'lib', 'diary-capture.js');
 
 // ─────────────────────────────────────────────
-// end.js: spawnDiaryEnricher invocation hardening
+// diary-capture.js: spawnDiaryEnricher invocation hardening
 // ─────────────────────────────────────────────
 
 describe('spawnDiaryEnricher invocation', () => {
-  const source = fs.readFileSync(END_JS, 'utf-8');
+  const source = fs.readFileSync(DIARY_CAPTURE_JS, 'utf-8');
 
   it('uses --max-turns >= 5 (haiku needs room to read AND write)', () => {
     const match = source.match(/'--max-turns',\s*'(\d+)'/);

--- a/hooks/__tests__/inject-context.test.js
+++ b/hooks/__tests__/inject-context.test.js
@@ -1,0 +1,265 @@
+/**
+ * inject-context.js — SDD-5 rendering + S7-1 relay-isolation tests.
+ *
+ * Covers:
+ * - renderRatifyPending / renderLoopFinished produce the model-visible forms.
+ * - loadPendingActions consumes normally, but SKIPS consumption when
+ *   ARCFORGE_SPAWNED is set (relay isolation).
+ * - SessionStart child process surfaces both the ratify line and the
+ *   loop-finished line; ARCFORGE_SPAWNED preserves the actions for the user's
+ *   next (unmarked) SessionStart.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const INJECT_CONTEXT = path.join(__dirname, '..', 'session-tracker', 'inject-context.js');
+
+// ─────────────────────────────────────────────
+// Pure render helpers
+// ─────────────────────────────────────────────
+
+describe('inject-context render helpers (SDD-5)', () => {
+  beforeEach(() => {
+    delete require.cache[require.resolve('../session-tracker/inject-context')];
+  });
+
+  it('renderRatifyPending uses the PARSABLE ratify command and pipeline doc', () => {
+    const { renderRatifyPending } = require('../session-tracker/inject-context');
+    const out = renderRatifyPending({
+      count: 2,
+      specs: [{ spec_id: 'my-spec', decision_ids: ['D-007', 'D-009'] }],
+    });
+    assert.ok(out.includes('2 decisions pending ratification'), 'mentions count');
+    assert.ok(
+      out.includes(
+        'ARCFORGE_MODE=attended node "$ARCFORGE_ROOT/scripts/cli.js" ratify my-spec D-007',
+      ),
+      'parsable ratify invocation with concrete spec/D-id',
+    );
+    assert.ok(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder, not JS interpolation.
+      out.includes('${ARCFORGE_ROOT}/docs/guide/sdd-pipeline.md'),
+      'points at the ARCFORGE_ROOT-relative pipeline guide',
+    );
+    assert.ok(!/(^|\s)arcforge ratify/.test(out), 'no bare `arcforge` bin invocation');
+  });
+
+  it('renderLoopFinished renders the morning review-queue line', () => {
+    const { renderLoopFinished } = require('../session-tracker/inject-context');
+    const out = renderLoopFinished({
+      status: 'complete',
+      completed_count: 3,
+      blocked: [{ id: 'T-9', reason: 'conflict' }],
+      base_branch: 'main',
+      total_cost: 2.5,
+    });
+    assert.ok(out.includes('3 merged on main'), 'mentions merged count + branch');
+    assert.ok(out.includes('1 blocked'), 'mentions blocked count');
+    assert.ok(out.includes('T-9'), 'lists blocked id');
+  });
+
+  it('renderLoopFinished tolerates a null base_branch', () => {
+    const { renderLoopFinished } = require('../session-tracker/inject-context');
+    const out = renderLoopFinished({ completed_count: 0, blocked: [], base_branch: null });
+    assert.ok(out.includes('0 merged'), 'renders without a branch suffix');
+    assert.ok(!out.includes('on null'), 'never prints "on null"');
+  });
+});
+
+// ─────────────────────────────────────────────
+// loadPendingActions relay isolation (S7-1)
+// ─────────────────────────────────────────────
+
+describe('loadPendingActions relay isolation (S7-1)', () => {
+  const originalEnv = { ...process.env };
+  let homeDir;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-relay-'));
+    process.env.HOME = homeDir;
+    delete process.env.ARCFORGE_SPAWNED;
+    delete require.cache[require.resolve('../session-tracker/inject-context')];
+    delete require.cache[require.resolve('../../scripts/lib/pending-actions')];
+    delete require.cache[require.resolve('../../scripts/lib/utils')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  function seedAction(project, type, payload) {
+    const { addPendingAction } = require('../../scripts/lib/pending-actions');
+    return addPendingAction(project, type, payload);
+  }
+
+  function unconsumedCount(project) {
+    const { getPendingActions } = require('../../scripts/lib/pending-actions');
+    return getPendingActions(project).length;
+  }
+
+  it('consumes pending actions on an unmarked session', () => {
+    const project = 'relay-proj';
+    seedAction(project, 'ratify-pending', { count: 1, specs: [] });
+    const { loadPendingActions } = require('../session-tracker/inject-context');
+
+    const result = loadPendingActions(project);
+    assert.ok(result.text, 'renders the action');
+    assert.strictEqual(unconsumedCount(project), 0, 'action consumed');
+  });
+
+  it('does NOT consume when ARCFORGE_SPAWNED is set', () => {
+    const project = 'relay-proj';
+    seedAction(project, 'ratify-pending', { count: 1, specs: [] });
+    process.env.ARCFORGE_SPAWNED = 'enricher';
+    const { loadPendingActions } = require('../session-tracker/inject-context');
+
+    const result = loadPendingActions(project);
+    assert.strictEqual(result.text, null, 'renders nothing for a spawned session');
+    assert.strictEqual(unconsumedCount(project), 1, 'action survives for the user');
+  });
+});
+
+// ─────────────────────────────────────────────
+// SessionStart child process (SDD-5 end-to-end)
+// ─────────────────────────────────────────────
+
+describe('inject-context SessionStart child process (SDD-5)', () => {
+  let homeDir;
+  let projectDir;
+  let project;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-ss-home-'));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-ss-proj-'));
+    project = path.basename(projectDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function pendingFile() {
+    return path.join(homeDir, '.arcforge', 'sessions', project, 'pending-actions.json');
+  }
+
+  function writePending(actions) {
+    const dir = path.dirname(pendingFile());
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(pendingFile(), JSON.stringify({ actions }, null, 2));
+  }
+
+  function makeAction(type, payload) {
+    return {
+      id: `${type}-${Math.random().toString(36).slice(2)}`,
+      type,
+      payload,
+      created: new Date().toISOString(),
+      consumed: false,
+      consumed_at: null,
+    };
+  }
+
+  it('surfaces BOTH the ratify count line and the loop-finished line', () => {
+    writePending([
+      makeAction('ratify-pending', {
+        count: 2,
+        specs: [{ spec_id: 'spec-x', decision_ids: ['D-001'] }],
+      }),
+      makeAction('loop-finished', {
+        status: 'complete',
+        completed_count: 4,
+        blocked: [{ id: 'T-2', reason: 'conflict' }],
+        base_branch: 'main',
+        total_cost: 1.0,
+      }),
+    ]);
+
+    const env = { ...process.env, HOME: homeDir, CLAUDE_PROJECT_DIR: projectDir };
+    delete env.ARCFORGE_SPAWNED;
+    const res = spawnSync('node', [INJECT_CONTEXT], {
+      input: JSON.stringify({
+        session_id: 'ss-test',
+        cwd: projectDir,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+
+    assert.strictEqual(res.status, 0, res.stderr);
+    // Parse the single JSON object the hook emits; assert against the decoded
+    // additionalContext so escaped quotes in the raw stdout don't trip us.
+    const parsed = JSON.parse(res.stdout.trim());
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    assert.ok(ctx.includes('pending ratification'), 'ratify line present');
+    assert.ok(
+      ctx.includes('ARCFORGE_MODE=attended node "$ARCFORGE_ROOT/scripts/cli.js" ratify'),
+      'parsable ratify command present',
+    );
+    assert.ok(ctx.includes('Loop finished: 4 merged on main'), 'loop-finished line present');
+  });
+
+  it('preserves actions under ARCFORGE_SPAWNED, then consumes on the next unmarked start', () => {
+    writePending([
+      makeAction('ratify-pending', {
+        count: 1,
+        specs: [{ spec_id: 'spec-x', decision_ids: ['D-001'] }],
+      }),
+    ]);
+
+    // Spawned session: must NOT consume.
+    const spawnedEnv = {
+      ...process.env,
+      HOME: homeDir,
+      CLAUDE_PROJECT_DIR: projectDir,
+      ARCFORGE_SPAWNED: 'enricher',
+    };
+    const spawned = spawnSync('node', [INJECT_CONTEXT], {
+      input: JSON.stringify({
+        cwd: projectDir,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      }),
+      encoding: 'utf-8',
+      env: spawnedEnv,
+    });
+    assert.strictEqual(spawned.status, 0, spawned.stderr);
+
+    let data = JSON.parse(fs.readFileSync(pendingFile(), 'utf-8'));
+    assert.strictEqual(
+      data.actions.filter((a) => !a.consumed).length,
+      1,
+      'spawned session preserved the action',
+    );
+
+    // Unmarked session: consumes.
+    const userEnv = { ...process.env, HOME: homeDir, CLAUDE_PROJECT_DIR: projectDir };
+    delete userEnv.ARCFORGE_SPAWNED;
+    const user = spawnSync('node', [INJECT_CONTEXT], {
+      input: JSON.stringify({
+        cwd: projectDir,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      }),
+      encoding: 'utf-8',
+      env: userEnv,
+    });
+    assert.strictEqual(user.status, 0, user.stderr);
+
+    data = JSON.parse(fs.readFileSync(pendingFile(), 'utf-8'));
+    assert.strictEqual(
+      data.actions.filter((a) => !a.consumed).length,
+      0,
+      'unmarked session consumed the action',
+    );
+  });
+});

--- a/hooks/__tests__/pre-compact.test.js
+++ b/hooks/__tests__/pre-compact.test.js
@@ -3,6 +3,9 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const PRE_COMPACT = path.join(__dirname, '..', 'pre-compact', 'main.js');
 
 describe('pre-compact: updateSessionFile', () => {
   const originalEnv = { ...process.env };
@@ -70,5 +73,156 @@ describe('pre-compact: updateSessionFile', () => {
 
     const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
     assert.strictEqual(updated.compactions.length, 2);
+  });
+});
+
+// ─────────────────────────────────────────────
+// PreCompact diary-capture dual path (ICL-8)
+// ─────────────────────────────────────────────
+
+describe('pre-compact: diary-capture fixture (ICL-8)', () => {
+  const originalEnv = { ...process.env };
+  let homeDir;
+  let tmpDir;
+  let binDir;
+  const sessionId = 'session-precompact-fixture';
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-home-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-tmp-'));
+    binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-bin-'));
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(binDir, { recursive: true, force: true });
+  });
+
+  function counterPath(name) {
+    // session_id comes from stdin → getSessionId() = `session-${id}`. Here the
+    // raw id already starts with "session-" so the counter file double-stamps;
+    // mirror getSessionId exactly: `session-${rawId}`.
+    return path.join(tmpDir, `arcforge-${name}-session-${sessionId}`);
+  }
+
+  function pendingActions(project) {
+    const file = path.join(homeDir, '.arcforge', 'sessions', project, 'pending-actions.json');
+    if (!fs.existsSync(file)) return [];
+    return JSON.parse(fs.readFileSync(file, 'utf-8')).actions;
+  }
+
+  async function waitFor(file, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(file)) return true;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return false;
+  }
+
+  it('stdin-only session_id: generates draft, calls enricher, queues diary-ready, resets counters', async () => {
+    // S5-4: CLAUDE_SESSION_ID explicitly UNSET — session id must come from stdin.
+    const marker = path.join(binDir, 'spawned.marker');
+    fs.writeFileSync(
+      path.join(binDir, 'claude'),
+      `#!/bin/sh\ncat > /dev/null\nprintf '%s' "$ARCFORGE_SPAWNED" > "${marker}"\n`,
+      { mode: 0o755 },
+    );
+
+    // Seed the user counter ABOVE threshold under the stdin-derived session id.
+    fs.writeFileSync(counterPath('user-count'), '15');
+    fs.writeFileSync(counterPath('tool-count'), '0');
+
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-proj-'));
+    const project = path.basename(projectDir);
+
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      TMPDIR: tmpDir,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      CLAUDE_PROJECT_DIR: projectDir,
+    };
+    delete env.CLAUDE_SESSION_ID;
+
+    const res = spawnSync('node', [PRE_COMPACT], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PreCompact',
+        cwd: projectDir,
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+
+      // diary-ready queued for next SessionStart.
+      const diaryReady = pendingActions(project).filter((a) => a.type === 'diary-ready');
+      assert.strictEqual(diaryReady.length, 1, 'diary-ready queued');
+
+      // Counter reset (the sole reset path) hit the file the suggester actually wrote.
+      assert.strictEqual(fs.readFileSync(counterPath('user-count'), 'utf-8'), '0', 'user reset');
+      assert.strictEqual(fs.readFileSync(counterPath('tool-count'), 'utf-8'), '0', 'tool reset');
+
+      // A draft was generated under the redirected HOME.
+      const diariesDir = path.join(homeDir, '.arcforge', 'diaries', project);
+      assert.ok(fs.existsSync(diariesDir), 'diaries dir created');
+
+      // Enricher stub fired with the relay-isolation env (poll: detached spawn).
+      assert.ok(await waitFor(marker, 5000), 'enricher stub invoked');
+      assert.strictEqual(fs.readFileSync(marker, 'utf-8'), 'enricher', 'ARCFORGE_SPAWNED=enricher');
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('below threshold: no draft, no diary-ready, counters preserved', () => {
+    fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(counterPath('user-count'), '2');
+    fs.writeFileSync(counterPath('tool-count'), '3');
+
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-proj-'));
+    const project = path.basename(projectDir);
+
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      TMPDIR: tmpDir,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      CLAUDE_PROJECT_DIR: projectDir,
+    };
+    delete env.CLAUDE_SESSION_ID;
+
+    const res = spawnSync('node', [PRE_COMPACT], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PreCompact',
+        cwd: projectDir,
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+      assert.strictEqual(pendingActions(project).length, 0, 'no actions queued');
+      assert.strictEqual(
+        fs.readFileSync(counterPath('user-count'), 'utf-8'),
+        '2',
+        'user preserved',
+      );
+      assert.strictEqual(
+        fs.readFileSync(counterPath('tool-count'), 'utf-8'),
+        '3',
+        'tool preserved',
+      );
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 });

--- a/hooks/compact-suggester/main.js
+++ b/hooks/compact-suggester/main.js
@@ -21,6 +21,7 @@ const {
   output,
   createSessionCounter,
 } = require('../../scripts/lib/utils');
+const { incrementSharedToolCount } = require('../../scripts/lib/diary-capture');
 
 const THRESHOLD = 50; // First suggestion
 const INTERVAL = 25; // Subsequent reminders
@@ -141,9 +142,10 @@ function main() {
   const newCount = currentCount + 1;
   counter.write(newCount);
 
-  // Also increment shared tool-count (used by diary threshold in session-tracker/end)
-  const diaryCounter = createSessionCounter('tool-count');
-  diaryCounter.write(diaryCounter.read() + 1);
+  // Also increment shared tool-count (used by diary threshold in session-tracker/end).
+  // SOLE increment path — owned by diary-capture so the diary and suggester
+  // thresholds share one source of truth (counter-ownership contract).
+  incrementSharedToolCount();
 
   // Check if suggestion is needed (suppress during write-heavy phases at non-threshold counts)
   if (shouldSuggest(newCount)) {

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -1,21 +1,30 @@
 # PreCompact Hook
 
-Records context compaction events for session tracking and triggers diary prompts when threshold is met.
+Records context compaction events for session tracking and captures the session
+diary when the threshold is met.
 
 ## What It Does
 
-1. **Updates current session file** with compaction markers
+1. **Resolves the session id from stdin** (`parseStdinJson` + `setSessionIdFromInput`)
+   before touching any counter, so the counts read belong to the live session.
+
+2. **Updates the current session file** with compaction markers
    - Adds timestamp to `compactions` array
    - Sets `lastCompaction` field
 
-2. **Threshold-triggered behavior** (when `userCount >= 10 OR toolCount >= 50`):
-   - Updates session with current user/tool counts
-   - Prompts user to run the `arc-journaling` skill
-   - Resets both counters (user messages and tool calls)
+3. **Threshold-triggered behavior** (when `userCount >= 10 OR toolCount >= 50`):
+   Delegates to the shared diary-capture core (`scripts/lib/diary-capture.js`),
+   the same path the Stop hook runs:
+   - Generates the auto-diary draft
+   - Spawns the background diary enricher (dual path — Stop AND PreCompact)
+   - Resets both counters (the sole reset path)
 
-3. **Below threshold**:
+   Then it queues a `diary-ready` pending action for the next `SessionStart`.
+   PreCompact stdout is reserved for the transcript channel and cannot render a
+   `systemMessage`, so the notification is deferred to inject-context.
+
+4. **Below threshold**:
    - Preserves counters for future accumulation
-   - Shows current count status
 
 ## Threshold Logic
 
@@ -25,22 +34,13 @@ Uses shared threshold from `scripts/lib/thresholds.js`:
 userCount >= 10 || toolCount >= 50
 ```
 
-This ensures diary prompts only appear for meaningful sessions.
+This ensures diary capture only happens for meaningful sessions.
 
-## Output Examples
+## Notification (pending action, not systemMessage)
 
-**Threshold met:**
-```
-📝 Context compaction detected. (15 messages, 47 tool calls)
-
-Please use the arc-journaling skill immediately to capture session reflections before context is compacted.
-```
-
-**Below threshold:**
-```
-📝 Context compaction. (3 messages, 12 tool calls)
-   Below threshold - counters preserved.
-```
+When the threshold is met, the hook calls `addPendingAction(project, 'diary-ready', …)`.
+The next `SessionStart(source: "compact")` surfaces it via inject-context.js as
+"📝 Diary draft ready — use /arcforge:arc-journaling …".
 
 ## Session File Format
 

--- a/hooks/pre-compact/main.js
+++ b/hooks/pre-compact/main.js
@@ -9,7 +9,6 @@
  */
 
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
 const {
   getSessionDir,
   getTimestamp,
@@ -18,18 +17,15 @@ const {
   getSessionId,
   readFileSafe,
   writeFileSafe,
-  createSessionCounter,
   log,
   readStdinSync,
+  parseStdinJson,
+  setSessionIdFromInput,
   loadSession,
   saveSession,
 } = require('../../scripts/lib/utils');
-const {
-  readCount: readUserCount,
-  resetCounter: resetUserCounter,
-} = require('../user-message-counter/main');
-const { shouldTrigger } = require('../../scripts/lib/thresholds');
 const { addPendingAction } = require('../../scripts/lib/pending-actions');
+const { runDiaryCapture } = require('../../scripts/lib/diary-capture');
 
 /**
  * Update session file with compaction marker
@@ -63,6 +59,12 @@ function main() {
     const stdin = readStdinSync();
     if (stdin) process.stdout.write(stdin);
 
+    // Resolve session id from stdin BEFORE any counter/state access so the
+    // counters we read are the live session's — not whatever CLAUDE_SESSION_ID
+    // env happened to be set to (S5-4).
+    const input = parseStdinJson(stdin);
+    setSessionIdFromInput(input);
+
     const project = getProjectName();
     const date = getDateString();
     const sessionId = getSessionId();
@@ -71,33 +73,17 @@ function main() {
     // Update session file with compaction marker
     updateSessionFile(project, date, timestamp, sessionId);
 
-    // Read counters
-    const userCount = readUserCount();
-    const toolCount = createSessionCounter('tool-count').read();
+    // Shared diary-capture core: threshold gate → draft → background enricher
+    // → counter reset. Enricher fires on PreCompact too (dual-path ON).
+    const { triggered, userCount, toolCount } = runDiaryCapture({ project, date, sessionId });
 
-    // Check threshold for diary trigger
-    if (shouldTrigger(userCount, toolCount)) {
-      // Update session with current counts
+    if (triggered) {
+      // Stamp the current counts onto the session file.
       const session = loadSession();
       if (session) {
         session.userMessages = userCount;
         session.toolCalls = toolCount;
         saveSession(session);
-      }
-
-      // Generate auto-diary draft (silent, best-effort)
-      try {
-        const autoDiaryPath = path.join(
-          __dirname,
-          '../../skills/arc-journaling/scripts/auto-diary.js',
-        );
-        execFileSync(
-          'node',
-          [autoDiaryPath, 'generate', '--project', project, '--date', date, '--session', sessionId],
-          { stdio: 'ignore', timeout: 5000 },
-        );
-      } catch {
-        // Non-blocking — draft generation is best-effort
       }
 
       // Queue notification for next SessionStart (PreCompact stdout doesn't render systemMessage)
@@ -106,10 +92,6 @@ function main() {
         userMessages: userCount,
         toolCalls: toolCount,
       });
-
-      // Reset counters after threshold is met
-      resetUserCounter();
-      createSessionCounter('tool-count').reset();
 
       log(
         `[pre-compact] Diary draft generated (${userCount} msgs, ${toolCount} tools). Queued diary-ready action.`,

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -8,9 +8,8 @@
  * 3. Queue pending actions (reflect-ready)
  */
 
-const fs = require('node:fs');
 const path = require('node:path');
-const { execFileSync, spawn } = require('node:child_process');
+const { execFileSync } = require('node:child_process');
 const {
   readStdinSync,
   parseStdinJson,
@@ -18,21 +17,14 @@ const {
   writeFileSafe,
   loadSession,
   getSessionDir,
-  getProjectSessionsDir,
   getProjectName,
   getDateString,
   getSessionId,
   getTimestamp,
-  createSessionCounter,
-  ensureDir,
   output,
 } = require('../../scripts/lib/utils');
 const { addPendingAction } = require('../../scripts/lib/pending-actions');
-const {
-  readCount: readUserCount,
-  resetCounter: resetUserCounter,
-} = require('../user-message-counter/main');
-const { shouldTrigger } = require('../../scripts/lib/thresholds');
+const { runDiaryCapture, readCounts } = require('../../scripts/lib/diary-capture');
 const { parseTranscript } = require('../../scripts/lib/transcript');
 
 /**
@@ -75,24 +67,6 @@ function saveSessionJson(session) {
 }
 
 /**
- * Try to generate auto-diary draft.
- * Returns draft path on success, null on failure.
- */
-function tryGenerateAutoDiary(project, date, sessionId) {
-  try {
-    const autoDiaryPath = path.join(__dirname, '../../skills/arc-journaling/scripts/auto-diary.js');
-    const result = execFileSync(
-      'node',
-      [autoDiaryPath, 'generate', '--project', project, '--date', date, '--session', sessionId],
-      { encoding: 'utf-8', timeout: 5000 },
-    ).trim();
-    return result || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Check if reflection is ready.
  * Returns { ready, strategy, count } or null on failure.
  */
@@ -128,72 +102,6 @@ function formatStats(session) {
 }
 
 /**
- * Spawn a background Claude instance to enrich the diary draft.
- * Fire-and-forget: detached process, hook exits immediately.
- */
-function spawnDiaryEnricher(draftPath, session) {
-  try {
-    const transcriptData = {
-      userMessages: session.userMessageContent || [],
-      toolsUsed: session.toolsUsed || [],
-      filesModified: session.filesModified || [],
-      stats: formatStats(session),
-    };
-
-    const prompt = [
-      'Read the diary draft and fill all <!-- TO BE ENRICHED --> sections.',
-      `Draft path: ${draftPath}`,
-      '',
-      'Session context (parsed summary):',
-      JSON.stringify(transcriptData, null, 2),
-      '',
-      'Write the enriched diary back to the same path.',
-      'Keep auto-generated metrics sections unchanged.',
-      'Fill Completed, In Progress, Decisions, Challenges from the session context.',
-    ].join('\n');
-
-    const systemPrompt =
-      'You are a diary enrichment agent. ' +
-      'Read the draft, fill placeholder sections using provided session data, ' +
-      'write the result back. Be concise and factual.';
-
-    // Capture stderr to a log file so silent failures leave a trail.
-    const sessionsDir = getProjectSessionsDir(session.project);
-    ensureDir(sessionsDir);
-    const stderrFd = fs.openSync(path.join(sessionsDir, 'enricher.log'), 'a');
-
-    const child = spawn(
-      'claude',
-      [
-        '--model',
-        'haiku',
-        // Haiku needs Read + Write + thinking; 10 leaves headroom (2 hits max-turns).
-        '--max-turns',
-        '10',
-        '--print',
-        '--dangerously-skip-permissions',
-        '--system-prompt',
-        systemPrompt,
-        '--tools',
-        'Read,Write',
-        '--disable-slash-commands',
-        '--strict-mcp-config',
-        '--mcp-config',
-        '{"mcpServers":{}}',
-      ],
-      { detached: true, stdio: ['pipe', 'ignore', stderrFd] },
-    );
-
-    child.stdin.write(prompt);
-    child.stdin.end();
-    child.unref();
-    fs.closeSync(stderrFd);
-  } catch {
-    // Fire-and-forget — spawn failure is non-fatal
-  }
-}
-
-/**
  * Format short message for stderr output (when threshold is not met)
  */
 function formatShortMessage(userCount, toolCount) {
@@ -210,8 +118,7 @@ function main() {
   setSessionIdFromInput(input);
 
   const session = getOrCreateSession();
-  const userCount = readUserCount();
-  const toolCount = createSessionCounter('tool-count').read();
+  const { userCount, toolCount } = readCounts();
 
   session.lastUpdated = getTimestamp();
   session.userMessages = userCount;
@@ -231,13 +138,22 @@ function main() {
 
   saveSessionJson(session);
 
-  if (shouldTrigger(userCount, toolCount)) {
-    const draftPath = tryGenerateAutoDiary(session.project, session.date, session.sessionId);
+  // Shared diary-capture core: threshold gate → draft → background enricher
+  // → counter reset (the sole reset path). The parsed-session summary is
+  // handed to the enricher.
+  const { triggered } = runDiaryCapture({
+    project: session.project,
+    date: session.date,
+    sessionId: session.sessionId,
+    transcriptData: {
+      userMessages: session.userMessageContent || [],
+      toolsUsed: session.toolsUsed || [],
+      filesModified: session.filesModified || [],
+      stats: formatStats(session),
+    },
+  });
 
-    if (draftPath) {
-      spawnDiaryEnricher(draftPath, session);
-    }
-
+  if (triggered) {
     const reflectStatus = checkReflectReady(session.project);
     if (reflectStatus?.ready) {
       addPendingAction(session.project, 'reflect-ready', {
@@ -245,13 +161,9 @@ function main() {
         count: reflectStatus.count,
       });
     }
-
-    output({ systemMessage: formatShortMessage(userCount, toolCount) });
-    resetUserCounter();
-    createSessionCounter('tool-count').reset();
-  } else {
-    output({ systemMessage: formatShortMessage(userCount, toolCount) });
   }
+
+  output({ systemMessage: formatShortMessage(userCount, toolCount) });
 
   process.exit(0);
 }
@@ -263,8 +175,6 @@ module.exports = {
   saveSessionJson,
   formatStats,
   formatShortMessage,
-  spawnDiaryEnricher,
-  tryGenerateAutoDiary,
   checkReflectReady,
 };
 

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -40,6 +40,8 @@ const { parseConfidenceFrontmatter, shouldAutoLoad } = require('../../scripts/li
 
 const { getPendingActions, consumeAction } = require('../../scripts/lib/pending-actions');
 
+const { draftIsStale } = require('../../scripts/lib/diary-capture');
+
 /**
  * Load instincts with confidence >= AUTO_LOAD_THRESHOLD
  */
@@ -110,30 +112,8 @@ function loadInstinctFiles(dir) {
     .filter(Boolean);
 }
 
-// The TO BE ENRICHED markers always appear in the template-stub header
-// region (Decisions/Challenges/etc.) within the first ~2KB of any draft.
-// Bounded read keeps SessionStart cheap even with hundreds of drafts.
-const STALE_DRAFT_PROBE_BYTES = 2048;
-
-function draftIsStale(filePath) {
-  let fd;
-  try {
-    fd = fs.openSync(filePath, 'r');
-    const buf = Buffer.alloc(STALE_DRAFT_PROBE_BYTES);
-    const n = fs.readSync(fd, buf, 0, STALE_DRAFT_PROBE_BYTES, 0);
-    return buf.subarray(0, n).includes('TO BE ENRICHED');
-  } catch {
-    return false;
-  } finally {
-    if (fd !== undefined) {
-      try {
-        fs.closeSync(fd);
-      } catch {
-        /* already closed */
-      }
-    }
-  }
-}
+// draftIsStale (TO BE ENRICHED probe) now lives in diary-capture.js — the
+// single owner shared by this healthcheck and the curator batch-assembler.
 
 /**
  * Returns { count, message } when stale drafts exist, else null.
@@ -166,21 +146,72 @@ function loadStaleDraftWarning(project) {
 }
 
 /**
+ * Render the overnight loop-finished review-queue line. The north-star morning
+ * surface: what landed, what's blocked, on which branch.
+ * @param {Object} payload - { status, completed_count, blocked, base_branch, total_cost }
+ * @returns {string}
+ */
+function renderLoopFinished(payload) {
+  const merged = payload.completed_count || 0;
+  const blocked = Array.isArray(payload.blocked) ? payload.blocked : [];
+  const onBranch = payload.base_branch ? ` on ${payload.base_branch}` : '';
+  const lines = [
+    `**🌙 Loop finished: ${merged} merged${onBranch}, ${blocked.length} blocked — review before ratifying.**`,
+  ];
+  if (typeof payload.total_cost === 'number' && payload.total_cost > 0) {
+    lines.push(`   Total cost: $${payload.total_cost.toFixed(2)}.`);
+  }
+  for (const b of blocked) {
+    lines.push(`   - blocked: ${b.id}${b.reason ? ` (${b.reason})` : ''}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Render the pending-ratification line. Uses the PARSABLE ratify invocation
+ * (no bare `arcforge` bin — not on PATH for marketplace/git-clone installs)
+ * and points at the ${ARCFORGE_ROOT}-relative pipeline guide.
+ * @param {Object} payload - { count, specs: [{ spec_id, decision_ids: [...] }] }
+ * @returns {string}
+ */
+function renderRatifyPending(payload) {
+  const count = payload.count || 0;
+  const specs = Array.isArray(payload.specs) ? payload.specs : [];
+  const first = specs[0];
+  const specId = first?.spec_id || '<spec-id>';
+  const dId = first?.decision_ids?.[0] || '<D-id>';
+  return [
+    `**⚖️ ${count} decision${count === 1 ? '' : 's'} pending ratification.** Review, then ratify each in attended mode:`,
+    `   ARCFORGE_MODE=attended node "$ARCFORGE_ROOT/scripts/cli.js" ratify ${specId} ${dId}`,
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: ${ARCFORGE_ROOT} is a literal placeholder the model expands, not JS interpolation.
+    '   See ${ARCFORGE_ROOT}/docs/guide/sdd-pipeline.md for the ratification workflow.',
+  ].join('\n');
+}
+
+/**
  * Load and consume pending actions for context injection.
  */
 function loadPendingActions(project) {
   try {
+    // Relay-isolation: a session arcforge spawned itself (e.g. the detached
+    // diary enricher, or a loop's headless task session) must NOT consume the
+    // user's pending actions — otherwise it eats diary-ready / reflect-ready /
+    // ratify-pending / loop-finished before the user's next SessionStart sees
+    // them. Mirrors the observe hook's eval-isolation precedent (S7-1).
+    if (process.env.ARCFORGE_SPAWNED) return { text: null, summary: null };
+
     const actions = getPendingActions(project);
     if (actions.length === 0) return { text: null, summary: null };
 
     const lines = [];
     const summaryParts = [];
 
+    const DEDICATED_TYPES = ['diary-ready', 'reflect-ready', 'loop-finished', 'ratify-pending'];
     const diaryActions = actions.filter((a) => a.type === 'diary-ready');
     const reflectActions = actions.filter((a) => a.type === 'reflect-ready');
-    const otherActions = actions.filter(
-      (a) => a.type !== 'reflect-ready' && a.type !== 'diary-ready',
-    );
+    const loopFinishedActions = actions.filter((a) => a.type === 'loop-finished');
+    const ratifyActions = actions.filter((a) => a.type === 'ratify-pending');
+    const otherActions = actions.filter((a) => !DEDICATED_TYPES.includes(a.type));
 
     if (diaryActions.length > 0) {
       lines.push('**📝 Diary draft ready — use /arcforge:arc-journaling to review and finalize.**');
@@ -194,6 +225,23 @@ function loadPendingActions(project) {
         `**${count} unprocessed diaries ready for reflection.** Run /arcforge:arc-reflecting to analyze patterns.`,
       );
       summaryParts.push(`${count} diaries pending reflection`);
+    }
+
+    // Overnight loop outcome — the morning review-queue surface (north star).
+    // Render before the ratify prompt so the user sees what landed first.
+    if (loopFinishedActions.length > 0) {
+      const latest = loopFinishedActions[loopFinishedActions.length - 1];
+      lines.push(renderLoopFinished(latest.payload || {}));
+      summaryParts.push('loop finished');
+    }
+
+    // Pending ratification — point at the PARSABLE ratify invocation, not the
+    // bare `arcforge` bin (not on PATH for marketplace/git-clone installs).
+    if (ratifyActions.length > 0) {
+      const latest = ratifyActions[ratifyActions.length - 1];
+      lines.push(renderRatifyPending(latest.payload || {}));
+      const count = latest.payload?.count || ratifyActions.length;
+      summaryParts.push(`${count} decision${count === 1 ? '' : 's'} pending ratification`);
     }
 
     for (const action of otherActions) {
@@ -319,6 +367,8 @@ module.exports = {
   loadInstinctFiles,
   loadPendingActions,
   loadStaleDraftWarning,
+  renderLoopFinished,
+  renderRatifyPending,
   logAvailableAliases,
   checkNewGlobalPromotions,
 };

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -1,0 +1,263 @@
+/**
+ * diary-capture.js — Shared diary-capture core for Stop and PreCompact hooks.
+ *
+ * Owns the threshold gating, draft generation, background enricher spawn, and
+ * the counter reset that both the Stop hook (session-tracker/end.js) and the
+ * PreCompact hook (pre-compact/main.js) run. Extracting it here removes the
+ * divergence between the two paths and makes the enricher fire on BOTH events.
+ *
+ * Counter-ownership contract (single-writer per counter):
+ * - user-count  — WRITTEN only by user-message-counter (UserPromptSubmit).
+ * - tool-count  — INCREMENTED only by compact-suggester via incrementSharedToolCount().
+ * - both        — READ and RESET only here (readCounts / resetCounters).
+ *   Reset (write 0) is distinct from the increment role; "重置" lives here, the
+ *   "寫" role stays with each counter's owner. No double-reset path remains.
+ *
+ * This module also owns the SOLE suggester-state path helper
+ * (getSuggesterStatePath) so ICL-9's compaction reset re-uses one filename
+ * instead of re-deriving it, and the SOLE stale-draft probe (draftIsStale)
+ * imported by inject-context and the curator batch-assembler.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync, spawn } = require('node:child_process');
+const {
+  createSessionCounter,
+  getProjectSessionsDir,
+  getTempDir,
+  getSessionId,
+  ensureDir,
+} = require('./utils');
+const { shouldTrigger } = require('./thresholds');
+
+// ---------------------------------------------------------------------------
+// Counter ownership — read + reset live here exclusively
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the shared diary-trigger counters.
+ * @returns {{ userCount: number, toolCount: number }}
+ */
+function readCounts() {
+  return {
+    userCount: createSessionCounter('user-count').read(),
+    toolCount: createSessionCounter('tool-count').read(),
+  };
+}
+
+/**
+ * Reset both diary-trigger counters. SOLE reset path for user-count/tool-count.
+ */
+function resetCounters() {
+  createSessionCounter('user-count').reset();
+  createSessionCounter('tool-count').reset();
+}
+
+/**
+ * Increment the shared tool-count. SOLE increment path — called only by
+ * compact-suggester on PostToolUse so the diary threshold and the suggester
+ * threshold share a single source of truth.
+ */
+function incrementSharedToolCount() {
+  const counter = createSessionCounter('tool-count');
+  counter.write(counter.read() + 1);
+}
+
+/**
+ * Canonical path of the compact-suggester JSON state file.
+ *
+ * The SOLE owner of this filename. ICL-9 (compact-suggester consolidation) and
+ * its PreCompact reset both call this helper so the writer and the resetter
+ * always agree on one path. Session-scoped, mirrors createSessionCounter's
+ * tmp-dir layout so it is wiped between sessions.
+ *
+ * @returns {string} Absolute path to the suggester state file.
+ */
+function getSuggesterStatePath() {
+  return path.join(getTempDir(), `arcforge-suggester-state-${getSessionId()}.json`);
+}
+
+// ---------------------------------------------------------------------------
+// Stale-draft probe — shared by inject-context and batch-assembler
+// ---------------------------------------------------------------------------
+
+// The TO BE ENRICHED markers always appear in the template-stub header
+// region (Decisions/Challenges/etc.) within the first ~2KB of any draft.
+// Bounded read keeps the SessionStart healthcheck and curator scan cheap.
+const STALE_DRAFT_PROBE_BYTES = 2048;
+
+/**
+ * Probe whether a diary draft still carries the enricher's TO BE ENRICHED
+ * placeholders (i.e. enrichment never ran / failed). Bounded read.
+ * @param {string} filePath - Absolute path to the draft.
+ * @returns {boolean} True if the stub marker is present.
+ */
+function draftIsStale(filePath) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buf = Buffer.alloc(STALE_DRAFT_PROBE_BYTES);
+    const n = fs.readSync(fd, buf, 0, STALE_DRAFT_PROBE_BYTES, 0);
+    return buf.subarray(0, n).includes('TO BE ENRICHED');
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Draft generation + background enrichment
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate an auto-diary draft. Returns the draft path on success, null on
+ * failure. Best-effort; never throws.
+ * @param {string} project
+ * @param {string} date
+ * @param {string} sessionId
+ * @returns {string|null}
+ */
+function tryGenerateAutoDiary(project, date, sessionId) {
+  try {
+    const autoDiaryPath = path.join(__dirname, '../../skills/arc-journaling/scripts/auto-diary.js');
+    const result = execFileSync(
+      'node',
+      [autoDiaryPath, 'generate', '--project', project, '--date', date, '--session', sessionId],
+      { encoding: 'utf-8', timeout: 5000 },
+    ).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Spawn a background Claude instance to enrich the diary draft.
+ * Fire-and-forget: detached process, caller exits immediately.
+ *
+ * The child runs with ARCFORGE_SPAWNED=enricher so its own SessionStart
+ * (inject-context) skips consuming the user's pending actions — otherwise the
+ * detached enricher's session would eat diary-ready / reflect-ready /
+ * ratify-pending before the user's next session sees them.
+ *
+ * @param {string} draftPath - Path to the draft to enrich.
+ * @param {Object} transcriptData - { userMessages, toolsUsed, filesModified, stats }.
+ * @param {string} project - Project name (for the enricher.log location).
+ */
+function spawnDiaryEnricher(draftPath, transcriptData, project) {
+  try {
+    const prompt = [
+      'Read the diary draft and fill all <!-- TO BE ENRICHED --> sections.',
+      `Draft path: ${draftPath}`,
+      '',
+      'Session context (parsed summary):',
+      JSON.stringify(transcriptData, null, 2),
+      '',
+      'Write the enriched diary back to the same path.',
+      'Keep auto-generated metrics sections unchanged.',
+      'Fill Completed, In Progress, Decisions, Challenges from the session context.',
+    ].join('\n');
+
+    const systemPrompt =
+      'You are a diary enrichment agent. ' +
+      'Read the draft, fill placeholder sections using provided session data, ' +
+      'write the result back. Be concise and factual.';
+
+    // Capture stderr to a log file so silent failures leave a trail.
+    const sessionsDir = getProjectSessionsDir(project);
+    ensureDir(sessionsDir);
+    const stderrFd = fs.openSync(path.join(sessionsDir, 'enricher.log'), 'a');
+
+    const child = spawn(
+      'claude',
+      [
+        '--model',
+        'haiku',
+        // Haiku needs Read + Write + thinking; 10 leaves headroom (2 hits max-turns).
+        '--max-turns',
+        '10',
+        '--print',
+        '--dangerously-skip-permissions',
+        '--system-prompt',
+        systemPrompt,
+        '--tools',
+        'Read,Write',
+        '--disable-slash-commands',
+        '--strict-mcp-config',
+        '--mcp-config',
+        '{"mcpServers":{}}',
+      ],
+      {
+        detached: true,
+        stdio: ['pipe', 'ignore', stderrFd],
+        env: { ...process.env, ARCFORGE_SPAWNED: 'enricher' },
+      },
+    );
+
+    // spawn reports a missing binary asynchronously via 'error' (ENOENT), not a
+    // sync throw — without this listener that event is unhandled and crashes the
+    // process. Swallow it to honor the fire-and-forget contract below.
+    child.on('error', () => {});
+    child.stdin.on('error', () => {});
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+    child.unref();
+    fs.closeSync(stderrFd);
+  } catch {
+    // Fire-and-forget — spawn failure is non-fatal
+  }
+}
+
+/**
+ * Shared diary-capture core for Stop and PreCompact.
+ *
+ * Reads the counters, gates on the shared threshold, and on a hit: generates a
+ * draft, spawns the background enricher (BOTH event paths), then resets the
+ * counters (the sole reset). Callers handle event-specific work (queuing
+ * diary-ready vs reflect-ready, session-file updates).
+ *
+ * @param {Object} opts
+ * @param {string} opts.project
+ * @param {string} opts.date
+ * @param {string} opts.sessionId
+ * @param {Object} [opts.transcriptData] - { userMessages, toolsUsed, filesModified, stats }.
+ * @returns {{ triggered: boolean, draftPath: string|null, userCount: number, toolCount: number }}
+ */
+function runDiaryCapture(opts) {
+  const { project, date, sessionId, transcriptData = {} } = opts;
+  const { userCount, toolCount } = readCounts();
+
+  if (!shouldTrigger(userCount, toolCount)) {
+    return { triggered: false, draftPath: null, userCount, toolCount };
+  }
+
+  const draftPath = tryGenerateAutoDiary(project, date, sessionId);
+  if (draftPath) {
+    spawnDiaryEnricher(draftPath, transcriptData, project);
+  }
+
+  resetCounters();
+
+  return { triggered: true, draftPath, userCount, toolCount };
+}
+
+module.exports = {
+  STALE_DRAFT_PROBE_BYTES,
+  readCounts,
+  resetCounters,
+  incrementSharedToolCount,
+  getSuggesterStatePath,
+  draftIsStale,
+  tryGenerateAutoDiary,
+  spawnDiaryEnricher,
+  runDiaryCapture,
+};

--- a/scripts/lib/learning-curator/batch-assembler.js
+++ b/scripts/lib/learning-curator/batch-assembler.js
@@ -24,6 +24,7 @@ const os = require('node:os');
 
 const { sanitizeObservationPayload, SANITIZER_POLICY_VERSION } = require('../sanitize-observation');
 const { atomicWriteFile, sha256Truncated } = require('../utils');
+const { draftIsStale } = require('../diary-capture');
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -151,6 +152,10 @@ const EVIDENCE_KIND_CONFIG = {
     idField: 'diary_id',
     store: 'diary',
     buildExtra: (sanitized) => ({ summary: sanitized }),
+    // Drafts whose enricher never ran still carry the TO BE ENRICHED stub.
+    // Skip them so a failed enrichment degrades to MISSING evidence rather
+    // than feeding template placeholders into the curator (S5-5).
+    skipStale: true,
   },
   reflect: {
     getDir: getReflectionsDir,
@@ -183,7 +188,10 @@ function readRecentEvidence(kind, homeDir, project) {
 
   const allFiles = walkFilesByMtime(dir, cfg.pattern);
   const scanned = allFiles.length;
-  const selected = allFiles.slice(0, cfg.maxN());
+  // Filter unenriched diary stubs before selecting so the maxN budget is spent
+  // on real evidence, not template placeholders (S5-5).
+  const eligible = cfg.skipStale ? allFiles.filter((f) => !draftIsStale(f.path)) : allFiles;
+  const selected = eligible.slice(0, cfg.maxN());
 
   const items = [];
   for (const { path: filePath } of selected) {

--- a/scripts/lib/loop-state.js
+++ b/scripts/lib/loop-state.js
@@ -150,6 +150,114 @@ function currentRunErrors(state) {
 }
 
 /**
+ * Count proposed decisions across specs/<id>/decisions.yml under projectRoot.
+ * Canonical single-level glob (specs then per-spec decisions.yml) — no recursion.
+ * Best-effort: any read/parse failure for a spec contributes zero, never throws.
+ * @param {string} projectRoot - Project root directory
+ * @returns {{ count: number, specs: Array<{ spec_id: string, decision_ids: string[] }> }}
+ */
+function scanProposedDecisions(projectRoot) {
+  const { parseDecisionLedger } = require('./sdd-utils');
+  const specsDir = path.join(projectRoot, 'specs');
+  const result = { count: 0, specs: [] };
+  let entries;
+  try {
+    entries = fs.readdirSync(specsDir, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const ledgerPath = path.join(specsDir, entry.name, 'decisions.yml');
+    let parsed;
+    try {
+      parsed = parseDecisionLedger(ledgerPath);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(parsed)) continue;
+    const decisionIds = parsed
+      .filter((d) => d && d.status === 'proposed')
+      .map((d) => d.id)
+      .filter(Boolean);
+    if (decisionIds.length > 0) {
+      result.count += decisionIds.length;
+      result.specs.push({ spec_id: entry.name, decision_ids: decisionIds });
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolve the current branch of projectRoot. Best-effort → null on failure.
+ * @param {string} projectRoot - Project root directory
+ * @returns {string|null}
+ */
+function resolveBaseBranch(projectRoot) {
+  try {
+    const { execFileSync } = require('node:child_process');
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Map failed_tasks → [{ id, reason }]. Reason is the latest recorded error for
+ * the task (errors are capped/run-scoped, so fall back to a generic reason when
+ * the entry has been evicted).
+ * @param {Object} state - Loop state
+ * @returns {Array<{ id: string, reason: string }>}
+ */
+function buildBlockedList(state) {
+  const failed = Array.isArray(state.failed_tasks) ? state.failed_tasks : [];
+  const errors = Array.isArray(state.errors) ? state.errors : [];
+  return failed.map((id) => {
+    const match = errors.filter((e) => e.task_id === id).pop();
+    return { id, reason: match ? match.error : 'failed after retries' };
+  });
+}
+
+/**
+ * Queue the morning review-queue actions: a deduped ratify-pending (when any
+ * proposed decisions exist) and a loop-finished outcome summary. Best-effort —
+ * never throws into finalize (a notification failure must not leave the loop
+ * sentinel non-terminal).
+ * @param {Object} state - Loop state
+ * @param {string} projectRoot - Project root directory
+ */
+function queueLoopNotifications(state, projectRoot) {
+  const { addPendingAction, getPendingActions } = require('./pending-actions');
+  const { sanitizeProjectName } = require('./utils');
+  const project = sanitizeProjectName(path.basename(projectRoot));
+
+  const proposed = scanProposedDecisions(projectRoot);
+  if (proposed.count > 0) {
+    // Dedup: addPendingAction always pushes a fresh entry, so skip if an
+    // unconsumed ratify-pending is already queued (a second finalize must not
+    // double-notify).
+    const existing = getPendingActions(project, 'ratify-pending');
+    if (existing.length === 0) {
+      addPendingAction(project, 'ratify-pending', {
+        count: proposed.count,
+        specs: proposed.specs,
+      });
+    }
+  }
+
+  addPendingAction(project, 'loop-finished', {
+    status: state.status,
+    completed_count: Array.isArray(state.completed_tasks) ? state.completed_tasks.length : 0,
+    blocked: buildBlockedList(state),
+    base_branch: resolveBaseBranch(projectRoot),
+    total_cost: state.total_cost || 0,
+  });
+}
+
+/**
  * Finalize loop state: stamp terminal status and persist.
  * @param {Object} state - Loop state
  * @param {number} maxRuns - Maximum iterations configured for the run
@@ -160,7 +268,17 @@ function finalizeLoop(state, maxRuns, projectRoot) {
     state.status = 'max_runs';
   }
   state.finished_at = getTimestamp();
+  // Persist terminal state FIRST — the loop sentinel must read terminal/finished
+  // before any notification work runs, or the SDD-5 ratify command the morning
+  // notification names would be denied by the (still-running) sentinel gate.
   saveLoopState(state, projectRoot);
+
+  // Morning review-queue notifications (SDD-5) — best-effort, never breaks finalize.
+  try {
+    queueLoopNotifications(state, projectRoot);
+  } catch {
+    /* notification enrichment is best-effort; terminal state is already saved */
+  }
 }
 
 /**

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -1,0 +1,168 @@
+// tests/scripts/diary-capture.test.js
+//
+// ICL-8: diary-capture.js is the shared diary-capture core + counter-ownership
+// owner. These tests cover threshold gating, reset-on-trigger-only, the binding
+// counter contract, the dual-path enricher spawn (PATH-stub claude), the
+// stale-draft probe, and the suggester-state path helper.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+describe('diary-capture', () => {
+  let homeDir;
+  let tmpDir;
+  let savedSession;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diary-capture-home-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diary-capture-tmp-'));
+    jest.spyOn(os, 'homedir').mockReturnValue(homeDir);
+    process.env.TMPDIR = tmpDir;
+    savedSession = process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = 'diary-capture-session';
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (savedSession === undefined) delete process.env.CLAUDE_SESSION_ID;
+    else process.env.CLAUDE_SESSION_ID = savedSession;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('counter ownership', () => {
+    it('readCounts reflects both counters', () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { readCounts } = require('../../scripts/lib/diary-capture');
+      createSessionCounter('user-count').write(3);
+      createSessionCounter('tool-count').write(7);
+      expect(readCounts()).toEqual({ userCount: 3, toolCount: 7 });
+    });
+
+    it('resetCounters zeroes both counters', () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { resetCounters, readCounts } = require('../../scripts/lib/diary-capture');
+      createSessionCounter('user-count').write(9);
+      createSessionCounter('tool-count').write(60);
+      resetCounters();
+      expect(readCounts()).toEqual({ userCount: 0, toolCount: 0 });
+    });
+
+    it('binding contract: incrementSharedToolCount x50 -> readCounts 50 -> shouldTrigger', () => {
+      const { incrementSharedToolCount, readCounts } = require('../../scripts/lib/diary-capture');
+      const { shouldTrigger } = require('../../scripts/lib/thresholds');
+      for (let i = 0; i < 50; i++) incrementSharedToolCount();
+      const { toolCount } = readCounts();
+      expect(toolCount).toBe(50);
+      expect(shouldTrigger(0, toolCount)).toBe(true);
+    });
+  });
+
+  describe('getSuggesterStatePath', () => {
+    it('is session-scoped and lives under the temp dir', () => {
+      const { getSuggesterStatePath } = require('../../scripts/lib/diary-capture');
+      const p = getSuggesterStatePath();
+      expect(p).toContain('arcforge-suggester-state-');
+      expect(p).toContain('diary-capture-session');
+    });
+  });
+
+  describe('draftIsStale', () => {
+    it('returns true for an unenriched stub and false for an enriched draft', () => {
+      const { draftIsStale } = require('../../scripts/lib/diary-capture');
+      const stub = path.join(tmpDir, 'stub.md');
+      const enriched = path.join(tmpDir, 'enriched.md');
+      fs.writeFileSync(stub, '# Diary\n\n## Decisions\n<!-- TO BE ENRICHED -->\n');
+      fs.writeFileSync(enriched, '# Diary\n\n## Decisions\n- shipped the fix\n');
+      expect(draftIsStale(stub)).toBe(true);
+      expect(draftIsStale(enriched)).toBe(false);
+    });
+  });
+
+  describe('runDiaryCapture threshold gating', () => {
+    it('does NOT trigger or reset below threshold', () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { runDiaryCapture, readCounts } = require('../../scripts/lib/diary-capture');
+      createSessionCounter('user-count').write(1);
+      createSessionCounter('tool-count').write(2);
+
+      const result = runDiaryCapture({
+        project: 'demo',
+        date: '2026-06-14',
+        sessionId: 'diary-capture-session',
+      });
+
+      expect(result.triggered).toBe(false);
+      // Counters preserved (reset only on trigger).
+      expect(readCounts()).toEqual({ userCount: 1, toolCount: 2 });
+    });
+
+    it('triggers above threshold, generates a draft, and resets counters', () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { runDiaryCapture, readCounts } = require('../../scripts/lib/diary-capture');
+      createSessionCounter('user-count').write(15); // >= MIN_USER_MESSAGES (10)
+      createSessionCounter('tool-count').write(3);
+
+      const result = runDiaryCapture({
+        project: 'demo',
+        date: '2026-06-14',
+        sessionId: 'diary-capture-session',
+      });
+
+      expect(result.triggered).toBe(true);
+      expect(result.draftPath).toBeTruthy();
+      expect(fs.existsSync(result.draftPath)).toBe(true);
+      // Sole reset path fired.
+      expect(readCounts()).toEqual({ userCount: 0, toolCount: 0 });
+    });
+  });
+
+  describe('dual-path enricher spawn (PATH-stub claude)', () => {
+    let binDir;
+    let savedPath;
+
+    beforeEach(() => {
+      binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diary-capture-bin-'));
+      savedPath = process.env.PATH;
+      process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+      // Stub `claude`: record ARCFORGE_SPAWNED to a marker so we can assert the
+      // detached enricher actually ran with the relay-isolation env.
+      const marker = path.join(binDir, 'spawned.marker');
+      const stub = `#!/bin/sh\ncat > /dev/null\nprintf '%s' "$ARCFORGE_SPAWNED" > "${marker}"\n`;
+      fs.writeFileSync(path.join(binDir, 'claude'), stub, { mode: 0o755 });
+    });
+
+    afterEach(() => {
+      process.env.PATH = savedPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+    });
+
+    async function waitForMarker(file, timeoutMs) {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (fs.existsSync(file)) return fs.readFileSync(file, 'utf-8');
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      return null;
+    }
+
+    it('spawns the enricher with ARCFORGE_SPAWNED=enricher when triggered', async () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { runDiaryCapture } = require('../../scripts/lib/diary-capture');
+      createSessionCounter('user-count').write(15);
+
+      const result = runDiaryCapture({
+        project: 'demo',
+        date: '2026-06-14',
+        sessionId: 'diary-capture-session',
+      });
+      expect(result.triggered).toBe(true);
+
+      const marker = path.join(binDir, 'spawned.marker');
+      const content = await waitForMarker(marker, 5000);
+      expect(content).toBe('enricher');
+    });
+  });
+});

--- a/tests/scripts/learning-curator-batch-assembler.test.js
+++ b/tests/scripts/learning-curator-batch-assembler.test.js
@@ -215,6 +215,24 @@ describe('assembleBatch — diary context', () => {
     }
   });
 
+  test('skips unenriched stub diaries, ingesting only enriched ones (S5-5)', () => {
+    const { assembleBatch } = getAssembler();
+    const project = 'stale-diary-project';
+    seedObservations(project, [makeObservation({ project })]);
+    seedDiaries(project, [
+      '# Session Summary\n\nShipped the enriched retry-budget fix.',
+      '# Session Summary\n\n## Decisions\n<!-- TO BE ENRICHED -->\nplaceholder-token-XYZ',
+    ]);
+
+    const result = assembleBatch({ project });
+    const promptContent = fs.readFileSync(result.prompt_path, 'utf8');
+
+    expect(promptContent).toContain('retry-budget fix');
+    // The unenriched stub must NOT contribute template placeholders.
+    expect(promptContent).not.toContain('TO BE ENRICHED');
+    expect(promptContent).not.toContain('placeholder-token-XYZ');
+  });
+
   test('limits diary context to at most 5 entries', () => {
     const { assembleBatch } = getAssembler();
     const project = 'many-diaries-project';

--- a/tests/scripts/loop-state.test.js
+++ b/tests/scripts/loop-state.test.js
@@ -103,6 +103,35 @@ describe('loop-state', () => {
   });
 
   describe('finalizeLoop', () => {
+    // finalizeLoop now queues morning review-queue pending actions under
+    // ~/.arcforge/sessions/{project} (SDD-5). Redirect homedir so those writes
+    // are isolated to the temp dir and never touch the real ~/.arcforge.
+    let homeDir;
+    beforeEach(() => {
+      homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'loop-state-home-'));
+      jest.spyOn(os, 'homedir').mockReturnValue(homeDir);
+      jest.resetModules();
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    // pending-actions reads via getProjectName-equivalent key: basename(projectRoot)
+    const projectKey = (root) => path.basename(root);
+    const getActions = (root, type) => {
+      const file = path.join(
+        homeDir,
+        '.arcforge',
+        'sessions',
+        projectKey(root),
+        'pending-actions.json',
+      );
+      if (!fs.existsSync(file)) return [];
+      const all = JSON.parse(fs.readFileSync(file, 'utf-8')).actions;
+      return type ? all.filter((a) => a.type === type) : all;
+    };
+
     it('stamps finished_at and persists state', () => {
       const state = loadLoopState(tmpDir);
       state.status = 'complete';
@@ -118,6 +147,92 @@ describe('loop-state', () => {
       finalizeLoop(state, 50, tmpDir);
       expect(state.status).toBe('max_runs');
       expect(loadLoopState(tmpDir).status).toBe('max_runs');
+    });
+
+    it('queues a loop-finished action with status/completed_count/blocked/cost', () => {
+      const state = loadLoopState(tmpDir);
+      state.status = 'complete';
+      state.completed_tasks = ['T-1', 'T-2'];
+      state.failed_tasks = ['T-3'];
+      state.errors = [{ task_id: 'T-3', error: 'boom', iteration: 1, timestamp: 'x', attempt: 2 }];
+      state.total_cost = 1.5;
+      finalizeLoop(state, 50, tmpDir);
+
+      const finished = getActions(tmpDir, 'loop-finished');
+      expect(finished).toHaveLength(1);
+      const p = finished[0].payload;
+      expect(p.status).toBe('complete');
+      expect(p.completed_count).toBe(2);
+      expect(p.blocked).toEqual([{ id: 'T-3', reason: 'boom' }]);
+      expect(p.total_cost).toBe(1.5);
+      // base_branch resolves to the temp repo's branch or null — must not throw.
+      expect('base_branch' in p).toBe(true);
+    });
+
+    it('falls back to a generic blocked reason when the error was evicted', () => {
+      const state = loadLoopState(tmpDir);
+      state.failed_tasks = ['T-9'];
+      state.errors = [];
+      finalizeLoop(state, 50, tmpDir);
+      const p = getActions(tmpDir, 'loop-finished')[0].payload;
+      expect(p.blocked).toEqual([{ id: 'T-9', reason: 'failed after retries' }]);
+    });
+
+    it('queues ratify-pending counting proposed decisions across specs', () => {
+      const mkLedger = (specId, body) => {
+        const dir = path.join(tmpDir, 'specs', specId);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'decisions.yml'), body);
+      };
+      mkLedger(
+        'spec-a',
+        '- id: D-001\n  status: proposed\n  decision: x\n- id: D-002\n  status: proposed\n  decision: y\n',
+      );
+      mkLedger('spec-b', '- id: D-003\n  status: accepted\n  decision: z\n');
+
+      const state = loadLoopState(tmpDir);
+      state.status = 'complete';
+      finalizeLoop(state, 50, tmpDir);
+
+      const ratify = getActions(tmpDir, 'ratify-pending');
+      expect(ratify).toHaveLength(1);
+      expect(ratify[0].payload.count).toBe(2);
+      expect(ratify[0].payload.specs).toEqual([
+        { spec_id: 'spec-a', decision_ids: ['D-001', 'D-002'] },
+      ]);
+    });
+
+    it('does not double-queue ratify-pending across two finalize calls', () => {
+      const dir = path.join(tmpDir, 'specs', 'spec-a');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'decisions.yml'), '- id: D-001\n  status: proposed\n');
+
+      finalizeLoop(loadLoopState(tmpDir), 50, tmpDir);
+      finalizeLoop(loadLoopState(tmpDir), 50, tmpDir);
+
+      expect(getActions(tmpDir, 'ratify-pending')).toHaveLength(1);
+    });
+
+    it('does not queue ratify-pending when no decisions are proposed', () => {
+      const dir = path.join(tmpDir, 'specs', 'spec-a');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'decisions.yml'), '- id: D-001\n  status: accepted\n');
+
+      finalizeLoop(loadLoopState(tmpDir), 50, tmpDir);
+      expect(getActions(tmpDir, 'ratify-pending')).toHaveLength(0);
+    });
+
+    it('writes a terminal sentinel that passes the AF-2 loop-sentinel gate (S3-4)', () => {
+      // After finalize, the on-disk sentinel is terminal, so the ratify command
+      // named in the morning notification is NOT denied by the sentinel gate.
+      const { loopSentinelPresent } = require('../../scripts/lib/sdd-utils');
+      const state = loadLoopState(tmpDir);
+      state.status = 'complete';
+      finalizeLoop(state, 50, tmpDir);
+
+      // Sentinel exists (resume depends on it) but reads as terminal.
+      expect(fs.existsSync(path.join(tmpDir, '.arcforge-loop.json'))).toBe(true);
+      expect(loopSentinelPresent(tmpDir)).toBe(false);
     });
   });
 


### PR DESCRIPTION
Wave 3 (PR-3b+3d; SDD-5 depends on ICL-8 → one agent). Closes the compaction/loop-end half of the learning loop.

## ICL-8 — diary-capture.js extraction
- New scripts/lib/diary-capture.js: sole owner of counter read+reset; `incrementSharedToolCount()` (compact-suggester's only writer), `getSuggesterStatePath()` (sole path helper for ICL-9), `readCounts()/runDiaryCapture()`; enricher ON for BOTH Stop and PreCompact
- S5-4: pre-compact parses stdin session_id before counter access (no CLAUDE_SESSION_ID env dependency); S5-5: `draftIsStale` probe shared, batch-assembler skips stub drafts (enricher failure → missing evidence, not template evidence); S7-1: enricher spawns with ARCFORGE_SPAWNED=enricher, inject-context relay SKIPS consumption when ARCFORGE_SPAWNED set (no more spawned sessions eating the user's pending actions)

## SDD-5 — the north-star morning surface
- finalizeLoop scans specs/*/decisions.yml → ratify-pending (dedup) + loop-finished {status, completed_count, blocked[], base_branch, total_cost}; inject-context renders both at SessionStart
- S3-1/S4-5: parsable model line `ARCFORGE_MODE=attended node "$ARCFORGE_ROOT/scripts/cli.js" ratify <spec> <D>` (no bare `arcforge` bin); S3-4: terminal sentinel written first so the named ratify command passes the AF-2 gate

## Acceptance (adversarially reviewed: approve)
- diary-capture 8/8, pre-compact fixture (stdin-only session_id), relay isolation, finalizeLoop ratify/loop-finished suite; npm test all 5 runners (Jest 2108, hooks 296, node 11, pytest 550, observer-daemon 16)

## ⚠️ Merge note
Co-edits hooks/session-tracker/inject-context.js with ICL-4 (#next). The require-block additions overlap (trivial); function bodies are disjoint (renderLoopFinished/loadPendingActions here vs loadAutoInstincts there). Recommend merging this first; ICL-4 rebases keeping both import blocks. loop-state.js is clean vs AF-7 (verified via merge-tree).