### PR TITLE
feat(cli): runDag worktree isolation + concurrency cap (AF-7)

### DIFF
--- a/scripts/cli/dag-commands.js
+++ b/scripts/cli/dag-commands.js
@@ -208,6 +208,12 @@ function runLoop(args, { projectRoot, specFlag }) {
     process.exit(1);
   }
 
+  const maxParallel = args.options['max-parallel'] ? parseInt(args.options['max-parallel'], 10) : 5;
+  if (args.options['max-parallel'] && (Number.isNaN(maxParallel) || maxParallel < 1)) {
+    console.error('Error: --max-parallel must be a positive integer');
+    process.exit(1);
+  }
+
   // --reset archives any existing state file before this run starts, so the
   // loop begins from a clean state. Deliberate pre-run action — never mid-run.
   if (args.flags.reset) {
@@ -221,6 +227,11 @@ function runLoop(args, { projectRoot, specFlag }) {
     maxRuns,
     maxCost,
     epic,
+    maxParallel,
+    // dag-mode worktrees start empty (no node_modules) — run the per-worktree
+    // installer by default so a downstream --verify-cmd has a usable tree.
+    // --no-project-setup opts out.
+    projectSetup: !args.flags['no-project-setup'],
     projectRoot,
     specId: resolved,
     taskTimeoutMs: taskTimeout ? taskTimeout * 1000 : null,

--- a/scripts/lib/cli-manifest.js
+++ b/scripts/lib/cli-manifest.js
@@ -129,6 +129,8 @@ const CLI_MANIFEST = {
       '--max-runs',
       '--max-cost',
       '--epic',
+      '--max-parallel',
+      '--no-project-setup',
       '--spec-id',
       '--task-timeout',
       '--permission-mode',

--- a/scripts/lib/loop-dag.js
+++ b/scripts/lib/loop-dag.js
@@ -1,0 +1,203 @@
+/**
+ * loop-dag.js - Worktree-isolated round execution for the DAG loop pattern.
+ *
+ * scripts/loop.js keeps the loop orchestration (round budget, stop
+ * conditions, finalize); this module owns one round of the isolated-worktree
+ * dag pattern: pick the ready/resumable epics, expand each to its own
+ * worktree, spawn a session in that worktree's cwd, and merge the successful
+ * ones back to base (aborting + blocking on conflict).
+ *
+ * `buildTaskPrompt` is injected by the caller rather than imported here — it
+ * lives in loop.js and is shared with the sequential pattern, so injecting it
+ * keeps the loop.js → loop-dag.js dependency one-directional.
+ */
+
+const { spawnSessionAsync } = require('./loop-session');
+const { saveLoopState, recordError } = require('./loop-state');
+const { getTimestamp } = require('./utils');
+
+/**
+ * Warn when the loop runs directly on main/master. Merge-back lands epic
+ * branches into the current branch, so an unattended dag loop on main pushes
+ * integrate commits straight onto the trunk — worth flagging once at start.
+ * @param {Coordinator} coord - Coordinator (provides _runGit at projectRoot)
+ */
+function warnIfBaseBranch(coord) {
+  const result = coord._runGit(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const branch = result.exitCode === 0 ? result.stdout.trim() : '';
+  if (branch === 'main' || branch === 'master') {
+    console.log(
+      `[loop] WARNING: running dag loop on "${branch}" — epic merge-back commits will land ` +
+        'directly on this branch. Consider running from a feature/integration branch.',
+    );
+  }
+}
+
+/**
+ * Select the epics to run as isolated worktree sessions this round.
+ * Resumable IN_PROGRESS epics that already have a worktree come first
+ * (interrupted overnight runs would otherwise be invisible — parallelTasks
+ * only returns PENDING), then ready PENDING epics fill the batch up to the
+ * concurrency cap.
+ * @param {Coordinator} coord - Coordinator instance
+ * @param {string|null} epicScope - Optional single-epic scope
+ * @param {number} maxParallel - Concurrency cap for the round
+ * @returns {{ epic: Object, resume: boolean }[]} Batch entries
+ */
+function selectRoundEpics(coord, epicScope, maxParallel) {
+  const inScope = (e) => epicScope === null || e.id === epicScope;
+  const resumable = coord.dag.epics
+    .filter((e) => e.status === 'in_progress' && e.worktree && inScope(e))
+    .map((epic) => ({ epic, resume: true }));
+  const ready = coord.parallelTasks(epicScope).map((epic) => ({ epic, resume: false }));
+  return [...resumable, ...ready].slice(0, maxParallel);
+}
+
+/**
+ * Expand a PENDING epic to its isolated worktree (with optional project
+ * setup). On any expand/setup failure the epic is blocked rather than
+ * aborting the whole loop, and the worktree (if created) is retained for
+ * inspection. Resumable epics already have a worktree — their path is just
+ * resolved.
+ * @param {Coordinator} coord - Coordinator instance
+ * @param {{ epic: Object, resume: boolean }} entry - Batch entry
+ * @param {Object} state - Loop state (for error recording)
+ * @param {boolean} projectSetup - Run the per-worktree installer
+ * @returns {string|null} Absolute worktree path, or null when blocked
+ */
+function prepareEpicWorktree(coord, entry, state, projectSetup) {
+  const { epic, resume } = entry;
+  if (resume) {
+    console.log(`[loop] Resuming in-progress epic ${epic.id} in existing worktree`);
+    return coord._resolveWorktreePath(epic.worktree);
+  }
+  try {
+    coord.expandWorktrees({ epicId: epic.id, projectSetup });
+    return coord._resolveWorktreePath(epic.id);
+  } catch (err) {
+    console.error(`[loop] Epic ${epic.id} worktree setup failed: ${err.message}`);
+    recordError(state, epic.id, err.message, 1);
+    state.failed_tasks.push(epic.id);
+    try {
+      coord.blockTask(epic.id, `Loop: worktree setup failed — ${err.message}`);
+    } catch (blockErr) {
+      console.error(`[loop] Warning: could not block task ${epic.id}: ${blockErr.message}`);
+    }
+    return null;
+  }
+}
+
+/**
+ * Integrate a successful epic session: merge its branch back to base,
+ * mark it complete, and clean up the worktree. A merge conflict triggers
+ * a WT-5 base abort (so the base never sits half-merged overnight) and
+ * blocks the epic; its worktree is retained for the human to resolve.
+ * @param {Coordinator} coord - Coordinator instance
+ * @param {Object} epic - Epic that completed
+ * @param {Object} state - Loop state
+ * @returns {boolean} Whether the epic was integrated successfully
+ */
+function integrateEpic(coord, epic, state) {
+  try {
+    coord.mergeEpics({ epicIds: [epic.id] });
+  } catch (mergeErr) {
+    console.error(`[loop] Merge conflict integrating ${epic.id}: ${mergeErr.message}`);
+    try {
+      coord.abortMerge();
+    } catch (abortErr) {
+      console.error(`[loop] Warning: merge --abort failed for ${epic.id}: ${abortErr.message}`);
+    }
+    recordError(state, epic.id, mergeErr.message, 1);
+    state.failed_tasks.push(epic.id);
+    try {
+      coord.blockTask(epic.id, `Loop: merge conflict — ${mergeErr.message}`);
+    } catch (blockErr) {
+      console.error(`[loop] Warning: could not block task ${epic.id}: ${blockErr.message}`);
+    }
+    return false;
+  }
+
+  try {
+    coord.completeTask(epic.id);
+    coord.cleanupWorktrees({ epicIds: [epic.id] });
+    state.completed_tasks.push(epic.id);
+    state.last_progress_at = getTimestamp();
+    console.log(`[loop] Epic ${epic.id} integrated and completed`);
+    return true;
+  } catch (err) {
+    console.error(`[loop] Warning: post-merge DAG update failed for ${epic.id}: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Run one isolated-worktree round: expand each batch epic, spawn a session
+ * in its worktree, and integrate the successful ones. Returns whether any
+ * epic made progress.
+ * @param {Coordinator} coord - Coordinator instance
+ * @param {{ epic: Object, resume: boolean }[]} batch - Round batch
+ * @param {Object} state - Loop state
+ * @param {Object} options - Loop options (projectRoot, projectSetup, spawn flags)
+ * @param {Function} buildTaskPrompt - (task, coord, projectRoot, workspaceRoot)=>string
+ * @returns {Promise<boolean>} Whether any epic was integrated this round
+ */
+async function runDagRound(coord, batch, state, options, buildTaskPrompt) {
+  const { projectRoot, projectSetup } = options;
+
+  // Phase 1: prepare worktrees (sequential — expand mutates the DAG under a
+  // lock and can't safely overlap). Blocked epics drop out of the spawn set.
+  const live = [];
+  for (const entry of batch) {
+    const worktreePath = prepareEpicWorktree(coord, entry, state, projectSetup);
+    if (worktreePath) live.push({ epic: entry.epic, worktreePath });
+  }
+  if (live.length === 0) {
+    saveLoopState(state, projectRoot);
+    return false;
+  }
+
+  // Phase 2: spawn each session in ITS OWN worktree cwd, concurrently. The
+  // prompt's Project Root points at the worktree so the headless session
+  // works there — never the base.
+  const spawnResults = await Promise.all(
+    live.map(({ epic, worktreePath }) =>
+      spawnSessionAsync(
+        buildTaskPrompt(epic, coord, projectRoot, worktreePath),
+        worktreePath,
+        options,
+      ),
+    ),
+  );
+
+  // Phase 3: integrate sequentially (DAG + git updates are not concurrent-safe).
+  let anySuccess = false;
+  for (let i = 0; i < live.length; i++) {
+    const { epic } = live[i];
+    const result = spawnResults[i];
+    state.total_cost += result.costUsd;
+
+    if (result.exitCode !== 0) {
+      console.log(`[loop] Epic ${epic.id} session failed`);
+      recordError(state, epic.id, result.stderr, 1);
+      state.failed_tasks.push(epic.id);
+      try {
+        coord.blockTask(epic.id, 'Loop: session failed in worktree batch');
+      } catch (err) {
+        console.error(`[loop] Warning: could not block task ${epic.id}: ${err.message}`);
+      }
+      continue;
+    }
+    if (integrateEpic(coord, epic, state)) anySuccess = true;
+  }
+
+  saveLoopState(state, projectRoot);
+  return anySuccess;
+}
+
+module.exports = {
+  warnIfBaseBranch,
+  selectRoundEpics,
+  prepareEpicWorktree,
+  integrateEpic,
+  runDagRound,
+};

--- a/scripts/loop.js
+++ b/scripts/loop.js
@@ -28,6 +28,7 @@ const {
   finalizeLoop,
 } = require('./lib/loop-state');
 const { isStalled, isRetryStorm, checkStopConditions, printSummary } = require('./lib/loop-state');
+const { warnIfBaseBranch, selectRoundEpics, runDagRound } = require('./lib/loop-dag');
 const { Feature } = require('./lib/models');
 const {
   detectPackageManager,
@@ -38,6 +39,9 @@ const {
 const { getTimestamp, readFileSafe } = require('./lib/utils');
 
 const MAX_RETRIES = 1;
+
+/** Default concurrency cap for the DAG pattern's per-round worktree batch. */
+const DEFAULT_MAX_PARALLEL = 5;
 
 /**
  * Parse loop CLI arguments
@@ -50,6 +54,8 @@ function parseLoopArgs(args) {
     maxRuns: 50,
     maxCost: null,
     epic: null,
+    maxParallel: DEFAULT_MAX_PARALLEL,
+    projectSetup: true,
     taskTimeoutMs: null,
     permissionMode: null,
     allowedTools: null,
@@ -71,6 +77,16 @@ function parseLoopArgs(args) {
           console.error('Error: --max-runs must be a positive integer');
           process.exit(1);
         }
+        break;
+      case '--max-parallel':
+        options.maxParallel = parseInt(args[++i], 10);
+        if (Number.isNaN(options.maxParallel) || options.maxParallel < 1) {
+          console.error('Error: --max-parallel must be a positive integer');
+          process.exit(1);
+        }
+        break;
+      case '--no-project-setup':
+        options.projectSetup = false;
         break;
       case '--max-cost':
         options.maxCost = parseFloat(args[++i]);
@@ -127,6 +143,8 @@ OPTIONS:
   --max-runs N               Maximum iterations (default: 50)
   --max-cost N               Maximum cost in dollars (default: unlimited)
   --epic <id>                Scope loop to a single epic (safe for parallel loops)
+  --max-parallel N           Max concurrent epics per round in dag mode (default: 5)
+  --no-project-setup         Skip per-worktree installer in dag mode (default: on)
   --task-timeout N           Per-session timeout in seconds (default: 600)
   --permission-mode <mode>   Pass --permission-mode through to spawned claude sessions
   --allowed-tools <tools>    Pass --allowed-tools through to spawned claude sessions
@@ -261,10 +279,15 @@ function buildVerificationLines(projectRoot) {
  * Uses coordinator.taskContext() for enriched task data.
  * @param {Object} task - Task from coordinator
  * @param {Coordinator} coord - Coordinator instance
- * @param {string} projectRoot - Project root directory
+ * @param {string} projectRoot - Project root directory (verification + spec
+ *   resolution are keyed here; the relative paths emitted resolve identically
+ *   from a worktree checkout of the same repo).
+ * @param {string} [workspaceRoot] - Actual session workspace for the
+ *   `## Project Root:` line. In dag mode this is the epic worktree so the
+ *   headless session works there (not the base). Defaults to projectRoot.
  * @returns {string} Prompt for the spawned session
  */
-function buildTaskPrompt(task, coord, projectRoot) {
+function buildTaskPrompt(task, coord, projectRoot, workspaceRoot) {
   const taskType = task instanceof Feature ? 'feature' : 'epic';
   const parts = [`# Task: ${task.name}`, ``, `## Task ID: ${task.id}`, `## Type: ${taskType}`];
 
@@ -300,7 +323,7 @@ function buildTaskPrompt(task, coord, projectRoot) {
     `Use TDD: write failing test first, then implement, then refactor.`,
     `Commit your changes with a conventional commit message.`,
     ``,
-    `## Project Root: ${projectRoot}`,
+    `## Project Root: ${workspaceRoot || projectRoot}`,
   );
 
   const verification = buildVerificationLines(projectRoot);
@@ -443,11 +466,12 @@ function runSequential(options) {
 
 /**
  * Run DAG-parallel loop pattern.
- * Independent tasks are spawned concurrently via spawnSessionAsync.
+ * Each round runs every ready (and resumable in-progress) epic as an
+ * isolated worktree session, then merges the successful ones back to base.
  * @param {Object} options - Loop options
  */
 async function runDag(options) {
-  const { projectRoot, maxRuns, maxCost, epic } = options;
+  const { projectRoot, maxRuns, maxCost, epic, maxParallel } = options;
   const state = loadLoopState(projectRoot);
   beginRun(state, { pattern: 'dag', maxRuns, maxCost });
   const epicScope = resolveEpicScope(epic, projectRoot);
@@ -465,60 +489,24 @@ async function runDag(options) {
 
     const coord = tryCreateCoordinator(projectRoot, state, options.specId);
     if (!coord) break;
+    if (state.iteration === 1) warnIfBaseBranch(coord);
 
-    // Try parallel tasks first
-    const parallelEpics = coord.parallelTasks(epicScope);
-    if (parallelEpics.length > 1) {
-      console.log(`[loop] Found ${parallelEpics.length} parallel epics — running concurrently`);
-
-      // Spawn all sessions concurrently
-      const taskEntries = parallelEpics.map((epicItem) => ({
-        epic: epicItem,
-        prompt: buildTaskPrompt(epicItem, coord, projectRoot),
-      }));
-      const spawnResults = await Promise.all(
-        taskEntries.map((entry) => spawnSessionAsync(entry.prompt, projectRoot, options)),
-      );
-
-      // Process results sequentially (state + DAG updates are not concurrent-safe)
-      let anySuccess = false;
-      for (let i = 0; i < parallelEpics.length; i++) {
-        const epicItem = parallelEpics[i];
-        const result = spawnResults[i];
-        state.total_cost += result.costUsd;
-
-        if (result.exitCode !== 0) {
-          console.log(`[loop] Task ${epicItem.id} failed`);
-          recordError(state, epicItem.id, result.stderr, 1);
-          state.failed_tasks.push(epicItem.id);
-          try {
-            coord.blockTask(epicItem.id, 'Loop: failed in parallel batch');
-          } catch (err) {
-            console.error(`[loop] Warning: could not block task ${epicItem.id}: ${err.message}`);
-          }
-        } else {
-          try {
-            coord.completeTask(epicItem.id);
-            state.completed_tasks.push(epicItem.id);
-            state.last_progress_at = getTimestamp();
-            console.log(`[loop] Task ${epicItem.id} completed successfully`);
-            anySuccess = true;
-          } catch (err) {
-            console.error(`[loop] Warning: DAG update failed for ${epicItem.id}: ${err.message}`);
-          }
-        }
-      }
-      saveLoopState(state, projectRoot);
-
+    // Every round with ≥1 ready/resumable epic takes the isolated worktree
+    // path — chain and diamond-join rounds with a single ready epic included.
+    const batch = selectRoundEpics(coord, epicScope, maxParallel);
+    if (batch.length > 0) {
+      console.log(`[loop] Running ${batch.length} epic(s) in isolated worktrees this round`);
+      const anySuccess = await runDagRound(coord, batch, state, options, buildTaskPrompt);
       if (!anySuccess) {
-        console.log('[loop] No parallel tasks succeeded');
+        console.log('[loop] No epics made progress this round');
         state.status = 'failed';
         break;
       }
       continue;
     }
 
-    // Fall back to next task
+    // No isolated epic work — fall back to feature-level next task (legacy
+    // non-isolated path for in-progress epics worked feature by feature).
     const task = coord.nextTask(epicScope);
     if (!task) {
       console.log('[loop] All tasks complete!');

--- a/tests/scripts/loop-rundag.test.js
+++ b/tests/scripts/loop-rundag.test.js
@@ -1,0 +1,353 @@
+/**
+ * loop-rundag.test.js — AF-7 worktree isolation for the DAG loop pattern.
+ *
+ * runDag must run every ready (and resumable in-progress) epic in its own git
+ * worktree: spawn cwd is the canonical worktree root (never the base
+ * projectRoot), the per-worktree installer runs, successful sessions merge back
+ * to base and clean up, and a single ready epic per round (chain/diamond) still
+ * takes the isolated path. A stub `claude` on PATH records its cwd and makes a
+ * commit so merge-back has content; _runSubprocess is spied so the installer
+ * seam is asserted without a real `npm install`.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const { Coordinator } = require('../../scripts/lib/coordinator');
+const {
+  getWorktreePath,
+  getWorktreeRoot,
+  parseWorktreePath,
+} = require('../../scripts/lib/worktree-paths');
+const { runDag } = require('../../scripts/loop');
+const { stringifyDagYaml } = require('../../scripts/lib/yaml-parser');
+const { TaskStatus } = require('../../scripts/lib/models');
+
+const SPEC_ID = 'rundag-spec';
+
+function runGit(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe' });
+}
+
+/** Initialise a git repo with a per-spec dag.yaml and a node project. */
+function setupRepo(epics) {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'rundag-')));
+  runGit(['init', '-q', '-b', 'work'], root);
+  runGit(['config', 'user.email', 'test@example.com'], root);
+  runGit(['config', 'user.name', 'Test User'], root);
+  // A node project so getDefaultInstallCommand resolves (installer seam fires).
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'fixture', version: '1.0.0', scripts: { test: 'jest' } }),
+  );
+  fs.writeFileSync(path.join(root, 'package-lock.json'), '{}');
+  fs.writeFileSync(path.join(root, 'README.md'), 'base\n');
+
+  const dagDir = path.join(root, 'specs', SPEC_ID);
+  fs.mkdirSync(dagDir, { recursive: true });
+  fs.writeFileSync(path.join(dagDir, 'dag.yaml'), stringifyDagYaml({ epics, blocked: [] }));
+
+  runGit(['add', '-A'], root);
+  runGit(['commit', '-q', '-m', 'init'], root);
+  return root;
+}
+
+function epic(id, overrides = {}) {
+  return {
+    id,
+    name: `Epic ${id}`,
+    spec_path: `specs/${SPEC_ID}/epics/${id}/epic.md`,
+    status: TaskStatus.PENDING,
+    worktree: null,
+    depends_on: [],
+    features: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Install a fake `claude` on PATH that: records its cwd to CLAUDE_CWD_LOG,
+ * makes a commit in that cwd (so the epic branch diverges and merge-back yields
+ * a real integrate commit), and emits valid session JSON. exitCode is taken
+ * from CLAUDE_EXIT (default 0); a non-zero value simulates a failed session.
+ */
+function installFakeClaude(binDir, cwdLog) {
+  fs.mkdirSync(binDir, { recursive: true });
+  const claudePath = path.join(binDir, 'claude');
+  const script = `#!/usr/bin/env bash
+set -e
+echo "$PWD" >> "${cwdLog}"
+if [ "\${CLAUDE_EXIT:-0}" = "0" ]; then
+  # Make a unique commit so the epic branch has content to merge back.
+  marker="work-$(basename "$PWD").txt"
+  echo "done in $PWD" > "$marker"
+  git add "$marker" >/dev/null 2>&1 || true
+  git commit -q -m "feat: session work" >/dev/null 2>&1 || true
+fi
+echo '{"total_cost_usd":0,"result":"done"}'
+exit "\${CLAUDE_EXIT:-0}"
+`;
+  fs.writeFileSync(claudePath, script, { mode: 0o755 });
+  return claudePath;
+}
+
+describe('runDag worktree isolation (AF-7)', () => {
+  const originalHome = process.env.HOME;
+  const originalPath = process.env.PATH;
+  const originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  const originalExit = process.env.CLAUDE_EXIT;
+  let testHome;
+  let binDir;
+  let cwdLog;
+  let root;
+  let subprocessCalls;
+
+  beforeEach(() => {
+    const realTmp = fs.realpathSync(os.tmpdir());
+    testHome = fs.mkdtempSync(path.join(realTmp, 'rundag-home-'));
+    process.env.HOME = testHome;
+    jest.spyOn(os, 'homedir').mockReturnValue(testHome);
+
+    binDir = fs.mkdtempSync(path.join(realTmp, 'rundag-bin-'));
+    cwdLog = path.join(binDir, 'cwd.log');
+    installFakeClaude(binDir, cwdLog);
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath}`;
+
+    // Spy the installer seam: record per-worktree install invocations and
+    // short-circuit the real `npm install` so the test stays fast/offline.
+    subprocessCalls = [];
+    jest.spyOn(Coordinator.prototype, '_runSubprocess').mockImplementation((workdir, command) => {
+      subprocessCalls.push({ workdir, command });
+      return { exitCode: 0 };
+    });
+
+    // Quiet the loop's heavy stdout while keeping assertions on state/git.
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    try {
+      const list = runGit(['worktree', 'list', '--porcelain'], root);
+      for (const line of list.split('\n')) {
+        if (!line.startsWith('worktree ')) continue;
+        const p = line.slice(9);
+        if (p !== root && fs.existsSync(p)) fs.rmSync(p, { recursive: true, force: true });
+      }
+    } catch {
+      /* root may not exist */
+    }
+    for (const dir of [root, testHome, binDir]) {
+      if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    }
+    process.env.HOME = originalHome;
+    process.env.PATH = originalPath;
+    if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+    if (originalExit === undefined) delete process.env.CLAUDE_EXIT;
+    else process.env.CLAUDE_EXIT = originalExit;
+  });
+
+  // The fake claude logs its $PWD verbatim. Those worktrees may already be
+  // cleaned up after a successful merge, so do NOT realpathSync the logged
+  // paths — testHome is realpath'd and getWorktreeRoot uses the mocked
+  // homedir, so the logged paths are already canonical and comparable as-is.
+  function loggedCwds() {
+    if (!fs.existsSync(cwdLog)) return [];
+    return fs
+      .readFileSync(cwdLog, 'utf8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  }
+
+  function baseOptions(overrides = {}) {
+    return {
+      pattern: 'dag',
+      maxRuns: 10,
+      maxCost: null,
+      epic: null,
+      maxParallel: 5,
+      projectSetup: true,
+      projectRoot: root,
+      specId: SPEC_ID,
+      taskTimeoutMs: 60000,
+      permissionMode: null,
+      allowedTools: null,
+      ...overrides,
+    };
+  }
+
+  test('spawns every session in its canonical worktree root, never the base', async () => {
+    root = setupRepo([epic('epic-a'), epic('epic-b')]);
+    await runDag(baseOptions());
+
+    const cwds = loggedCwds();
+    expect(cwds.length).toBe(2);
+    const expected = ['epic-a', 'epic-b'].map((id) => getWorktreePath(root, SPEC_ID, id)).sort();
+    expect(cwds.sort()).toEqual(expected);
+    // None of the sessions ran in the base projectRoot.
+    expect(cwds).not.toContain(root);
+    // Every spawn cwd is under the canonical worktree root and parses as managed.
+    const wtRoot = getWorktreeRoot();
+    for (const c of cwds) {
+      expect(c.startsWith(wtRoot)).toBe(true);
+      expect(parseWorktreePath(c)).not.toBeNull();
+    }
+  });
+
+  test('runs the per-worktree installer for each expanded epic', async () => {
+    root = setupRepo([epic('epic-a'), epic('epic-b')]);
+    await runDag(baseOptions());
+
+    const installWorktrees = subprocessCalls.map((c) => c.workdir).sort();
+    const expected = ['epic-a', 'epic-b'].map((id) => getWorktreePath(root, SPEC_ID, id)).sort();
+    expect(installWorktrees).toEqual(expected);
+    // The recorded command is the detected installer (npm for this fixture).
+    expect(subprocessCalls[0].command).toEqual(['npm', 'install']);
+  });
+
+  test('--no-project-setup skips the installer', async () => {
+    root = setupRepo([epic('epic-a')]);
+    await runDag(baseOptions({ projectSetup: false }));
+    expect(subprocessCalls.length).toBe(0);
+  });
+
+  test('merges successful epics back to base and marks them completed + cleaned', async () => {
+    root = setupRepo([epic('epic-a'), epic('epic-b')]);
+    await runDag(baseOptions());
+
+    const baseLog = runGit(['log', '--oneline'], root);
+    expect(baseLog).toContain('integrate epic-a');
+    expect(baseLog).toContain('integrate epic-b');
+
+    const status = new Coordinator(root, SPEC_ID).status();
+    for (const e of status.epics) {
+      expect(e.status).toBe(TaskStatus.COMPLETED);
+      // Worktree cleaned up after a successful merge.
+      expect(e.worktree).toBeNull();
+    }
+    expect(fs.existsSync(getWorktreePath(root, SPEC_ID, 'epic-a'))).toBe(false);
+  });
+
+  test('honors --max-parallel: 7 ready epics with cap 5 → 5 then 2', async () => {
+    const epics = Array.from({ length: 7 }, (_, i) => epic(`epic-${i + 1}`));
+    root = setupRepo(epics);
+    await runDag(baseOptions({ maxParallel: 5 }));
+
+    // 7 total spawns across two rounds; round 1 caps at 5 (the first 5
+    // append-ordered cwd-log entries are 5 distinct worktrees), round 2 = 2.
+    const cwds = loggedCwds();
+    expect(cwds.length).toBe(7);
+    expect(new Set(cwds.slice(0, 5)).size).toBe(5);
+    const status = new Coordinator(root, SPEC_ID).status();
+    expect(status.epics.every((e) => e.status === TaskStatus.COMPLETED)).toBe(true);
+  });
+
+  test('--max-parallel 2 caps each round at two epics', async () => {
+    root = setupRepo([epic('epic-1'), epic('epic-2'), epic('epic-3')]);
+    await runDag(baseOptions({ maxParallel: 2 }));
+
+    // Round 1 spawns exactly 2 distinct worktrees, round 2 spawns the last 1.
+    const cwds = loggedCwds();
+    expect(cwds.length).toBe(3);
+    expect(new Set(cwds.slice(0, 2)).size).toBe(2);
+    const status = new Coordinator(root, SPEC_ID).status();
+    expect(status.epics.every((e) => e.status === TaskStatus.COMPLETED)).toBe(true);
+  });
+
+  test('chain DAG (one ready epic per round) still takes the isolated path', async () => {
+    root = setupRepo([
+      epic('epic-1'),
+      epic('epic-2', { depends_on: ['epic-1'] }),
+      epic('epic-3', { depends_on: ['epic-2'] }),
+    ]);
+    await runDag(baseOptions());
+
+    // Each link ran in its own worktree (never the base) and merged back.
+    const cwds = loggedCwds();
+    expect(cwds.length).toBe(3);
+    expect(cwds).not.toContain(root);
+    const baseLog = runGit(['log', '--oneline'], root);
+    expect(baseLog).toContain('integrate epic-1');
+    expect(baseLog).toContain('integrate epic-2');
+    expect(baseLog).toContain('integrate epic-3');
+  });
+
+  test('resumes an interrupted in-progress epic that already has a worktree', async () => {
+    root = setupRepo([epic('epic-a')]);
+    // Simulate an interrupted overnight run: expand created the worktree and
+    // flipped the epic to in_progress, but the session never completed.
+    new Coordinator(root, SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+    const wtPath = getWorktreePath(root, SPEC_ID, 'epic-a');
+
+    await runDag(baseOptions());
+
+    // The resume respawned the session in the EXISTING worktree (not a no-op
+    // "All tasks complete"), and integrated it.
+    expect(loggedCwds()).toContain(wtPath);
+    const status = new Coordinator(root, SPEC_ID).status();
+    expect(status.epics[0].status).toBe(TaskStatus.COMPLETED);
+  });
+
+  test('a merge conflict aborts the base merge and blocks the epic, base stays clean', async () => {
+    root = setupRepo([epic('epic-a')]);
+    // Build a real divergence on shared.txt: expand epic-a to its worktree,
+    // commit one side on the epic branch and the conflicting side on base,
+    // and leave the epic in_progress so runDag RESUMES it (the resumed session
+    // adds another commit, then merge-back conflicts on shared.txt).
+    const wtPath = getWorktreePath(root, SPEC_ID, 'epic-a');
+    new Coordinator(root, SPEC_ID).expandWorktrees({ epicId: 'epic-a' });
+    fs.writeFileSync(path.join(wtPath, 'shared.txt'), 'epic side\n');
+    runGit(['add', 'shared.txt'], wtPath);
+    runGit(['commit', '-q', '-m', 'feat: epic edits shared'], wtPath);
+    fs.writeFileSync(path.join(root, 'shared.txt'), 'base side\n');
+    runGit(['add', 'shared.txt'], root);
+    runGit(['commit', '-q', '-m', 'chore: base edits shared'], root);
+
+    await runDag(baseOptions());
+
+    // Base is clean (merge was aborted — no half-merged MERGE_HEAD).
+    const gitDir = runGit(['rev-parse', '--git-dir'], root).trim();
+    expect(fs.existsSync(path.join(root, gitDir, 'MERGE_HEAD'))).toBe(false);
+    expect(runGit(['status', '--porcelain', 'shared.txt'], root).trim()).toBe('');
+    // Epic is blocked, not completed; worktree retained for resolution.
+    const status = new Coordinator(root, SPEC_ID).status({ blockedOnly: false });
+    expect(status.epics[0].status).toBe(TaskStatus.BLOCKED);
+    expect(status.blocked.some((b) => b.task_id === 'epic-a')).toBe(true);
+    expect(fs.existsSync(wtPath)).toBe(true);
+  });
+
+  test('a failed session blocks the epic and retains its worktree', async () => {
+    root = setupRepo([epic('epic-a')]);
+    process.env.CLAUDE_EXIT = '1';
+
+    await runDag(baseOptions());
+
+    const status = new Coordinator(root, SPEC_ID).status();
+    expect(status.epics[0].status).toBe(TaskStatus.BLOCKED);
+    // Worktree retained (failures are not cleaned up).
+    expect(fs.existsSync(getWorktreePath(root, SPEC_ID, 'epic-a'))).toBe(true);
+  });
+
+  test('a per-worktree installer failure blocks that epic, not the whole loop', async () => {
+    root = setupRepo([epic('epic-a'), epic('epic-b')]);
+    // epic-a's installer fails; expandWorktrees throws — runDag must catch it,
+    // block epic-a, and still run + integrate epic-b (no loop-level throw).
+    Coordinator.prototype._runSubprocess.mockImplementation((workdir) => {
+      subprocessCalls.push({ workdir });
+      return workdir.endsWith('epic-a') ? { exitCode: 1 } : { exitCode: 0 };
+    });
+
+    await expect(runDag(baseOptions())).resolves.toBeUndefined();
+
+    const status = new Coordinator(root, SPEC_ID).status({ blockedOnly: false });
+    const byId = Object.fromEntries(status.epics.map((e) => [e.id, e.status]));
+    expect(byId['epic-a']).toBe(TaskStatus.BLOCKED);
+    expect(byId['epic-b']).toBe(TaskStatus.COMPLETED);
+    expect(status.blocked.some((b) => /setup failed/.test(b.reason))).toBe(true);
+  });
+});


### PR DESCRIPTION
Wave 3 (PR-3c). **The largest single unlock** — overnight `loop --pattern dag` becomes safe and fuses goals 1/6/7 (worktree isolation + autopilot + fan-out into one model).

## What
- runDag isolates EVERY round: per-epic expandWorktrees, spawn cwd=worktree, completeTask+mergeEpics+cleanup on success (failures retained), conflict → WT-5 base abortMerge + blockTask + continue round; `--max-parallel` default 5
- S4-1: removed the `parallelEpics.length>1` gate (chain/diamond rounds no longer leak to bare base) + IN_PROGRESS resume semantics (respawn worktree'd IN_PROGRESS epics — interrupted overnight runs are no longer invisible / falsely 'All complete')
- S4-3/S6-2: expand with projectSetup:true (`--no-project-setup` escape) so fresh worktrees have node_modules for AF-8's --verify-cmd; S4-2: worktree path → buildTaskPrompt `## Project Root:`; S7-1: spawn via AF-10 env helper (ARCFORGE_SPAWNED + ARCFORGE_MODE scrub)
- Round-execution helpers extracted to a NEW scripts/lib/loop-dag.js to keep loop.js under the 700 hard cap (CORE-2-style decomposition)

## Acceptance (adversarially reviewed: approve)
- loop-rundag.test.js: stub-claude cwd always canonical worktree root (never projectRoot); 7-ready cap-5 → 5+2; chain-DAG per-round worktree cwd + merge commits; interrupted-run resume; merge-back integrate commits; conflict → blocked + clean base porcelain; sequential loop.test.js unchanged & green; npm test all 5 runners. loop-state.js clean vs SDD-5 (merge-tree verified).