### PR TITLE
feat(learning): wire loadAutoInstincts into SessionStart + activate draft→active transform (ICL-4)

### DIFF
--- a/docs/plans/references/learning-curator-schema/layer-8-activation-runtime-influence-surface.md
+++ b/docs/plans/references/learning-curator-schema/layer-8-activation-runtime-influence-surface.md
@@ -175,13 +175,13 @@ The exact active root must be explicit and allowlisted. Layer 8 must not infer a
 
 | Candidate `artifact_type` | Activation target | Runtime influence contract |
 |---|---|---|
-| `instinct` | `~/.arcforge/instincts/<project>/<id>.md` or `~/.arcforge/instincts/global/<id>.md` according to candidate scope | Active instinct record only; must not auto-load into Claude context. |
+| `instinct` | `~/.arcforge/instincts/<project>/<id>.md` or `~/.arcforge/instincts/global/<id>.md` according to candidate scope | Active instinct record. May be surfaced at SessionStart only through the **activation-gated** injection path (ICL-4): a reviewer must have explicitly activated it. Confidence-based auto-load remains forbidden. |
 | `skill` | allowed `skills/<name>/SKILL.md` active root | May influence future Claude behavior through normal skill discovery only after activation. |
 | `command` | allowed active command root | May influence command availability only after activation. |
 | `agent` | allowed active agent root | May influence agent availability only after activation. |
 | `claude_md_addition` | manual patch artifact / instructions | No automatic edit to `CLAUDE.md`; user applies manually if desired. |
 
-For the pivot, activated instincts are durable learning atoms, not automatic LLM influence units. The SessionStart auto-load behavior remains forbidden. Influence reaches Claude only through explicitly activated skills / commands / agents or a manually applied CLAUDE.md patch outside automatic activation.
+Activated instincts are durable learning atoms. **Reviewed slice 2 (ICL-4) revision:** an instinct that a reviewer has explicitly activated on the dashboard MAY be surfaced into Claude context at SessionStart through the activation-gated injection path. The gate is the activation lifecycle, not confidence — the retired confidence-based auto-load (any high-confidence file surfacing automatically) remains forbidden. The injection is governed by the `inject_activated_instincts` kill-switch (default ON; explicit `false` silences it), is capped at the top five by confidence, and folds ActivationRecords by candidate_id (latest wins, so a deactivated instinct stops injecting). Influence still reaches Claude only after an explicit reviewer activation — never from pending/approved/materialized candidates, and never via an automatic CLAUDE.md patch.
 
 ## Primary output — ActivationRecord
 
@@ -343,6 +343,9 @@ type ActivationSafetyMetadata = {
   claude_md_auto_apply: false;
 
   runtime_boundary: {
+    // Confidence-based auto-load (any high-confidence file surfacing without
+    // review) stays disabled; the field name predates ICL-4. The ICL-4
+    // activation-gated injection is a distinct, reviewer-gated path.
     session_start_instinct_autoload_disabled_required: true;
     global_auto_promote_disabled_required: true;
   };
@@ -352,8 +355,8 @@ type ActivationSafetyMetadata = {
 Before enabling Layer 8 activation in production, implementation must verify the old behavior-changing shortcuts are disabled:
 
 ```text
-SessionStart instinct auto-load  disabled
-project → global auto-promote    disabled
+SessionStart confidence auto-load  disabled   (ICL-4 gated injection is separate)
+project → global auto-promote      disabled
 statistical analyzer production candidate path disabled
 ```
 
@@ -431,7 +434,7 @@ Runtime consumers may read active behavior surfaces only after Layer 8 has creat
 
 - Claude Code skill discovery may read activated skills in the allowed active skills root.
 - Command/agent discovery may read activated command/agent roots if those artifact types are implemented.
-- Instinct readers may read activated instinct files for dashboard/history/evolve input, but SessionStart must not auto-load instinct body into Claude context.
+- Instinct readers may read activated instinct files for dashboard/history/evolve input. SessionStart may additionally inject an activated instinct's trigger/body summary into Claude context through the activation-gated path (ICL-4); it must never confidence-auto-load a non-activated instinct.
 - Manual `CLAUDE.md` patch remains outside automatic runtime write; user applies it manually if desired.
 
 Layer 5 consumes Layer 8 success reports as lifecycle transition events.
@@ -450,7 +453,7 @@ Layer 8 must not:
 - generate or modify candidate meaning;
 - materialize drafts from candidate body if Layer 7 materialization is missing;
 - auto-apply `claude_md_addition` to `CLAUDE.md`;
-- re-enable SessionStart instinct auto-load;
+- re-enable confidence-based SessionStart instinct auto-load (the activation-gated injection of ICL-4 is the only permitted SessionStart instinct path);
 - auto-promote project candidates to global;
 - activate directly from pending or approved state;
 - treat activation registry as a replacement for Layer 5 lifecycle source of truth;
@@ -480,7 +483,8 @@ Blocked shortcuts:
 Pending Candidate → Active Surface       BLOCKED
 Approved Candidate → Active Surface      BLOCKED
 Materialized Draft → Active Surface      BLOCKED without explicit Activate
-Activated Instinct → SessionStart load   BLOCKED
+Non-activated Instinct → SessionStart    BLOCKED (no confidence auto-load)
+Activated Instinct → SessionStart inject ALLOWED (gated, kill-switch, top-5)
 claude_md_addition → auto-edit CLAUDE.md  BLOCKED
 ```
 
@@ -493,7 +497,7 @@ claude_md_addition → auto-edit CLAUDE.md  BLOCKED
 5. Active writes are atomic, lock-protected, and backed up when superseding existing artifacts.
 6. Activation records are persisted before reporting lifecycle success.
 7. Layer 5 receives `activated` / `deactivated` transitions only after side effects are durable.
-8. `instinct` activation does not reintroduce SessionStart auto-load into Claude context.
+8. `instinct` activation does not reintroduce confidence-based SessionStart auto-load. Activated instincts MAY surface at SessionStart only through the ICL-4 activation-gated injection (kill-switch default ON, top-5 by confidence, deactivation removes them).
 9. `skill` activation writes only to an allowed active skills root.
 10. `claude_md_addition` is never automatically applied to `CLAUDE.md`.
 11. Failed activation creates no `activated` lifecycle event.
@@ -507,7 +511,7 @@ The first 3.1 implementation slice uses these defaults unless a later reviewed p
 
 1. Activation supports **`instinct` targets only**, written under `~/.arcforge/instincts/<project>/` for project-scoped candidates or `~/.arcforge/instincts/global/` for global-scoped candidates. Global instinct activation is first-slice behavior but still does not auto-load into Claude context. No active skills root is enabled by default. Future skill activation must require an explicit dashboard-selected, allowlisted skills root.
 2. `command` and `agent` activation are **reserved** until skill activation is implemented, reviewed, and proven safe. `claude_md_addition` remains manual-only and is never auto-applied.
-3. Activated instincts are consumed by dashboard/history/evolve surfaces only in the first slice. They must not be auto-loaded into Claude context at SessionStart and must not become direct runtime instructions.
+3. **Revised by ICL-4 (reviewed slice 2):** activated instincts are consumed by dashboard/history/evolve surfaces AND, when explicitly activated, by the SessionStart activation-gated injection path (kill-switch `inject_activated_instincts` default ON, top-5 by confidence, latest-wins fold over ActivationRecords). They are never confidence-auto-loaded and never become hard runtime instructions — they are surfaced as advisory context the model applies where relevant.
 4. Deactivation uses `move_to_disabled_archive` with a backup record. The first dashboard UX exposes deactivate status and backup metadata; full rollback/supersede UX is deferred.
 5. **Overwrite policy defaults**:
    - `instinct`: `"supersede_with_backup"` — re-activating an instinct after manual edit must preserve the prior body as a backup record, not hard-fail. The instinct path includes a candidate-derived `<id>`, so collisions are intended re-activations.
@@ -519,5 +523,5 @@ The first 3.1 implementation slice uses these defaults unless a later reviewed p
 
 1. Active skills root selection and policy for future skill activation.
 2. Command/agent activation after skill activation is proven safe.
-3. Any non-runtime reader for activated instincts beyond dashboard/history/evolve.
+3. ~~Any non-runtime reader for activated instincts beyond dashboard/history/evolve.~~ **RESOLVED (ICL-4):** the SessionStart activation-gated injection is the first such consumer — it reads only explicitly-activated instinct files, gated by the `inject_activated_instincts` kill-switch (default ON) and capped at the top five by confidence.
 4. Rich rollback/supersede dashboard UX.

--- a/hooks/__tests__/e2e-hooks.test.js
+++ b/hooks/__tests__/e2e-hooks.test.js
@@ -156,8 +156,9 @@ describe('E2E: session-tracker/inject-context.js', () => {
   });
 
   it('does not auto-inject high-confidence instincts into stdout', () => {
-    // Invariant: SessionStart must not surface instinct text in Claude
-    // context regardless of confidence. Influence requires explicit activation.
+    // Invariant (ICL-4): confidence alone never surfaces an instinct. Influence
+    // requires an explicit ActivationRecord — this seeded file has none, so it
+    // must not appear, however high its confidence.
     const projectName = path.basename(testDir);
     const instinctsDir = path.join(testDir, '.arcforge', 'instincts', projectName);
     fs.mkdirSync(instinctsDir, { recursive: true });

--- a/hooks/__tests__/inject-activated-instincts.test.js
+++ b/hooks/__tests__/inject-activated-instincts.test.js
@@ -1,0 +1,254 @@
+// hooks/__tests__/inject-activated-instincts.test.js
+//
+// ICL-4 — SessionStart injection of ACTIVATED instincts.
+//
+// The gate is the activation lifecycle, not confidence. Every fixture uses the
+// real materialize() → activate() chain (no hand-written YAML) so the test
+// proves the content contract end to end: a dashboard-activated instinct is
+// transformed into loadable YAML frontmatter and surfaces at SessionStart.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
+
+const materializeModule = require('../../scripts/lib/learning-curator/materialize');
+const {
+  activate,
+  deactivate,
+  defaultActivationPolicy,
+} = require('../../scripts/lib/learning-curator/activate');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let testDir;
+let projectRoot;
+let projectName;
+let arcforgeRoot;
+const originalEnv = { ...process.env };
+
+function makeCandidate(overrides = {}) {
+  const candidateId = overrides.candidate_id || `cand_${crypto.randomBytes(4).toString('hex')}`;
+  return {
+    schema_version: 1,
+    candidate_id: candidateId,
+    artifact_type: 'instinct',
+    scope: { kind: 'project', project: projectName, project_id: 'proj-hash' },
+    name: overrides.name || `instinct-${candidateId}`,
+    summary: overrides.summary || 'A behavioral pattern.',
+    rationale: 'Observed pattern.',
+    body: overrides.body || 'Prefer Edit before Bash when modifying files.',
+    body_source: 'llm_curator',
+    domain: overrides.domain || 'workflow',
+    trigger: overrides.trigger || 'when editing files',
+    evidence: [{ evidence_id: 'ev-1', evidence_type: 'observation', relevance: 'x', summary: 's' }],
+    evidence_quality: overrides.evidence_quality || 'low',
+    lifecycle: { status: 'approved', status_changed_at: '2026-05-21T00:00:00Z' },
+    created_at: '2026-05-21T00:00:00Z',
+    updated_at: '2026-05-21T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// Run the real materialize → activate chain. Returns the candidate.
+function activateCandidate(overrides = {}) {
+  const candidate = makeCandidate(overrides);
+  const matResult = materializeModule.materialize({
+    candidate,
+    sourceActionId: 'act_seed',
+    requestedArtifactType: 'instinct',
+    renderPolicy: materializeModule.defaultRenderPolicy(),
+    arcforgeRoot,
+  });
+  if (!matResult.ok) throw new Error(`materialize failed: ${matResult.failure.reason}`);
+
+  const actResult = activate({
+    candidate: { ...candidate, lifecycle: { status: 'materialized', status_changed_at: 'x' } },
+    materializationRecord: matResult.record,
+    activationRequest: {
+      schema_version: 1,
+      request_id: `req_${crypto.randomBytes(4).toString('hex')}`,
+      source_action_id: 'act_test',
+      action: 'activate',
+      candidate_id: candidate.candidate_id,
+      target: { target_kind: 'instinct' },
+      reviewer_ack: { confirmed_behavior_change: true, saw_target_summary: true },
+    },
+    activationPolicy: defaultActivationPolicy(arcforgeRoot),
+    arcforgeRoot,
+  });
+  if (!actResult.ok) throw new Error(`activate failed: ${actResult.failure.reason}`);
+  return { candidate, activationRecord: actResult.record };
+}
+
+function deactivateCandidate(candidate, activationRecord) {
+  const result = deactivate({
+    candidate: { ...candidate, lifecycle: { status: 'activated', status_changed_at: 'x' } },
+    activationRecord,
+    activationRequest: {
+      schema_version: 1,
+      request_id: `req_${crypto.randomBytes(4).toString('hex')}`,
+      source_action_id: 'act_test',
+      action: 'deactivate',
+      candidate_id: candidate.candidate_id,
+      target: { target_kind: 'instinct' },
+      reviewer_ack: { confirmed_behavior_change: true, saw_target_summary: true },
+    },
+    activationPolicy: defaultActivationPolicy(arcforgeRoot),
+    arcforgeRoot,
+  });
+  if (!result.ok) throw new Error(`deactivate failed: ${result.failure.reason}`);
+}
+
+function runInjectContext() {
+  const scriptPath = path.join(__dirname, '..', 'session-tracker', 'inject-context.js');
+  const result = spawnSync('node', [scriptPath], {
+    input: JSON.stringify({
+      session_id: 'icl4',
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+      cwd: projectRoot,
+      transcript_path: path.join(testDir, 'transcript.jsonl'),
+    }),
+    env: { ...process.env, HOME: testDir, CLAUDE_PROJECT_DIR: projectRoot },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0, `inject-context exit non-zero. stderr: ${result.stderr}`);
+  return result.stdout;
+}
+
+beforeEach(() => {
+  testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-icl4-inject-'));
+  projectRoot = path.join(testDir, 'project');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  projectName = path.basename(projectRoot);
+  arcforgeRoot = path.join(testDir, '.arcforge');
+  process.env.HOME = testDir;
+  process.env.CLAUDE_PROJECT_DIR = projectRoot;
+});
+
+afterEach(() => {
+  fs.rmSync(testDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+});
+
+// ---------------------------------------------------------------------------
+// Case 1: activated instinct is injected
+// ---------------------------------------------------------------------------
+
+describe('ICL-4 activated instinct injection', () => {
+  it('injects an activated instinct into SessionStart context', () => {
+    const { candidate } = activateCandidate({ trigger: 'inject-me-canary' });
+    const stdout = runInjectContext();
+    assert.ok(stdout.includes('Active Behavioral Instincts'), `stdout: ${stdout}`);
+    assert.ok(stdout.includes(candidate.candidate_id), `stdout: ${stdout}`);
+    assert.ok(stdout.includes('inject-me-canary'), `stdout: ${stdout}`);
+  });
+
+  // Case 2: deactivated instinct is not injected
+  it('does not inject a deactivated instinct', () => {
+    const { candidate, activationRecord } = activateCandidate({ trigger: 'deact-canary' });
+    deactivateCandidate(candidate, activationRecord);
+    const stdout = runInjectContext();
+    assert.ok(!stdout.includes('deact-canary'), `deactivated instinct injected. stdout: ${stdout}`);
+    assert.ok(
+      !stdout.includes('Active Behavioral Instincts'),
+      `no instincts should remain. stdout: ${stdout}`,
+    );
+  });
+
+  // Case 3: a non-activated high-confidence file in the same dir is NOT injected
+  it('does not inject a non-activated high-confidence file in the same dir', () => {
+    const { candidate } = activateCandidate({ trigger: 'activated-canary' });
+    // Hand-place a high-confidence instinct with NO activation record.
+    const instinctsDir = path.join(arcforgeRoot, 'instincts', projectName);
+    fs.writeFileSync(
+      path.join(instinctsDir, 'rogue-high-conf.md'),
+      `---\nid: rogue-high-conf\nconfidence: 0.95\ntrigger: rogue-canary\ndomain: workflow\n---\n\n## Action\nshould not inject\n`,
+      'utf-8',
+    );
+    const stdout = runInjectContext();
+    assert.ok(
+      stdout.includes(candidate.candidate_id),
+      `activated should inject. stdout: ${stdout}`,
+    );
+    assert.ok(!stdout.includes('rogue-canary'), `non-activated injected. stdout: ${stdout}`);
+    assert.ok(!stdout.includes('rogue-high-conf'), `non-activated injected. stdout: ${stdout}`);
+  });
+
+  // Case 4: kill-switch disables injection
+  it('injects nothing when inject_activated_instincts is false (kill-switch)', () => {
+    activateCandidate({ trigger: 'killswitch-canary' });
+    const configDir = path.join(arcforgeRoot, 'learning');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ scope: 'global', inject_activated_instincts: false }),
+      'utf-8',
+    );
+    const stdout = runInjectContext();
+    assert.ok(!stdout.includes('killswitch-canary'), `kill-switch failed. stdout: ${stdout}`);
+    assert.ok(
+      !stdout.includes('Active Behavioral Instincts'),
+      `kill-switch failed. stdout: ${stdout}`,
+    );
+  });
+
+  // Case 5: cap at 5, ordered by confidence
+  it('caps injection at the top 5 activated instincts by confidence', () => {
+    // 7 activated instincts; evidence_quality maps to distinct confidences so
+    // the top-5 ordering is deterministic. 3 high (0.60), 2 medium (0.55),
+    // 2 low (0.50): the two low ones must be dropped.
+    const ids = [];
+    for (let i = 0; i < 3; i++) ids.push(activateCandidate({ evidence_quality: 'high' }).candidate);
+    for (let i = 0; i < 2; i++)
+      ids.push(activateCandidate({ evidence_quality: 'medium' }).candidate);
+    const lows = [];
+    for (let i = 0; i < 2; i++) lows.push(activateCandidate({ evidence_quality: 'low' }).candidate);
+
+    const stdout = runInjectContext();
+    const parsed = JSON.parse(stdout);
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    const instinctLines = ctx.split('\n').filter((l) => /^- \*\*cand_/.test(l));
+    assert.strictEqual(instinctLines.length, 5, `expected 5 lines, got ${instinctLines.length}`);
+    // The two lowest-confidence instincts must be the dropped ones.
+    for (const low of lows) {
+      assert.ok(
+        !instinctLines.some((l) => l.includes(low.candidate_id)),
+        `lowest-confidence instinct should have been capped out: ${low.candidate_id}`,
+      );
+    }
+  });
+
+  // Case 6: zero-state — no learning, no output
+  it('emits no instinct output when nothing is activated (zero-state)', () => {
+    const stdout = runInjectContext();
+    assert.ok(
+      !stdout.includes('Active Behavioral Instincts'),
+      `zero-state should be silent. stdout: ${stdout}`,
+    );
+  });
+
+  // E2E: config false makes the header disappear (re-enabled by default)
+  it('header is present by default and disappears when config is false', () => {
+    activateCandidate({ trigger: 'e2e-canary' });
+    const withInjection = runInjectContext();
+    assert.ok(withInjection.includes('Active Behavioral Instincts'), `default ON failed`);
+
+    const configDir = path.join(arcforgeRoot, 'learning');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ scope: 'global', inject_activated_instincts: false }),
+      'utf-8',
+    );
+    const disabled = runInjectContext();
+    assert.ok(!disabled.includes('Active Behavioral Instincts'), `config false should silence`);
+  });
+});

--- a/hooks/__tests__/instinct-keyspace-migration.test.js
+++ b/hooks/__tests__/instinct-keyspace-migration.test.js
@@ -110,8 +110,24 @@ describe('start.js migrateInstincts', () => {
   });
 });
 
+// Seed an ActivationRecord so an instinct passes the ICL-4 activation gate.
+function seedActivation(candidateId) {
+  const dir = path.join(testDir, '.arcforge', 'learning', 'activations');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `act_${candidateId}.json`),
+    JSON.stringify({
+      schema_version: 1,
+      activation_id: `act_${candidateId}`,
+      action: 'activate',
+      created_at: new Date().toISOString(),
+      candidate_id: candidateId,
+    }),
+  );
+}
+
 describe('inject-context loadAutoInstincts — first-session window (S5-6)', () => {
-  it('lazily migrates on a basename miss, then loads the migrated instinct', () => {
+  it('lazily migrates on a basename miss, then loads the migrated (activated) instinct', () => {
     const { getProjectName } = require(UTILS);
     const { getInstinctsDir } = require(SESSION_UTILS);
     const inject = require(INJECT);
@@ -125,16 +141,44 @@ describe('inject-context loadAutoInstincts — first-session window (S5-6)', () 
       path.join(hashDir, 'cand_inject.md'),
       instinctFile('cand_inject', project, 'proj-hash-www', 0.9),
     );
+    // ICL-4: injection is activation-gated. Activate the candidate so it loads.
+    seedActivation('cand_inject');
 
     const result = inject.loadAutoInstincts(project);
 
-    // The instinct was migrated and then loaded (count reflects the high-conf
-    // migrated file).
-    assert.strictEqual(result.count, 1, 'migrated instinct should be loaded');
+    // The instinct was migrated and then loaded (it is activated).
+    assert.strictEqual(result.count, 1, 'migrated + activated instinct should be loaded');
     assert.ok(/cand_inject/.test(result.text), 'loaded text should mention the instinct');
 
     // And it physically moved into the name-keyed dir.
     const nameFile = path.join(getInstinctsDir(project), 'cand_inject.md');
     assert.ok(fs.existsSync(nameFile), 'file should be migrated to the name-keyed dir');
+  });
+
+  it('still migrates a non-activated instinct on basename miss, but does not inject it', () => {
+    const { getProjectName } = require(UTILS);
+    const { getInstinctsDir } = require(SESSION_UTILS);
+    const inject = require(INJECT);
+
+    const project = getProjectName();
+    const hashDir = path.join(testDir, '.arcforge', 'instincts', 'proj-hash-www');
+    fs.mkdirSync(hashDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hashDir, 'cand_noact.md'),
+      instinctFile('cand_noact', project, 'proj-hash-www', 0.9),
+    );
+    // No activation record seeded.
+
+    const result = inject.loadAutoInstincts(project);
+
+    // Activation gate: a non-activated instinct never injects, however high its
+    // confidence.
+    assert.strictEqual(result.count, 0, 'non-activated instinct must not inject');
+    // But the S5-6 first-session migration still ran as a side effect.
+    const nameFile = path.join(getInstinctsDir(project), 'cand_noact.md');
+    assert.ok(
+      fs.existsSync(nameFile),
+      'migration should still move the file to the name-keyed dir',
+    );
   });
 });

--- a/hooks/__tests__/learning-unification.test.js
+++ b/hooks/__tests__/learning-unification.test.js
@@ -171,10 +171,10 @@ describe('inject-context loads instincts', () => {
 });
 
 // ─────────────────────────────────────────────
-// 5b. SessionStart does NOT auto-inject instincts into Claude context
+// 5b. SessionStart injection is activation-GATED, not confidence-gated (ICL-4)
 // ─────────────────────────────────────────────
 
-describe('SessionStart does not auto-inject instincts', () => {
+describe('SessionStart does not inject non-activated instincts', () => {
   let testDir;
   let projectRoot;
   const originalEnv = { ...process.env };
@@ -186,9 +186,9 @@ describe('SessionStart does not auto-inject instincts', () => {
     process.env.HOME = testDir;
     process.env.CLAUDE_PROJECT_DIR = projectRoot;
 
-    // Seed a high-confidence instinct that the retired auto-loader would have
-    // injected into Claude context. After Slice A, SessionStart must not
-    // surface it.
+    // Seed a HIGH-confidence instinct with NO ActivationRecord. Under ICL-4 the
+    // gate is the activation lifecycle, not confidence — so even a 0.9 instinct
+    // must NOT be injected unless a reviewer explicitly activated it.
     const projectName = path.basename(projectRoot);
     const instinctsDir = path.join(testDir, '.arcforge', 'instincts', projectName);
     fs.mkdirSync(instinctsDir, { recursive: true });
@@ -205,7 +205,7 @@ describe('SessionStart does not auto-inject instincts', () => {
     Object.assign(process.env, originalEnv);
   });
 
-  it('does not emit Active Behavioral Instincts header in SessionStart output', () => {
+  it('does not emit Active Behavioral Instincts header for a non-activated instinct', () => {
     const { spawnSync } = require('node:child_process');
     const hookInput = {
       session_id: 'no-autoload',
@@ -222,11 +222,11 @@ describe('SessionStart does not auto-inject instincts', () => {
     });
     assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 
-    // The auto-loader prepended this exact header. If it ever re-appears in
-    // stdout, the auto-load behavior has regressed.
+    // Confidence alone must never inject. If this header re-appears for a
+    // non-activated instinct, the confidence-auto-load behavior has regressed.
     assert.ok(
       !result.stdout.includes('Active Behavioral Instincts'),
-      `SessionStart must not auto-inject instincts. Got stdout: ${result.stdout}`,
+      `SessionStart must not inject non-activated instincts. Got stdout: ${result.stdout}`,
     );
     assert.ok(
       !result.stdout.includes('high-conf-test'),

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -33,19 +33,35 @@ const {
   getInstinctsDir,
   getGlobalInstinctsDir,
   getInstinctsGlobalIndex,
+  getInstinctsRoot,
   migrateInstinctsToNameKey,
 } = require('../../scripts/lib/session-utils');
 
-const { parseConfidenceFrontmatter, shouldAutoLoad } = require('../../scripts/lib/confidence');
+const { parseConfidenceFrontmatter } = require('../../scripts/lib/confidence');
+const { getArcforgeHome } = require('../../scripts/lib/utils');
+const { listActivatedCandidateIds } = require('../../scripts/lib/learning-curator/activate');
+const { isInjectActivatedInstinctsEnabled } = require('../../scripts/lib/learning');
 
 const { getPendingActions, consumeAction } = require('../../scripts/lib/pending-actions');
 
 const { draftIsStale } = require('../../scripts/lib/diary-capture');
 
+// Max activated instincts injected into SessionStart context (ICL-4).
+const MAX_INJECTED_INSTINCTS = 5;
+
 /**
- * Load instincts with confidence >= AUTO_LOAD_THRESHOLD
+ * Load activated instincts for SessionStart context injection (ICL-4).
+ *
+ * The GATE is the activation lifecycle, not confidence: an instinct is injected
+ * only when a reviewer explicitly activated it on the dashboard and has not
+ * since deactivated it (`listActivatedCandidateIds` folds ActivationRecords by
+ * candidate_id, latest wins). Confidence is used ONLY to sort and cap the top
+ * five — never as a threshold. The `inject_activated_instincts` kill-switch is
+ * DEFAULT ON; only an explicit `false` in the global learning config silences it.
  */
 function loadAutoInstincts(project) {
+  if (!isInjectActivatedInstinctsEnabled()) return { text: null, count: 0 };
+
   let projectInstincts = loadInstinctFiles(getInstinctsDir(project));
   // First-session window (ICL-3, S5-6): start.js runs async and is skipped on
   // source=compact, so the name-keyed dir may still be empty while stale
@@ -60,25 +76,40 @@ function loadAutoInstincts(project) {
     }
   }
   const globalInstincts = loadInstinctFiles(getGlobalInstinctsDir());
-  const autoLoaded = [...projectInstincts, ...globalInstincts].filter((i) =>
-    shouldAutoLoad(i.confidence),
-  );
 
-  if (autoLoaded.length === 0) return { text: null, count: 0 };
+  let activated;
+  try {
+    // Active instinct files live under <home>/instincts; ActivationRecords live
+    // under <home>/learning/activations — both rooted at the same arcforge home.
+    const arcforgeRoot = path.dirname(getInstinctsRoot()) || getArcforgeHome();
+    activated = listActivatedCandidateIds(arcforgeRoot);
+  } catch {
+    activated = new Set();
+  }
+  if (activated.size === 0) return { text: null, count: 0 };
+
+  // Gate: a file is injected only when its basename (candidate_id) is in the
+  // activated set. Confidence is NOT a gate here.
+  const gated = [...projectInstincts, ...globalInstincts].filter((i) => activated.has(i.id));
+  if (gated.length === 0) return { text: null, count: 0 };
+
+  // Confidence sorts + caps the top five; it does not exclude anything.
+  gated.sort((a, b) => (b.confidence || 0) - (a.confidence || 0));
+  const top = gated.slice(0, MAX_INJECTED_INSTINCTS);
 
   const lines = [
     '## Active Behavioral Instincts\n',
-    'These patterns were auto-detected from your tool usage:\n',
+    'These patterns were activated for this project. Apply them where relevant:\n',
   ];
 
-  for (const inst of autoLoaded) {
-    const pctStr = Math.round(inst.confidence * 100);
+  for (const inst of top) {
+    const pctStr = Math.round((inst.confidence || 0) * 100);
     lines.push(`- **${inst.id}** (${pctStr}%): ${inst.trigger || inst.action || ''}`);
   }
 
   lines.push('\nInvoke /arcforge:arc-observing to confirm/contradict these patterns.');
 
-  return { text: lines.join('\n'), count: autoLoaded.length };
+  return { text: lines.join('\n'), count: top.length };
 }
 
 /**
@@ -327,9 +358,15 @@ function main() {
   const contextParts = [];
   const userParts = [];
 
-  // loadAutoInstincts is intentionally not called — SessionStart must not
-  // auto-inject instinct text into Claude context. Influence reaches the
-  // model only through explicit activation.
+  // Activated behavioral instincts (ICL-4). Influence reaches the model only
+  // through explicit dashboard activation (activation-gated, top-5 by
+  // confidence, kill-switch default ON) — never via the retired confidence
+  // auto-load.
+  const { text: instinctContext, count: instinctCount } = loadAutoInstincts(project);
+  if (instinctContext) {
+    contextParts.push(instinctContext);
+    userParts.push(`${instinctCount} active instinct${instinctCount === 1 ? '' : 's'}`);
+  }
 
   // Pending action notifications
   const { text: pendingContext, summary: pendingSummary } = loadPendingActions(project);

--- a/scripts/lib/learning-curator/activate.js
+++ b/scripts/lib/learning-curator/activate.js
@@ -70,6 +70,112 @@ function getActivationsDir(arcforgeRoot) {
   return path.join(arcforgeRoot, 'learning', 'activations');
 }
 
+// ---------------------------------------------------------------------------
+// Draft → active content transform (ICL-4 / S5-1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a candidate's evidence_quality to an initial confidence value.
+ * Activated instincts enter the confidence lifecycle at a deliberately modest
+ * starting point; subsequent confirm/contradict/decay moves it from there.
+ * Falls back to 0.5 (the shared INITIAL constant) for unknown/absent quality.
+ *
+ * @param {string|undefined} evidenceQuality
+ * @returns {number} initial confidence in [0,1]
+ */
+function initialConfidenceFor(evidenceQuality) {
+  switch (evidenceQuality) {
+    case 'high':
+      return 0.6;
+    case 'medium':
+      return 0.55;
+    case 'low':
+      return 0.5;
+    default:
+      return 0.5;
+  }
+}
+
+/**
+ * Escape a value for safe inclusion inside a double-quoted YAML scalar.
+ * Mirrors the confidence.js frontmatter writer's quoting expectations: strip
+ * control characters and escape embedded double quotes.
+ */
+function yamlQuote(value) {
+  const str = String(value == null ? '' : value)
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control char sanitization
+    .replace(/[\x00-\x1f\x7f]/g, ' ');
+  return `"${str.replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Transform a materialized INACTIVE DRAFT into active instinct content.
+ *
+ * The materializer (materialize.js) emits a draft whose header is a fenced
+ * ```json metadata block plus an "INACTIVE DRAFT" banner — a shape the
+ * injection/decay readers (loadInstinctFiles, instinct.js, confidence.js)
+ * cannot parse, because they require leading `---` YAML frontmatter with a
+ * numeric `confidence` field. Without this transform every dashboard-activated
+ * instinct would be silently filtered out (frontmatter.confidence === undefined).
+ *
+ * This emits the canonical active form: YAML `---` frontmatter carrying
+ * id / confidence / source / domain / trigger, followed by the candidate body.
+ * The embedded ```json scope block is preserved so the keyspace migration
+ * (readInstinctProjectScope) can still recover the source scope.
+ *
+ * @param {object} candidate
+ * @returns {string} active instinct file content
+ */
+function buildActiveInstinctContent(candidate) {
+  const id = candidate.candidate_id;
+  const confidence = initialConfidenceFor(candidate.evidence_quality);
+  const domain = candidate.domain || 'general';
+  const trigger = candidate.trigger || candidate.summary || '';
+  const today = new Date().toISOString().split('T')[0];
+
+  // Provenance metadata block — readInstinctProjectScope (session-utils.js)
+  // reads scope.project from this fenced JSON to keyspace-migrate the file.
+  const provenance = {
+    candidate_id: id,
+    scope: candidate.scope,
+    source: 'curator',
+    activated_at: new Date().toISOString(),
+  };
+
+  const lines = [
+    '---',
+    `id: ${id}`,
+    `trigger: ${yamlQuote(trigger)}`,
+    `domain: ${domain}`,
+    'source: curator',
+    `confidence: ${confidence.toFixed(2)}`,
+    `extracted: ${today}`,
+    `last_confirmed: ${today}`,
+    'confirmations: 0',
+    'contradictions: 0',
+    '---',
+    '',
+    '```json',
+    JSON.stringify(provenance, null, 2),
+    '```',
+    '',
+    `# ${candidate.name || id}`,
+    '',
+  ];
+
+  if (candidate.summary) {
+    lines.push(`> **Summary:** ${candidate.summary}`, '');
+  }
+
+  lines.push('## Action', '', candidate.body || '', '');
+
+  if (candidate.trigger) {
+    lines.push('## Trigger', '', candidate.trigger, '');
+  }
+
+  return lines.join('\n');
+}
+
 function getActivationLockPath(arcforgeRoot) {
   return path.join(getActivationsDir(arcforgeRoot), 'activation.lock');
 }
@@ -371,9 +477,15 @@ function activate({
       }
     }
 
-    // Write active file atomically
-    atomicWriteFile(activePath, draftContent);
-    const activeContentHash = sha256Truncated(draftContent, 64);
+    // Write active file atomically. The draft is verbatim-verified above, but
+    // the active artifact is a TRANSFORM (ICL-4 / S5-1): the INACTIVE DRAFT
+    // banner is stripped and YAML `---` frontmatter (id/confidence/source/
+    // domain/trigger) is emitted so the injection/decay readers can parse it.
+    // active_content_hash records the on-disk active form; the audit trail keeps
+    // source_draft_content_hash (the draft) separately.
+    const activeContent = buildActiveInstinctContent(candidate);
+    atomicWriteFile(activePath, activeContent);
+    const activeContentHash = sha256Truncated(activeContent, 64);
 
     // Build active artifact record
     const activePathHash = sha256Truncated(activePath, 32);
@@ -631,6 +743,57 @@ function findLatestActivation(arcforgeRoot, candidateId) {
 }
 
 // ---------------------------------------------------------------------------
+// listActivatedCandidateIds — fold all ActivationRecords (latest wins)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan learning/activations, fold every record by candidate_id keeping the most
+ * recent (by created_at, file-name tiebreak), and return the set of candidate
+ * ids whose latest record is an `activate` (i.e. currently active, not since
+ * deactivated). This is the activation GATE for SessionStart injection (ICL-4):
+ * influence reaches the model only for candidates a reviewer explicitly
+ * activated and has not deactivated.
+ *
+ * @param {string} arcforgeRoot
+ * @returns {Set<string>} candidate ids whose latest action === 'activate'
+ */
+function listActivatedCandidateIds(arcforgeRoot) {
+  const activated = new Set();
+  const activationsDir = getActivationsDir(arcforgeRoot);
+  if (!fs.existsSync(activationsDir)) return activated;
+
+  let entries;
+  try {
+    entries = fs.readdirSync(activationsDir).sort();
+  } catch {
+    return activated;
+  }
+
+  // candidate_id -> { action, created_at }
+  const latestByCandidate = new Map();
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    try {
+      const record = JSON.parse(fs.readFileSync(path.join(activationsDir, entry), 'utf8'));
+      const id = record.candidate_id;
+      if (!id || (record.action !== 'activate' && record.action !== 'deactivate')) continue;
+      const prev = latestByCandidate.get(id);
+      // Sorted file iteration gives a stable tiebreak when created_at ties.
+      if (!prev || record.created_at >= prev.created_at) {
+        latestByCandidate.set(id, { action: record.action, created_at: record.created_at });
+      }
+    } catch {
+      // Corrupted record — skip
+    }
+  }
+
+  for (const [id, latest] of latestByCandidate) {
+    if (latest.action === 'activate') activated.add(id);
+  }
+  return activated;
+}
+
+// ---------------------------------------------------------------------------
 // findLatestMaterialization — scan candidate drafts dir for the latest record
 // ---------------------------------------------------------------------------
 
@@ -674,6 +837,9 @@ module.exports = {
   deactivate,
   defaultActivationPolicy,
   buildActiveInstinctPath,
+  buildActiveInstinctContent,
+  initialConfidenceFor,
   findLatestActivation,
+  listActivatedCandidateIds,
   findLatestMaterialization,
 };

--- a/scripts/lib/learning.js
+++ b/scripts/lib/learning.js
@@ -94,6 +94,23 @@ function isLearningEnabled({ scope = 'project', projectRoot = process.cwd(), hom
   return readScopeConfig({ scope, projectRoot, homeDir }).enabled === true;
 }
 
+/**
+ * Kill-switch for SessionStart injection of activated instincts (ICL-4).
+ *
+ * DEFAULT ON: injection happens unless `inject_activated_instincts` is set to
+ * the literal `false` in the global learning config. Any other value (absent,
+ * true, missing config file) leaves injection enabled. The switch is read from
+ * the global-scope config because activated-instinct injection is a HOME-global
+ * behavior, not project-scoped.
+ *
+ * @returns {boolean} true when injection is enabled
+ */
+function isInjectActivatedInstinctsEnabled({ homeDir } = {}) {
+  const config = readJsonFile(getLearningConfigPath({ scope: 'global', homeDir }), null);
+  if (config && config.inject_activated_instincts === false) return false;
+  return true;
+}
+
 function setLearningEnabled({
   scope = 'project',
   enabled,
@@ -733,6 +750,7 @@ module.exports = {
   getProjectId,
   inspectCandidate,
   isLearningEnabled,
+  isInjectActivatedInstinctsEnabled,
   listLearningInbox,
   listMaterializedDrafts,
   loadCandidates,

--- a/tests/scripts/inject-activated-instincts-contract.test.js
+++ b/tests/scripts/inject-activated-instincts-contract.test.js
@@ -1,0 +1,146 @@
+// tests/scripts/inject-activated-instincts-contract.test.js
+//
+// ICL-4 / S5-1 content contract.
+//
+// Proves the real chain materialize() → activate() → loadInstinctFiles() works
+// end to end: the draft→active TRANSFORM emits YAML frontmatter so the active
+// file is loadable with a NUMERIC confidence, and the instinct.js status reader
+// lists it. NO hand-written YAML fixtures — that would defeat the contract.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+
+let tmpDir;
+let homedirSpy;
+let materializeModule;
+let activateModule;
+
+function makeCandidate(overrides = {}) {
+  const candidateId = overrides.candidate_id || `cand_${crypto.randomBytes(4).toString('hex')}`;
+  return {
+    schema_version: 1,
+    candidate_id: candidateId,
+    artifact_type: 'instinct',
+    scope: { kind: 'project', project: 'contract-project', project_id: 'proj-hash' },
+    name: 'prefer-edit-over-bash',
+    summary: 'Prefer Edit before Bash.',
+    rationale: 'Observed.',
+    body: 'When editing files, prefer Edit then Bash.',
+    body_source: 'llm_curator',
+    domain: 'workflow',
+    trigger: 'when editing files',
+    evidence: [{ evidence_id: 'ev-1', evidence_type: 'observation', relevance: 'x', summary: 's' }],
+    evidence_quality: 'medium',
+    lifecycle: { status: 'approved', status_changed_at: '2026-05-21T00:00:00Z' },
+    created_at: '2026-05-21T00:00:00Z',
+    updated_at: '2026-05-21T00:00:00Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-icl4-contract-'));
+  homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tmpDir);
+  materializeModule = require('../../scripts/lib/learning-curator/materialize');
+  activateModule = require('../../scripts/lib/learning-curator/activate');
+});
+
+afterEach(() => {
+  homedirSpy.mockRestore();
+  jest.resetModules();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('ICL-4 content contract: materialize → activate → loadInstinctFiles', () => {
+  it('activated instinct loads with a numeric confidence and instinct.js lists it', () => {
+    const arcforgeRoot = path.join(tmpDir, '.arcforge');
+    const candidate = makeCandidate();
+
+    // 1. Materialize (writes the JSON-header INACTIVE DRAFT).
+    const matResult = materializeModule.materialize({
+      candidate,
+      sourceActionId: 'act_seed',
+      requestedArtifactType: 'instinct',
+      renderPolicy: materializeModule.defaultRenderPolicy(),
+      arcforgeRoot,
+    });
+    expect(matResult.ok).toBe(true);
+
+    // 2. Activate (the transform — strips banner, emits YAML frontmatter).
+    const actResult = activateModule.activate({
+      candidate: { ...candidate, lifecycle: { status: 'materialized', status_changed_at: 'x' } },
+      materializationRecord: matResult.record,
+      activationRequest: {
+        schema_version: 1,
+        request_id: 'req_x',
+        source_action_id: 'act_test',
+        action: 'activate',
+        candidate_id: candidate.candidate_id,
+        target: { target_kind: 'instinct' },
+        reviewer_ack: { confirmed_behavior_change: true, saw_target_summary: true },
+      },
+      activationPolicy: activateModule.defaultActivationPolicy(arcforgeRoot),
+      arcforgeRoot,
+    });
+    expect(actResult.ok).toBe(true);
+    const activePath = actResult.activeArtifacts[0].active_path;
+
+    // 3a. The active file must NOT carry the INACTIVE DRAFT banner.
+    const activeContent = fs.readFileSync(activePath, 'utf8');
+    expect(activeContent).not.toContain('INACTIVE DRAFT');
+    expect(activeContent.startsWith('---\n')).toBe(true);
+
+    // 3b. loadInstinctFiles (injection-side parser) must load it with a NUMBER.
+    const injectContext = require('../../hooks/session-tracker/inject-context');
+    const dir = path.dirname(activePath);
+    const loaded = injectContext.loadInstinctFiles(dir);
+    const match = loaded.find((i) => i.id === candidate.candidate_id);
+    expect(match).toBeDefined();
+    expect(typeof match.confidence).toBe('number');
+    expect(Number.isFinite(match.confidence)).toBe(true);
+
+    // 3c. instinct.js status reader must list it (visibility contract).
+    const instinctCli = require('../../skills/arc-observing/scripts/instinct');
+    const statusLoaded = instinctCli.loadInstincts(dir);
+    const statusMatch = statusLoaded.find((i) => i.id === candidate.candidate_id);
+    expect(statusMatch).toBeDefined();
+    expect(typeof statusMatch.frontmatter.confidence).toBe('number');
+  });
+
+  it('initial confidence reflects evidence_quality', () => {
+    const arcforgeRoot = path.join(tmpDir, '.arcforge');
+    const { initialConfidenceFor } = activateModule;
+    expect(initialConfidenceFor('high')).toBeGreaterThan(initialConfidenceFor('low'));
+    expect(initialConfidenceFor(undefined)).toBe(0.5);
+
+    // End-to-end: a 'high' candidate's active file carries a higher confidence.
+    const candidate = makeCandidate({ evidence_quality: 'high' });
+    const matResult = materializeModule.materialize({
+      candidate,
+      sourceActionId: 'act_seed',
+      requestedArtifactType: 'instinct',
+      renderPolicy: materializeModule.defaultRenderPolicy(),
+      arcforgeRoot,
+    });
+    const actResult = activateModule.activate({
+      candidate: { ...candidate, lifecycle: { status: 'materialized', status_changed_at: 'x' } },
+      materializationRecord: matResult.record,
+      activationRequest: {
+        schema_version: 1,
+        request_id: 'req_x',
+        source_action_id: 'act_test',
+        action: 'activate',
+        candidate_id: candidate.candidate_id,
+        target: { target_kind: 'instinct' },
+        reviewer_ack: { confirmed_behavior_change: true, saw_target_summary: true },
+      },
+      activationPolicy: activateModule.defaultActivationPolicy(arcforgeRoot),
+      arcforgeRoot,
+    });
+    const content = fs.readFileSync(actResult.activeArtifacts[0].active_path, 'utf8');
+    expect(content).toMatch(/confidence: 0\.60/);
+  });
+});

--- a/tests/scripts/learning-curator-activate.test.js
+++ b/tests/scripts/learning-curator-activate.test.js
@@ -70,6 +70,7 @@ let activate;
 let deactivate;
 let defaultActivationPolicy;
 let buildActiveInstinctPath;
+let listActivatedCandidateIds;
 
 beforeEach(() => {
   jest.resetModules();
@@ -82,6 +83,7 @@ beforeEach(() => {
     deactivate,
     defaultActivationPolicy,
     buildActiveInstinctPath,
+    listActivatedCandidateIds,
   } = require('../../scripts/lib/learning-curator/activate'));
 });
 
@@ -1054,5 +1056,54 @@ describe('deactivate — reviewer_ack enforcement', () => {
     });
 
     expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ICL-4: listActivatedCandidateIds folds ActivationRecords (latest wins)
+// ---------------------------------------------------------------------------
+
+describe('listActivatedCandidateIds — activation gate (ICL-4)', () => {
+  it('returns empty when no activations dir exists', () => {
+    const arcforgeRoot = path.join(tmpDir, '.arcforge');
+    expect(listActivatedCandidateIds(arcforgeRoot).size).toBe(0);
+  });
+
+  it('includes activated candidates and excludes deactivated (latest wins)', () => {
+    const a = runMaterialize();
+    const b = runMaterialize();
+
+    // Activate both.
+    activate({
+      candidate: a.candidate,
+      materializationRecord: a.materializationRecord,
+      activationRequest: makeActivationRequest({ candidate_id: a.candidate.candidate_id }),
+      activationPolicy: defaultActivationPolicy(a.arcforgeRoot),
+      arcforgeRoot: a.arcforgeRoot,
+    });
+    const actB = activate({
+      candidate: b.candidate,
+      materializationRecord: b.materializationRecord,
+      activationRequest: makeActivationRequest({ candidate_id: b.candidate.candidate_id }),
+      activationPolicy: defaultActivationPolicy(b.arcforgeRoot),
+      arcforgeRoot: b.arcforgeRoot,
+    });
+
+    // Deactivate b — its latest record must now win and exclude it.
+    deactivate({
+      candidate: { ...b.candidate, lifecycle: { status: 'activated', status_changed_at: 'x' } },
+      activationRecord: actB.record,
+      activationRequest: {
+        ...makeActivationRequest({ candidate_id: b.candidate.candidate_id }),
+        action: 'deactivate',
+        expected_candidate_status: 'activated',
+      },
+      activationPolicy: defaultActivationPolicy(b.arcforgeRoot),
+      arcforgeRoot: b.arcforgeRoot,
+    });
+
+    const set = listActivatedCandidateIds(a.arcforgeRoot);
+    expect(set.has(a.candidate.candidate_id)).toBe(true);
+    expect(set.has(b.candidate.candidate_id)).toBe(false);
   });
 });

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -11,8 +11,10 @@ const {
   appendCandidate,
   assertCanMaterialize,
   getCandidateQueuePath,
+  getLearningConfigPath,
   inspectCandidate,
   isLearningEnabled,
+  isInjectActivatedInstinctsEnabled,
   listLearningInbox,
   loadCandidates,
   materializeCandidate,
@@ -90,6 +92,33 @@ describe('learning subsystem MVP-1', () => {
     });
 
     expect(isLearningEnabled({ scope: 'project', projectRoot, homeDir })).toBe(false);
+  });
+
+  describe('inject_activated_instincts kill-switch (ICL-4)', () => {
+    function writeGlobalConfig(obj) {
+      const configPath = getLearningConfigPath({ scope: 'global', homeDir });
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify(obj), 'utf8');
+    }
+
+    it('defaults ON when no config exists', () => {
+      expect(isInjectActivatedInstinctsEnabled({ homeDir })).toBe(true);
+    });
+
+    it('defaults ON when the field is absent', () => {
+      writeGlobalConfig({ scope: 'global', enabled: true });
+      expect(isInjectActivatedInstinctsEnabled({ homeDir })).toBe(true);
+    });
+
+    it('stays ON when explicitly true', () => {
+      writeGlobalConfig({ scope: 'global', inject_activated_instincts: true });
+      expect(isInjectActivatedInstinctsEnabled({ homeDir })).toBe(true);
+    });
+
+    it('turns OFF only on explicit false', () => {
+      writeGlobalConfig({ scope: 'global', inject_activated_instincts: false });
+      expect(isInjectActivatedInstinctsEnabled({ homeDir })).toBe(false);
+    });
   });
 
   it('validates required candidate queue schema fields', () => {


### PR DESCRIPTION
Wave 3 (PR-3a). **The learning-loop payoff** — dashboard-activated instincts finally inject into SessionStart context (the blueprint's single highest-value fix; `loadAutoInstincts` was implemented but deliberately uncalled since the layer-8 design).

## What
- inject-context: lifecycle-filtered injection — gate is ACTIVATION (reviewer-approved on the dashboard, ActivationRecords folded by candidate_id latest-wins), NOT confidence; confidence only sorts + caps top-5; `inject_activated_instincts` kill-switch DEFAULT ON
- S5-1 prerequisite content contract: activate() now TRANSFORMS draft→active — strips the `<!-- INACTIVE DRAFT -->` banner, emits YAML frontmatter (id, confidence initial, source:curator, domain, trigger). Without this, materialize.js JSON-header drafts (no frontmatter/confidence) get filtered by `frontmatter.confidence===undefined` and EVERY real activated instinct silently fails to inject. record schema already stores source/active content hashes (audit-compatible)
- layer-8 doc revised as reviewed slice 2

## Acceptance (adversarially reviewed: approve)
- activate draft→active transform; 6 fixture cases (activated injects / deactivated no-inject / non-activated high-confidence excluded / …); E2E: SessionStart shows 'Active Behavioral Instincts' by default, gone when kill-switch off; npm test green
- Behavioral footprint → eval ICL-13 (Wave 6)

## ⚠️ Merge note
Co-edits inject-context.js with #icl-8-sdd-5 (require-block overlap; bodies disjoint). Merge that one first, then this rebases keeping both import blocks.