### PR TITLE
fix(hooks): seam migration — dual-direction worktree nudge, generic docs, platform INSTALL (WT-7)

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -5,12 +5,22 @@ Enable agentic skills in Codex via native skill discovery. One clone, one symlin
 ## Prerequisites
 
 - Git
+- Node.js — the arcforge CLI (`scripts/cli.js`) runs on Node; skills that
+  call it need it on your `PATH`
 
 ## Installation
 
 1. **Clone arcforge:**
    ```bash
    git clone https://github.com/GregoryHo/arcforge ~/.agents/arcforge
+   ```
+
+   This is the **standard clone location**, and skills resolve the CLI
+   through `ARCFORGE_ROOT`. Codex has no SessionStart hook to export it, so
+   skills fall back to `~/.agents/arcforge` automatically. If you clone
+   somewhere else, export it in your shell profile so the CLI resolves:
+   ```bash
+   export ARCFORGE_ROOT=/your/arcforge/checkout
    ```
 
 2. **Create the skills directory:**

--- a/.gemini/INSTALL.md
+++ b/.gemini/INSTALL.md
@@ -5,12 +5,23 @@ Enable agentic skills in Gemini CLI via native skill discovery.
 ## Prerequisites
 
 - Git
+- Node.js — the arcforge CLI (`scripts/cli.js`) runs on Node; skills that
+  call it need it on your `PATH`
 
 ## Installation
 
 1. **Clone arcforge:**
    ```bash
    git clone https://github.com/GregoryHo/arcforge ~/.agents/arcforge
+   ```
+
+   This is the **standard clone location**, and skills resolve the CLI
+   through `ARCFORGE_ROOT`. Gemini CLI has no SessionStart hook to export
+   it, so skills fall back to `~/.agents/arcforge` automatically. If you
+   clone somewhere else, export it in your shell profile so the CLI
+   resolves:
+   ```bash
+   export ARCFORGE_ROOT=/your/arcforge/checkout
    ```
 
 2. **Symlink each skill into the Gemini skills directory:**

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -6,12 +6,22 @@ Enable agentic skills in OpenCode via native skill discovery and system transfor
 
 - [OpenCode.ai](https://opencode.ai) installed
 - Git
+- Node.js — the arcforge CLI (`scripts/cli.js`) runs on Node; skills that
+  call it need it on your `PATH`
 
 ## Installation
 
 1. **Clone arcforge:**
    ```bash
    git clone https://github.com/GregoryHo/arcforge ~/.agents/arcforge
+   ```
+
+   This is the **standard clone location**, and skills resolve the CLI
+   through `ARCFORGE_ROOT`. OpenCode has no SessionStart hook to export it,
+   so skills fall back to `~/.agents/arcforge` automatically. If you clone
+   somewhere else, export it in your shell profile so the CLI resolves:
+   ```bash
+   export ARCFORGE_ROOT=/your/arcforge/checkout
    ```
 
 2. **Symlink skills:**

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ All 33 skills, each listed once. Workflow skills hand off sequentially, discipli
 - **arc-agent-driven** - Automated execution with subagent per task and two-stage review
 - **arc-implementing** - Orchestrate large project implementation in a worktree
 - **arc-coordinating** - Worktree management for multi-epic projects
-- **arc-using-worktrees** - Create isolated workspace for epic development
+- **arc-using-worktrees** - Isolated git worktree for any repo: a branch, experiment, or review checkout via the generic CLI; epic work auto-escalates to the coordinator
 - **arc-dispatching-parallel** - Dispatch multiple agents for independent tasks
 - **arc-dispatching-teammates** - Lead-present multi-epic parallelism via agent teammates
 - **arc-looping** - Autonomous cross-session loop execution

--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -363,24 +363,32 @@ The complete catalog still uses functional categories for lookup:
 
 ### arc-using-worktrees
 
-**Purpose:** Thin wrapper around `arcforge expand --epic <id>` for creating
-an isolated worktree for a single epic. Delegates all path derivation,
-marker writing, and project setup to `scripts/lib/coordinator.js`.
+**Purpose:** Isolated git worktrees for **any** repo, in two tiers. A
+**generic tier** (`arcforge worktree add|list|remove`) handles a parallel
+branch, an experiment, or a review checkout in any project; a **composition
+tier** hands single-epic work to the coordinator. Both derive the canonical
+path at runtime — you never invent one.
 
-**When to use:** When creating isolated workspace for epic development.
+**When to use:** When work needs an isolated workspace — a parallel branch,
+an experiment, a review checkout, or scoping to one epic — in any git repo.
 
-**Key workflow:**
-1. Identify the epic id from `dag.yaml` or the user's request
-2. Invoke `node "${SKILL_ROOT}/scripts/coordinator.js" expand --epic <id> --project-setup`
-3. Read the absolute worktree path from the command's JSON output
-4. Report it verbatim to the user — do not reconstruct or hardcode
+**Key workflow (top-down, first match wins):**
+1. `.arcforge-epic` exists in cwd → already inside an epic worktree; never
+   nest. Work → arc-implementing; integration → arc-finishing.
+2. `specs/<id>/dag.yaml` exists and the work matches an epic id → composition
+   tier: escalate to the coordinator (`arcforge expand --epic <id>`).
+3. Anything else (a branch, experiment, or review checkout) → generic tier:
+   `arcforge worktree add <name>`, then read the absolute `path` from the
+   JSON output and `cd` there.
 
 **Artifacts:**
-- Output: worktree at the canonical path
-  (`~/.arcforge/worktrees/<project>-<hash>-<epic>/`), `.arcforge-epic` marker
-  authored by the coordinator, `dag.yaml` epic status updated
+- Generic: a managed worktree at `~/.arcforge/worktrees/<project>-<hash>-<slug>/`
+  with **no** marker (`kind: generic`)
+- Epic (composition tier): worktree + `.arcforge-epic` marker authored by the
+  coordinator, `dag.yaml` epic status updated
 
-For the full derivation rules see
+For the full derivation rules — including the generic null-spec path, kind
+annotation, and the sync/merge invisibility guarantee — see
 [`docs/guide/worktree-workflow.md`](worktree-workflow.md) and the Worktree
 Rule in `skills/arc-using/SKILL.md`.
 

--- a/docs/guide/worktree-workflow.md
+++ b/docs/guide/worktree-workflow.md
@@ -91,6 +91,92 @@ which delegates to `git worktree remove <absolute-path>`.
 - After cleanup the epic's `worktree` field in `specs/<spec-id>/dag.yaml`
   is cleared to `null`.
 
+## Generic (non-epic) worktrees
+
+Not every worktree is an epic. A throwaway branch, an experiment, or a
+review checkout needs the same isolation without the DAG machinery. The
+`arcforge worktree add|list|remove` subcommands (engine:
+`scripts/lib/worktree-generic.js`) manage these **generic** worktrees, and
+they live beside epic worktrees under `~/.arcforge/worktrees/` with no path
+collision.
+
+### Null-spec path derivation
+
+A generic worktree reuses the canonical derivation with **no spec id** —
+`getWorktreePath(projectRoot, /* specId = */ null, slug)`, the documented
+legacy-null hash branch. The directory name is
+`<project>-<hash6>-<slug>/`, where `<slug>` is the sanitized worktree name
+and `<hash6>` folds only the project path (epic hashes additionally fold
+the spec id in, so the two namespaces never collide). As always, **the
+path is derived, never hardcoded** — read it from the CLI's JSON output.
+
+```bash
+arcforge worktree add my-experiment --json
+# { "name": "my-experiment", "slug": "my-experiment", "branch": "my-experiment",
+#   "branch_created": true,
+#   "path": "/Users/alice/.arcforge/worktrees/proj-3f2a91-my-experiment" }
+```
+
+`add` defaults the branch to the worktree name; an existing branch is
+checked out as-is, a missing one is created from `--from` (default: base
+HEAD). `--setup` auto-detects and runs the project installer in the fresh
+worktree (adds a `setup_command` field to the JSON).
+
+### Kind annotation
+
+`arcforge worktree list --json` enumerates every worktree git knows about
+and tags each with a `kind`:
+
+```bash
+arcforge worktree list --json
+# { "count": N, "worktrees": [
+#   { "path": "...", "branch": "...", "head": "...", "kind": "base" },
+#   { "path": "...", "branch": "...", "head": "...", "kind": "epic",
+#     "epic": "epic-001", "spec_id": "spec-x" },
+#   { "path": "...", "branch": "...", "head": "...", "kind": "generic" } ] }
+```
+
+| `kind` | Meaning |
+|--------|---------|
+| `base` | The main checkout — first non-managed entry |
+| `epic` | A managed path carrying an `.arcforge-epic` marker (`epic`/`spec_id` attached) |
+| `generic` | A managed path with **no** marker — created by `arcforge worktree add` |
+| `external` | Any other non-managed entry (e.g. a user-placed raw-git worktree) |
+
+The discrimination needs **no new marker file**: `kind` is derived from
+`parseWorktreePath × hasArcforgeMarker`. A generic worktree is, by
+definition, the managed-but-markerless case.
+
+### Sync / merge invisibility guarantee
+
+Because a generic worktree has no `.arcforge-epic` marker, the
+coordinator's DAG machinery cannot see it and never touches it:
+
+- `arc-coordinating sync` keys off marker files, so a generic worktree is
+  skipped — its progress is never carried into any `dag.yaml`.
+- `_findBaseWorktree` / `arcforge merge` walk the worktree list and reason
+  only over base + epic entries; the generic one is inert to them.
+- `arc-guard`'s worktree rules self-gate on the marker, so raw `git merge`
+  or a loop launch inside a generic worktree is **not** blocked — it is the
+  user's own business, not coordinator territory.
+
+This is the build-time seam fix: a generic worktree is invisible to epic
+tooling by construction, not by special-casing.
+
+### Finishing and removing a generic worktree
+
+A generic worktree is finished through the **non-epic path** of
+`arc-finishing` (its Step 0 marker check routes there when no
+`.arcforge-epic` is present). Cleanup is `arcforge worktree remove <name>`,
+which refuses to touch an epic (marker-bearing) worktree — those belong to
+`arcforge cleanup` — refuses a non-managed path, and refuses a dirty tree
+unless `--force` is given:
+
+```bash
+arcforge worktree remove my-experiment --json
+# { "removed": true, "path": "/Users/alice/.arcforge/worktrees/proj-3f2a91-my-experiment" }
+```
+
 ## 概念總覽 / Concept Overview
 
 ```

--- a/hooks/__tests__/arc-guard.test.js
+++ b/hooks/__tests__/arc-guard.test.js
@@ -50,6 +50,24 @@ describe('arc-guard evaluate', () => {
     assert.strictEqual(reason, null);
   });
 
+  // WT-7 seam regression: a GENERIC (non-epic) worktree created by `arcforge
+  // worktree add` is a managed path with NO `.arcforge-epic` marker. arc-guard
+  // self-gates on the marker, so the generic worktree must hit the no-op
+  // invariant — raw `git merge` and a loop launch there are the user's own
+  // business, not coordinator territory. Zero code change in arc-guard; this
+  // pins that the new worktree kind stays untouched.
+  it('no-op invariant: generic (markerless) worktree → never denies', () => {
+    const { evaluate } = require('../arc-guard/main');
+    const generic = base(); // managed dir shape, but no `.arcforge-epic` marker
+    for (const cmd of ['git merge main', 'git merge --no-ff feature', 'node scripts/loop.js']) {
+      assert.strictEqual(
+        evaluate({ tool_name: 'Bash', tool_input: { command: cmd }, cwd: generic }),
+        null,
+        `generic worktree must not deny: ${cmd}`,
+      );
+    }
+  });
+
   it('ignores non-Bash tools entirely', () => {
     const { evaluate } = require('../arc-guard/main');
     assert.strictEqual(

--- a/hooks/__tests__/arc-remind.test.js
+++ b/hooks/__tests__/arc-remind.test.js
@@ -104,6 +104,33 @@ describe('arc-remind worktree-add + ship-a-skill nudges', () => {
     assert.ok(worktreeAddNudge().includes('arcforge expand'));
     assert.ok(evalBeforeShipNudge().includes('arc-writing-skills'));
   });
+
+  it('worktree-add nudge points BOTH directions (epic + non-epic)', () => {
+    const { worktreeAddNudge } = require('../arc-remind/main');
+    const msg = worktreeAddNudge();
+    // Epic direction: the coordinator's expand.
+    assert.ok(msg.includes('arcforge expand'), 'epic direction → arcforge expand');
+    // Non-epic direction (WT-2 CLI): the generic worktree subcommand.
+    assert.ok(msg.includes('arcforge worktree add'), 'non-epic direction → arcforge worktree add');
+  });
+
+  it('the CLI-routed worktree add does NOT fire the nudge (seam solved by construction)', () => {
+    // The nudge is gated on the raw `git worktree add` regex. A command routed
+    // through the arcforge CLI never contains that literal, so it never trips —
+    // this is the build-time seam fix (WT-2/WT-7), pinned here.
+    const { isWorktreeAdd } = require('../arc-remind/main');
+    assert.strictEqual(
+      isWorktreeAdd('node /opt/arcforge/scripts/cli.js worktree add t1'),
+      false,
+      'CLI-routed worktree add must not match',
+    );
+    assert.strictEqual(
+      isWorktreeAdd('arcforge worktree add t1'),
+      false,
+      'bare arcforge worktree add must not match',
+    );
+    assert.ok(isWorktreeAdd('git worktree add ../wt feat'), 'raw git form still matches');
+  });
 });
 
 describe('arc-remind main-branch nudge', () => {

--- a/hooks/arc-remind/README.md
+++ b/hooks/arc-remind/README.md
@@ -10,7 +10,7 @@ Dispatches by tool; emits a user-facing `systemMessage` for these triggers:
 | Trigger | Tool | Nudge |
 |---------|------|-------|
 | `gh pr create` / `gh pr merge` | Bash | verify (`arc-verifying`) + review (`arc-requesting-review`); notes whether a test ran this session |
-| `git worktree add` in an arcforge project (`specs/`) | Bash | prefer `arcforge expand` for epic worktrees (`arc-using-worktrees`) |
+| raw `git worktree add` in an arcforge project (`specs/`) | Bash | prefer the arcforge CLI in BOTH directions — `arcforge expand` for epic worktrees, `arcforge worktree add` for non-epic ones (`arc-using-worktrees`). A CLI-routed worktree add never contains the raw `git worktree add` literal, so it never trips this nudge. |
 | `git commit` / `push` after a SKILL.md edit (once/session) | Bash + Edit/Write | freshness-aware eval-before-ship: compares `evals/benchmarks/latest.json` against the session's SKILL.md edits (`arc-writing-skills` Iron Law) |
 | first code (non-doc) edit on `main`/`master` (once/session) | Edit/Write | prefer a branch / epic worktree for feature work (`arc-executing-tasks`) |
 

--- a/hooks/arc-remind/main.js
+++ b/hooks/arc-remind/main.js
@@ -21,8 +21,10 @@
  *   PR boundary   `gh pr create`/`merge`  -> verify (arc-verifying) + review
  *                                            (arc-requesting-review); notes whether
  *                                            a test ran this session
- *   worktree add  `git worktree add` in an arcforge project -> prefer `arcforge
- *                                            expand` for epic worktrees
+ *   worktree add  raw `git worktree add` in an arcforge project -> prefer the
+ *                                            arcforge CLI in BOTH directions:
+ *                                            `arcforge expand` for epic worktrees,
+ *                                            `arcforge worktree add` for non-epic ones
  *   ship a skill  `git commit`/`push` after editing a SKILL.md (once/session)
  *                                         -> freshness-aware eval nudge: compares
  *                                            evals/benchmarks/latest.json (`generated`,
@@ -149,9 +151,12 @@ function buildReminder(command, testSeen) {
 
 function worktreeAddNudge() {
   return (
-    '\n🌳 Manual `git worktree add` in an arcforge project. For EPIC worktrees, ' +
-    '`arcforge expand` (see arc-using-worktrees) creates the `.arcforge-epic` marker and ' +
-    'keeps the DAG in sync — prefer it for epic work. (Fine for a non-epic worktree.)\n'
+    '\n🌳 Manual `git worktree add` in an arcforge project. Prefer the arcforge CLI so ' +
+    'the path is derived and hooks stay quiet (see arc-using-worktrees):\n' +
+    '  • EPIC work → `arcforge expand --epic <id>` — writes the `.arcforge-epic` marker ' +
+    'and keeps the DAG in sync.\n' +
+    '  • Non-epic work (a branch, experiment, or review checkout) → `arcforge worktree add ' +
+    '<name>` — a managed worktree with no marker.\n'
   );
 }
 


### PR DESCRIPTION
Wave 3 (PR-3f).

## What
- arc-remind worktreeAddNudge → dual-direction (epic→`arcforge expand`; non-epic→`arcforge worktree add`) + README + tests; arc-guard zero code change + markerless no-op regression test
- docs/guide/worktree-workflow.md new 'Generic (non-epic) worktrees' section (null-spec derivation, kind annotation, sync/merge invisibility guarantee, finish handoff — matched to the REAL worktree-generic.js JSON field names, not the RFC); README + skills-reference updates
- S1-1: .codex/.gemini/.opencode INSTALL.md each gain ARCFORGE_ROOT guidance (~/.agents/arcforge — the AF-1 fallback basis) + Node prerequisite (previously Git-only)

## Acceptance (adversarially reviewed: approve)
- test:hooks green (dual-direction nudge, CLI form doesn't fire, markerless generic no-deny); shipped-surface greps clean (residual match is only the contributor plan doc quoting the criterion); three INSTALL.md carry ARCFORGE_ROOT + Node