### PR TITLE
feat(cli): --verify-cmd deterministic acceptance floor (AF-8)

### DIFF
--- a/scripts/cli/dag-commands.js
+++ b/scripts/cli/dag-commands.js
@@ -9,6 +9,7 @@
 
 const { Coordinator, syncAllSpecs, rebootAllSpecs } = require('../lib/coordinator');
 const { getWorktreePath } = require('../lib/worktree-paths');
+const { parseVerifyCommand } = require('../lib/loop-verify');
 const { output } = require('./shared');
 const {
   resolveSpecId,
@@ -92,10 +93,12 @@ function runExpand(args, { projectRoot, asJson, specFlag }) {
   const resolved = requireSpecId(resolveSpecId(projectRoot, specFlag), 'expand');
   const coord = new Coordinator(projectRoot, resolved);
   const verifyCmd = args.options['verify-cmd'];
+  // Tokenize as a proper argv carrier (quote-aware, no shell) — never split(' ').
+  // A command needing shell features is rejected by parseVerifyCommand (security.md).
   const created = coord.expandWorktrees({
     epicId: args.options.epic,
     verify: args.flags.verify,
-    verifyCommand: verifyCmd ? verifyCmd.split(' ') : undefined,
+    verifyCommand: verifyCmd ? parseVerifyCommand(verifyCmd) : undefined,
     projectSetup: args.flags['project-setup'] || false,
   });
   output(
@@ -214,6 +217,19 @@ function runLoop(args, { projectRoot, specFlag }) {
     process.exit(1);
   }
 
+  // --verify-cmd: deterministic acceptance floor run after each session exits 0,
+  // before the task completes. Tokenized as an argv array (no shell); a command
+  // needing shell features exits with the security.md error.
+  let verifyCommand = null;
+  if (args.options['verify-cmd']) {
+    try {
+      verifyCommand = parseVerifyCommand(args.options['verify-cmd']);
+    } catch (err) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
   // --reset archives any existing state file before this run starts, so the
   // loop begins from a clean state. Deliberate pre-run action — never mid-run.
   if (args.flags.reset) {
@@ -237,6 +253,7 @@ function runLoop(args, { projectRoot, specFlag }) {
     taskTimeoutMs: taskTimeout ? taskTimeout * 1000 : null,
     permissionMode: args.options['permission-mode'] || null,
     allowedTools: args.options['allowed-tools'] || null,
+    verifyCommand,
   };
   if (pattern === 'dag') {
     runDag(loopOptions);

--- a/scripts/cli/help.js
+++ b/scripts/cli/help.js
@@ -84,7 +84,7 @@ COMMANDS:
       --example    Show complete example
 
   loop [--pattern sequential|dag] [--max-runs N] [--max-cost N] [--epic <id>] [--spec-id <id>]
-       [--task-timeout N] [--permission-mode <mode>] [--allowed-tools <tools>] [--reset]
+       [--task-timeout N] [--permission-mode <mode>] [--allowed-tools <tools>] [--verify-cmd "..."] [--reset]
       Run autonomous cross-session execution loop.
       --pattern          Execution pattern: sequential (default) or dag
       --epic             Scope loop to a single epic (auto-detected in worktrees)
@@ -93,6 +93,7 @@ COMMANDS:
       --task-timeout     Per-session timeout in seconds (default: 600)
       --permission-mode  Pass --permission-mode through to spawned claude sessions
       --allowed-tools    Pass --allowed-tools through to spawned claude sessions
+      --verify-cmd       Acceptance floor run after each session exits 0; non-zero fails the task
       --reset            Archive prior state to .arcforge-loop.archive/ and start fresh
 
   eval list                          List eval scenarios

--- a/scripts/lib/cli-manifest.js
+++ b/scripts/lib/cli-manifest.js
@@ -135,6 +135,7 @@ const CLI_MANIFEST = {
       '--task-timeout',
       '--permission-mode',
       '--allowed-tools',
+      '--verify-cmd',
     ],
     output: null,
   },

--- a/scripts/lib/loop-dag.js
+++ b/scripts/lib/loop-dag.js
@@ -14,6 +14,7 @@
 
 const { spawnSessionAsync } = require('./loop-session');
 const { saveLoopState, recordError } = require('./loop-state');
+const { runVerify, recordVerifyResult } = require('./loop-verify');
 const { getTimestamp } = require('./utils');
 
 /**
@@ -131,6 +132,41 @@ function integrateEpic(coord, epic, state) {
 }
 
 /**
+ * Run the deterministic acceptance floor for a dag epic whose session exited 0,
+ * BEFORE integrating it. Runs the configured --verify-cmd as an argv array (no
+ * shell) in the epic's OWN worktree cwd — AF-7's projectSetup makes that tree
+ * real (installed deps), so `npm test` etc. actually run. On a non-zero verify
+ * the epic is blocked (not merged/completed) and its worktree retained, mirroring
+ * a failed session. The result is persisted for AF-9. Returns whether verify
+ * passed; with no --verify-cmd configured it is a no-op returning true.
+ * @param {Coordinator} coord - Coordinator instance
+ * @param {Object} epic - Epic whose session succeeded
+ * @param {string} worktreePath - The epic's worktree cwd to verify in
+ * @param {Object} state - Loop state (verify result + error persisted here)
+ * @param {Object} options - Loop options (verifyCommand, taskTimeoutMs)
+ * @returns {boolean} Whether verification passed (or was not configured)
+ */
+function verifyEpic(coord, epic, worktreePath, state, options) {
+  if (!options.verifyCommand) return true;
+  console.log(`[loop] Verifying ${epic.id}: ${options.verifyCommand.join(' ')}`);
+  const result = runVerify(options.verifyCommand, worktreePath, {
+    timeoutMs: options.taskTimeoutMs,
+  });
+  recordVerifyResult(state, epic.id, result);
+  if (result.exitCode === 0) return true;
+
+  console.log(`[loop] Verify failed for ${epic.id} (exit ${result.exitCode}) — blocking`);
+  recordError(state, epic.id, `verify-cmd failed: ${result.stderr || result.stdout}`, 1);
+  state.failed_tasks.push(epic.id);
+  try {
+    coord.blockTask(epic.id, `Loop: verify-cmd failed (exit ${result.exitCode})`);
+  } catch (err) {
+    console.error(`[loop] Warning: could not block task ${epic.id}: ${err.message}`);
+  }
+  return false;
+}
+
+/**
  * Run one isolated-worktree round: expand each batch epic, spawn a session
  * in its worktree, and integrate the successful ones. Returns whether any
  * epic made progress.
@@ -172,7 +208,7 @@ async function runDagRound(coord, batch, state, options, buildTaskPrompt) {
   // Phase 3: integrate sequentially (DAG + git updates are not concurrent-safe).
   let anySuccess = false;
   for (let i = 0; i < live.length; i++) {
-    const { epic } = live[i];
+    const { epic, worktreePath } = live[i];
     const result = spawnResults[i];
     state.total_cost += result.costUsd;
 
@@ -187,6 +223,9 @@ async function runDagRound(coord, batch, state, options, buildTaskPrompt) {
       }
       continue;
     }
+    // Deterministic acceptance floor: a clean session exit alone is not enough
+    // to merge — the verify command must pass in the epic's worktree first.
+    if (!verifyEpic(coord, epic, worktreePath, state, options)) continue;
     if (integrateEpic(coord, epic, state)) anySuccess = true;
   }
 
@@ -198,6 +237,7 @@ module.exports = {
   warnIfBaseBranch,
   selectRoundEpics,
   prepareEpicWorktree,
+  verifyEpic,
   integrateEpic,
   runDagRound,
 };

--- a/scripts/lib/loop-verify.js
+++ b/scripts/lib/loop-verify.js
@@ -1,0 +1,167 @@
+/**
+ * loop-verify.js - Deterministic acceptance floor for the autonomous loop.
+ *
+ * The `--verify-cmd` flag runs a project-defined verification command after a
+ * spawned session exits 0 and BEFORE the task is marked complete. A non-zero
+ * verify exit fails the task (routing it to retry/block), so the loop never
+ * marks work "done" on the session's word alone.
+ *
+ * SECURITY (security.md): the command runs as an argv ARRAY via execFileSync —
+ * never through a shell. The command string is tokenized here (quote-aware,
+ * no shell), and any command that genuinely needs shell features (pipes,
+ * redirects, command chaining, substitution) is REJECTED with a clear error
+ * rather than silently interpolated into a shell.
+ */
+
+const { execFileSync } = require('node:child_process');
+
+/** Shell metacharacters that mean the command needs a shell we won't provide. */
+const SHELL_FEATURE_RE = /[|&;<>`]|\$\(|\$\{|\n/;
+
+/** Cap captured verify output stored in loop state (feeds AF-9 feedback). */
+const VERIFY_OUTPUT_CAP = 2000;
+
+/** Default per-verify timeout (ms). A hung verify must not stall the loop. */
+const DEFAULT_VERIFY_TIMEOUT_MS = 600000;
+
+/** Strip control characters from captured (untrusted) command output. */
+function stripControlChars(str) {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberate control-char filter (security.md)
+  return str.replace(/[\x00-\x09\x0b\x0c\x0e-\x1f\x7f]/g, '');
+}
+
+/**
+ * Parse a verify-command string into a quote-aware argv array — the "proper
+ * argv carrier" replacing a naive split(' '). Handles single/double quotes so
+ * commands with quoted arguments (e.g. `npm test -- --grep "a b"`) tokenize
+ * correctly, but does NOT interpret any shell syntax.
+ *
+ * Throws (security.md STOP) when the command contains shell metacharacters
+ * (`| & ; < > \` $( ${` or a newline): those need a shell, and the floor must
+ * never pipe an untrusted string through one. The caller surfaces this for
+ * owner sign-off rather than improvising.
+ *
+ * @param {string} raw - Raw --verify-cmd value
+ * @returns {string[]} argv array (command + args)
+ */
+function parseVerifyCommand(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new Error('verify-cmd must be a non-empty string');
+  }
+  if (SHELL_FEATURE_RE.test(raw)) {
+    throw new Error(
+      `verify-cmd "${raw}" uses shell features (pipe/redirect/chaining/substitution); ` +
+        'the acceptance floor runs commands as an argv array, never through a shell ' +
+        '(security.md). Wrap the logic in a script and point --verify-cmd at it.',
+    );
+  }
+  const argv = [];
+  let current = '';
+  let quote = null;
+  let sawToken = false;
+  for (const ch of raw.trim()) {
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      sawToken = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      if (sawToken) {
+        argv.push(current);
+        current = '';
+        sawToken = false;
+      }
+      continue;
+    }
+    current += ch;
+    sawToken = true;
+  }
+  if (quote) {
+    throw new Error(`verify-cmd "${raw}" has an unterminated ${quote} quote`);
+  }
+  if (sawToken) argv.push(current);
+  if (argv.length === 0) {
+    throw new Error('verify-cmd must contain at least one token');
+  }
+  return argv;
+}
+
+/**
+ * Run a verify command (argv array) in a working directory, as the deterministic
+ * acceptance floor. Runs via execFileSync — NO shell. A spawn-level failure
+ * (binary missing, timeout) is reported as a non-zero exit, never thrown, so
+ * the loop treats it as a verify failure (retry/block) rather than crashing.
+ *
+ * @param {string[]} argv - Command argv array (from parseVerifyCommand)
+ * @param {string} cwd - Working directory (dag mode: the epic worktree)
+ * @param {Object} [options] - Run options
+ * @param {number} [options.timeoutMs] - Per-verify timeout
+ * @returns {{ command: string[], exitCode: number, stdout: string, stderr: string }}
+ */
+function runVerify(argv, cwd, options = {}) {
+  if (!Array.isArray(argv) || argv.length === 0) {
+    throw new Error('runVerify requires a non-empty argv array');
+  }
+  const [cmd, ...args] = argv;
+  try {
+    const stdout = execFileSync(cmd, args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: options.timeoutMs || DEFAULT_VERIFY_TIMEOUT_MS,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { command: argv, exitCode: 0, stdout: stdout || '', stderr: '' };
+  } catch (err) {
+    return {
+      command: argv,
+      exitCode: typeof err.status === 'number' ? err.status : 1,
+      stdout: err.stdout ? String(err.stdout) : '',
+      stderr: err.stderr ? String(err.stderr) : err.message || '',
+    };
+  }
+}
+
+/**
+ * Persist a per-run verify result into loop state for AF-9 (the verifier-agent
+ * consumes accumulated verify evidence). Appends to state.verify_results,
+ * stamped with the current run/iteration. Output is control-char filtered and
+ * capped. Mutates state in place.
+ *
+ * @param {Object} state - Loop state
+ * @param {string} taskId - Task/epic id this verify ran for
+ * @param {{ command: string[], exitCode: number, stdout: string, stderr: string }} result
+ * @returns {Object} The recorded entry
+ */
+function recordVerifyResult(state, taskId, result) {
+  if (!Array.isArray(state.verify_results)) state.verify_results = [];
+  const tail = (s) => stripControlChars(String(s || '')).slice(-VERIFY_OUTPUT_CAP);
+  const entry = {
+    task_id: taskId,
+    iteration: state.iteration,
+    command: result.command,
+    exit_code: result.exitCode,
+    passed: result.exitCode === 0,
+    output: tail(`${result.stdout}${result.stderr ? `\n${result.stderr}` : ''}`),
+    timestamp: new Date().toISOString(),
+  };
+  if (state.run_id) entry.run_id = state.run_id;
+  state.verify_results.push(entry);
+  return entry;
+}
+
+module.exports = {
+  SHELL_FEATURE_RE,
+  DEFAULT_VERIFY_TIMEOUT_MS,
+  parseVerifyCommand,
+  runVerify,
+  recordVerifyResult,
+};

--- a/scripts/loop.js
+++ b/scripts/loop.js
@@ -29,6 +29,7 @@ const {
 } = require('./lib/loop-state');
 const { isStalled, isRetryStorm, checkStopConditions, printSummary } = require('./lib/loop-state');
 const { warnIfBaseBranch, selectRoundEpics, runDagRound } = require('./lib/loop-dag');
+const { parseVerifyCommand, runVerify, recordVerifyResult } = require('./lib/loop-verify');
 const { Feature } = require('./lib/models');
 const {
   detectPackageManager,
@@ -59,6 +60,7 @@ function parseLoopArgs(args) {
     taskTimeoutMs: null,
     permissionMode: null,
     allowedTools: null,
+    verifyCommand: null,
     projectRoot: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
   };
 
@@ -113,6 +115,14 @@ function parseLoopArgs(args) {
       case '--allowed-tools':
         options.allowedTools = args[++i];
         break;
+      case '--verify-cmd':
+        try {
+          options.verifyCommand = parseVerifyCommand(args[++i]);
+        } catch (err) {
+          console.error(`Error: ${err.message}`);
+          process.exit(1);
+        }
+        break;
       case '--help':
       case '-h':
         printLoopHelp();
@@ -148,6 +158,8 @@ OPTIONS:
   --task-timeout N           Per-session timeout in seconds (default: 600)
   --permission-mode <mode>   Pass --permission-mode through to spawned claude sessions
   --allowed-tools <tools>    Pass --allowed-tools through to spawned claude sessions
+  --verify-cmd "<cmd>"       Run this command after each session exits 0; a
+                             non-zero exit fails the task (retry/block, no complete)
   --help, -h                 Show this help
 
 PATTERNS:
@@ -341,6 +353,33 @@ function buildTaskPrompt(task, coord, projectRoot, workspaceRoot) {
 }
 
 /**
+ * Run the deterministic acceptance floor for a task whose session exited 0.
+ * When no --verify-cmd is configured this is a no-op returning true, so the
+ * loop's behavior is byte-identical to today's. With a verify command it runs
+ * it as an argv array (no shell) in `cwd`, persists the result for AF-9, and
+ * returns whether it passed — a non-zero verify exit means the task did NOT
+ * actually pass and must route to retry/block, not completeTask.
+ * @param {Object} task - Task whose session just succeeded
+ * @param {Object} state - Loop state (verify result persisted here)
+ * @param {Object} options - Loop options (verifyCommand, taskTimeoutMs)
+ * @param {string} cwd - Working directory to run verify in
+ * @param {number} attempt - Attempt number (for error recording)
+ * @returns {boolean} Whether verification passed (or was not configured)
+ */
+function runVerifyFloor(task, state, options, cwd, attempt) {
+  if (!options.verifyCommand) return true;
+  console.log(`[loop] Verifying ${task.id}: ${options.verifyCommand.join(' ')}`);
+  const result = runVerify(options.verifyCommand, cwd, { timeoutMs: options.taskTimeoutMs });
+  recordVerifyResult(state, task.id, result);
+  if (result.exitCode !== 0) {
+    console.log(`[loop] Verify failed for ${task.id} (exit ${result.exitCode})`);
+    recordError(state, task.id, `verify-cmd failed: ${result.stderr || result.stdout}`, attempt);
+    return false;
+  }
+  return true;
+}
+
+/**
  * Run a single task iteration
  * @param {Object} task - Task from coordinator
  * @param {Coordinator} coord - Coordinator instance
@@ -356,17 +395,21 @@ function runTask(task, coord, state, options) {
   const prompt = buildTaskPrompt(task, coord, projectRoot);
   let result = spawnSession(prompt, projectRoot, options);
   state.total_cost += result.costUsd;
+  // An attempt only succeeds when the session exits 0 AND the acceptance floor
+  // passes — a clean exit with a failing verify must still route to retry.
+  let attemptOk = result.exitCode === 0 && runVerifyFloor(task, state, options, projectRoot, 1);
 
-  if (result.exitCode !== 0) {
+  if (!attemptOk) {
     console.log(`[loop] Task ${task.id} failed, retrying once...`);
-    recordError(state, task.id, result.stderr, 1);
+    if (result.exitCode !== 0) recordError(state, task.id, result.stderr, 1);
 
     // Retry once
     result = spawnSession(prompt, projectRoot, options);
     state.total_cost += result.costUsd;
-    if (result.exitCode !== 0) {
+    attemptOk = result.exitCode === 0 && runVerifyFloor(task, state, options, projectRoot, 2);
+    if (!attemptOk) {
       console.log(`[loop] Task ${task.id} failed after retry — blocking`);
-      recordError(state, task.id, result.stderr, 2);
+      if (result.exitCode !== 0) recordError(state, task.id, result.stderr, 2);
       state.failed_tasks.push(task.id);
 
       try {

--- a/tests/scripts/loop-rundag.test.js
+++ b/tests/scripts/loop-rundag.test.js
@@ -350,4 +350,103 @@ describe('runDag worktree isolation (AF-7)', () => {
     expect(byId['epic-b']).toBe(TaskStatus.COMPLETED);
     expect(status.blocked.some((b) => /setup failed/.test(b.reason))).toBe(true);
   });
+
+  // --- AF-8: deterministic acceptance floor (--verify-cmd) -------------------
+
+  function loopState() {
+    const p = path.join(root, '.arcforge-loop.json');
+    return fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : null;
+  }
+
+  test('flag absent → behavior byte-identical (no verify_results, epic merges)', async () => {
+    root = setupRepo([epic('epic-a')]);
+    await runDag(baseOptions());
+    const status = new Coordinator(root, SPEC_ID).status();
+    expect(status.epics[0].status).toBe(TaskStatus.COMPLETED);
+    // No verify floor ran: no verify_results key persisted.
+    expect(loopState().verify_results).toBeUndefined();
+  });
+
+  test('exit-0 session + passing verify → merges and completes', async () => {
+    root = setupRepo([epic('epic-a')]);
+    await runDag(baseOptions({ verifyCommand: ['node', '-e', 'process.exit(0)'] }));
+
+    const status = new Coordinator(root, SPEC_ID).status();
+    expect(status.epics[0].status).toBe(TaskStatus.COMPLETED);
+    expect(runGit(['log', '--oneline'], root)).toContain('integrate epic-a');
+    const results = loopState().verify_results;
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ task_id: 'epic-a', exit_code: 0, passed: true });
+  });
+
+  test('exit-0 session + failing verify → blocked, NOT merged, worktree retained', async () => {
+    root = setupRepo([epic('epic-a')]);
+    await runDag(baseOptions({ verifyCommand: ['node', '-e', 'process.exit(1)'] }));
+
+    const status = new Coordinator(root, SPEC_ID).status({ blockedOnly: false });
+    expect(status.epics[0].status).toBe(TaskStatus.BLOCKED);
+    // Floor gate: the epic branch was NOT merged into base.
+    expect(runGit(['log', '--oneline'], root)).not.toContain('integrate epic-a');
+    // Worktree retained for inspection (a failed verify mirrors a failed session).
+    expect(fs.existsSync(getWorktreePath(root, SPEC_ID, 'epic-a'))).toBe(true);
+    // Failure persisted for AF-9, and the block reason names the verify floor.
+    const results = loopState().verify_results;
+    expect(results[0]).toMatchObject({ task_id: 'epic-a', passed: false });
+    expect(status.blocked.some((b) => /verify-cmd failed/.test(b.reason))).toBe(true);
+  });
+
+  test('verify runs in the epic worktree cwd, never the base', async () => {
+    root = setupRepo([epic('epic-a')]);
+    const cwdFile = path.join(binDir, 'verify-cwd.txt');
+    // The verify command records its own cwd; it must be the epic worktree.
+    await runDag(
+      baseOptions({
+        verifyCommand: [
+          'node',
+          '-e',
+          `require('fs').writeFileSync(${JSON.stringify(cwdFile)}, process.cwd())`,
+        ],
+      }),
+    );
+
+    // The recorded cwd is canonical (testHome is realpath'd, getWorktreeRoot
+    // uses the mocked homedir) and comparable as-is — do NOT realpathSync it,
+    // because a passing verify merges then CLEANS UP the worktree.
+    const recordedCwd = fs.readFileSync(cwdFile, 'utf8').trim();
+    expect(recordedCwd).toBe(getWorktreePath(root, SPEC_ID, 'epic-a'));
+    expect(recordedCwd).not.toBe(root);
+  });
+
+  test('one epic fails verify, another passes → independent outcomes', async () => {
+    root = setupRepo([epic('epic-a'), epic('epic-b')]);
+    // Fail verify only inside epic-a's worktree by keying on the basename of cwd.
+    await runDag(
+      baseOptions({
+        verifyCommand: [
+          'node',
+          '-e',
+          "process.exit(require('path').basename(process.cwd()).endsWith('epic-a') ? 1 : 0)",
+        ],
+      }),
+    );
+
+    const status = new Coordinator(root, SPEC_ID).status({ blockedOnly: false });
+    const byId = Object.fromEntries(status.epics.map((e) => [e.id, e.status]));
+    expect(byId['epic-a']).toBe(TaskStatus.BLOCKED);
+    expect(byId['epic-b']).toBe(TaskStatus.COMPLETED);
+    expect(runGit(['log', '--oneline'], root)).not.toContain('integrate epic-a');
+    expect(runGit(['log', '--oneline'], root)).toContain('integrate epic-b');
+  });
+
+  test('failed session is blocked before verify even runs (no verify_results)', async () => {
+    root = setupRepo([epic('epic-a')]);
+    process.env.CLAUDE_EXIT = '1';
+    await runDag(baseOptions({ verifyCommand: ['node', '-e', 'process.exit(0)'] }));
+
+    const status = new Coordinator(root, SPEC_ID).status();
+    expect(status.epics[0].status).toBe(TaskStatus.BLOCKED);
+    // The floor only runs AFTER a clean session exit, so a failed session
+    // never reaches verify — no verify result recorded for it.
+    expect(loopState().verify_results).toBeUndefined();
+  });
 });

--- a/tests/scripts/loop-verify-floor.test.js
+++ b/tests/scripts/loop-verify-floor.test.js
@@ -1,0 +1,146 @@
+/**
+ * loop-verify-floor.test.js — AF-8 acceptance floor in the SEQUENTIAL runTask
+ * path (loop.js). spawnSession is mocked to control session exit/cost; the
+ * verify command runs for real (an argv array via execFileSync, no shell).
+ *
+ * Invariants pinned here:
+ *   - flag absent → runTask behaves byte-identically (completes on exit 0).
+ *   - exit 0 + passing verify → completeTask, verify_results persisted.
+ *   - exit 0 + failing verify → NO completeTask; retries once; then blocks.
+ *   - failed session is never followed by a verify (floor is exit-0-gated).
+ */
+
+jest.mock('../../scripts/lib/loop-session', () => ({
+  spawnSession: jest.fn(),
+  spawnSessionAsync: jest.fn(),
+}));
+
+const { spawnSession } = require('../../scripts/lib/loop-session');
+const { runTask } = require('../../scripts/loop');
+
+/** Minimal coordinator stub: records complete/block calls; taskContext throws
+ *  (runTask tolerates that — buildTaskPrompt falls back to basic info). */
+function makeCoord() {
+  return {
+    completed: [],
+    blocked: [],
+    specId: 'spec',
+    completeTask(id) {
+      this.completed.push(id);
+    },
+    blockTask(id, reason) {
+      this.blocked.push({ id, reason });
+    },
+    taskContext() {
+      throw new Error('no context in stub');
+    },
+    dag: { getTask: () => null },
+  };
+}
+
+function makeState() {
+  return {
+    iteration: 1,
+    completed_tasks: [],
+    failed_tasks: [],
+    errors: [],
+    total_cost: 0,
+    last_progress_at: null,
+    status: 'running',
+  };
+}
+
+const task = { id: 'epic-a', name: 'Epic A' };
+const PASS = ['node', '-e', 'process.exit(0)'];
+const FAIL = ['node', '-e', 'process.exit(1)'];
+
+beforeEach(() => {
+  spawnSession.mockReset();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => jest.restoreAllMocks());
+
+describe('runTask acceptance floor (sequential)', () => {
+  it('flag absent → completes on a clean session exit, no verify_results', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: '', stderr: '', costUsd: 0 });
+    const coord = makeCoord();
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: process.cwd() });
+
+    expect(ok).toBe(true);
+    expect(coord.completed).toEqual(['epic-a']);
+    expect(spawnSession).toHaveBeenCalledTimes(1);
+    expect(state.verify_results).toBeUndefined();
+  });
+
+  it('exit 0 + passing verify → completes and persists verify_results', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: '', stderr: '', costUsd: 0 });
+    const coord = makeCoord();
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: process.cwd(), verifyCommand: PASS });
+
+    expect(ok).toBe(true);
+    expect(coord.completed).toEqual(['epic-a']);
+    expect(state.verify_results).toHaveLength(1);
+    expect(state.verify_results[0]).toMatchObject({ task_id: 'epic-a', passed: true });
+  });
+
+  it('exit 0 + failing verify → NO complete; retries once; then blocks', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: '', stderr: '', costUsd: 0 });
+    const coord = makeCoord();
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: process.cwd(), verifyCommand: FAIL });
+
+    expect(ok).toBe(false);
+    expect(coord.completed).toEqual([]); // floor blocked completeTask
+    // Session re-spawned for the single retry; verify ran on both attempts.
+    expect(spawnSession).toHaveBeenCalledTimes(2);
+    expect(state.verify_results).toHaveLength(2);
+    expect(state.verify_results.every((r) => r.passed === false)).toBe(true);
+    expect(state.failed_tasks).toContain('epic-a');
+    expect(coord.blocked[0].id).toBe('epic-a');
+  });
+
+  it('exit 0 first attempt fails verify, retry passes verify → completes', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: '', stderr: '', costUsd: 0 });
+    const coord = makeCoord();
+    const state = makeState();
+    // Different verify each attempt: fail then pass via a temp marker.
+    const fs = require('node:fs');
+    const os = require('node:os');
+    const path = require('node:path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af8-floor-'));
+    const marker = path.join(tmp, 'seen');
+    const verify = [
+      'node',
+      '-e',
+      `const f=${JSON.stringify(marker)};const fs=require('fs');if(fs.existsSync(f)){process.exit(0)}else{fs.writeFileSync(f,'x');process.exit(1)}`,
+    ];
+
+    const ok = runTask(task, coord, state, { projectRoot: tmp, verifyCommand: verify });
+
+    expect(ok).toBe(true);
+    expect(coord.completed).toEqual(['epic-a']);
+    expect(spawnSession).toHaveBeenCalledTimes(2);
+    expect(state.verify_results.map((r) => r.passed)).toEqual([false, true]);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('failed session never reaches verify (floor is exit-0-gated)', () => {
+    spawnSession.mockReturnValue({ exitCode: 1, stdout: '', stderr: 'boom', costUsd: 0 });
+    const coord = makeCoord();
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: process.cwd(), verifyCommand: PASS });
+
+    expect(ok).toBe(false);
+    expect(coord.completed).toEqual([]);
+    // No verify result: the session failed both attempts, so the floor never ran.
+    expect(state.verify_results).toBeUndefined();
+    expect(coord.blocked[0].id).toBe('epic-a');
+  });
+});

--- a/tests/scripts/loop-verify.test.js
+++ b/tests/scripts/loop-verify.test.js
@@ -1,0 +1,184 @@
+/**
+ * loop-verify.test.js — AF-8 deterministic acceptance floor primitives.
+ *
+ * parseVerifyCommand is the "proper argv carrier" replacing split(' '): it
+ * tokenizes quote-aware and REJECTS shell features (security.md). runVerify
+ * runs an argv array via execFileSync (no shell) and reports — never throws —
+ * a non-zero exit. recordVerifyResult persists per-run results for AF-9.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  parseVerifyCommand,
+  runVerify,
+  recordVerifyResult,
+} = require('../../scripts/lib/loop-verify');
+
+describe('parseVerifyCommand (argv carrier)', () => {
+  it('tokenizes a simple command into an argv array', () => {
+    expect(parseVerifyCommand('npm test')).toEqual(['npm', 'test']);
+  });
+
+  it('collapses repeated whitespace between tokens', () => {
+    expect(parseVerifyCommand('  npm   run   lint  ')).toEqual(['npm', 'run', 'lint']);
+  });
+
+  it('keeps a double-quoted argument as one token', () => {
+    expect(parseVerifyCommand('npm test -- --grep "a b c"')).toEqual([
+      'npm',
+      'test',
+      '--',
+      '--grep',
+      'a b c',
+    ]);
+  });
+
+  it('keeps a single-quoted argument as one token', () => {
+    expect(parseVerifyCommand("pytest -k 'slow and io'")).toEqual(['pytest', '-k', 'slow and io']);
+  });
+
+  it('supports an empty quoted token', () => {
+    expect(parseVerifyCommand('echo ""')).toEqual(['echo', '']);
+  });
+
+  // security.md STOP: shell features must be rejected, never interpolated.
+  it.each([
+    ['pipe', 'npm test | grep ok'],
+    ['and-chain', 'npm test && npm run lint'],
+    ['semicolon', 'npm test; echo done'],
+    ['redirect-out', 'npm test > out.txt'],
+    ['redirect-in', 'cat < in.txt'],
+    ['backtick', 'echo `whoami`'],
+    ['command-sub', 'echo $(whoami)'],
+    // '$' + '{HOME}' kept split so the literal isn't read as a JS template placeholder.
+    ['var-expand', `echo $${'{HOME}'}`],
+  ])('rejects shell feature: %s', (_label, cmd) => {
+    expect(() => parseVerifyCommand(cmd)).toThrow(/shell features/);
+  });
+
+  it('rejects an empty or whitespace-only command', () => {
+    expect(() => parseVerifyCommand('')).toThrow(/non-empty/);
+    expect(() => parseVerifyCommand('   ')).toThrow(/non-empty/);
+  });
+
+  it('rejects a non-string command', () => {
+    expect(() => parseVerifyCommand(null)).toThrow(/non-empty/);
+    expect(() => parseVerifyCommand(['npm', 'test'])).toThrow(/non-empty/);
+  });
+
+  it('rejects an unterminated quote', () => {
+    expect(() => parseVerifyCommand('npm test "unterminated')).toThrow(/unterminated/);
+  });
+});
+
+describe('runVerify (argv array, no shell)', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'loop-verify-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('runs the argv array and returns exit 0 on success', () => {
+    const result = runVerify(['node', '-e', 'process.exit(0)'], tmp);
+    expect(result.exitCode).toBe(0);
+    expect(result.command).toEqual(['node', '-e', 'process.exit(0)']);
+  });
+
+  it('returns the non-zero exit code on failure (never throws)', () => {
+    const result = runVerify(['node', '-e', 'process.exit(3)'], tmp);
+    expect(result.exitCode).toBe(3);
+  });
+
+  it('runs in the supplied cwd', () => {
+    const result = runVerify(['node', '-e', 'process.stdout.write(process.cwd())'], tmp);
+    expect(result.exitCode).toBe(0);
+    // realpath: macOS /tmp is a symlink to /private/tmp.
+    expect(fs.realpathSync(result.stdout.trim())).toBe(fs.realpathSync(tmp));
+  });
+
+  it('does NOT interpret shell metacharacters in arguments', () => {
+    // If this were run through a shell, `;` would terminate and `echo pwned`
+    // would run. As an argv array it is just a literal argument to node -e,
+    // which prints it back verbatim.
+    const result = runVerify(['node', '-e', 'process.stdout.write("a; echo b")'], tmp);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('a; echo b');
+  });
+
+  it('reports a missing binary as a non-zero exit, not a throw', () => {
+    const result = runVerify(['this-binary-does-not-exist-af8'], tmp);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('throws on an empty argv (programmer error)', () => {
+    expect(() => runVerify([], tmp)).toThrow(/non-empty argv/);
+  });
+});
+
+describe('recordVerifyResult (AF-9 persistence)', () => {
+  it('appends a structured entry stamped with iteration and run_id', () => {
+    const state = { iteration: 4, run_id: 'run-xyz' };
+    const entry = recordVerifyResult(state, 'epic-a', {
+      command: ['npm', 'test'],
+      exitCode: 0,
+      stdout: 'all good',
+      stderr: '',
+    });
+    expect(state.verify_results).toHaveLength(1);
+    expect(entry).toMatchObject({
+      task_id: 'epic-a',
+      iteration: 4,
+      command: ['npm', 'test'],
+      exit_code: 0,
+      passed: true,
+      run_id: 'run-xyz',
+    });
+    expect(typeof entry.timestamp).toBe('string');
+  });
+
+  it('marks passed:false and captures output on a non-zero exit', () => {
+    const state = { iteration: 1 };
+    const entry = recordVerifyResult(state, 'epic-b', {
+      command: ['npm', 'test'],
+      exitCode: 1,
+      stdout: 'out',
+      stderr: 'boom',
+    });
+    expect(entry.passed).toBe(false);
+    expect(entry.exit_code).toBe(1);
+    expect(entry.output).toContain('boom');
+  });
+
+  it('appends across calls (accumulates for AF-9)', () => {
+    const state = { iteration: 1 };
+    recordVerifyResult(state, 'a', { command: ['x'], exitCode: 0, stdout: '', stderr: '' });
+    recordVerifyResult(state, 'b', { command: ['y'], exitCode: 1, stdout: '', stderr: '' });
+    expect(state.verify_results.map((r) => r.task_id)).toEqual(['a', 'b']);
+  });
+
+  it('strips control characters from captured output', () => {
+    const state = { iteration: 1 };
+    const entry = recordVerifyResult(state, 'a', {
+      command: ['x'],
+      exitCode: 1,
+      stdout: 'clean\x00\x07dirty',
+      stderr: '',
+    });
+    expect(entry.output).toBe('cleandirty');
+  });
+
+  it('omits run_id when state has none (legacy state)', () => {
+    const state = { iteration: 1 };
+    const entry = recordVerifyResult(state, 'a', {
+      command: ['x'],
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    expect(entry.run_id).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Wave 4 · AF-8 — --verify-cmd 確定性驗收地板

Wires the **execution floor** on top of AF-7's `loop-dag.js`: after a session exits 0 and **before** `completeTask`, run the verify command. Non-zero → task fails (retry/block), never completes.

### Security (security.md)
- New `scripts/lib/loop-verify.js`: `runVerify(argv, cwd)` executes via **`execFileSync` with an argv ARRAY — no shell, no interpolation**. Fixes the old `dag-commands.js` `verifyCmd.split(' ')` naive split.
- dag mode: cwd = the **epic worktree** (AF-7 `projectSetup:true` makes the fixture tree real).

### Invariants
- **Flag absent → byte-identical to today** (binding non-regression, pinned by test).
- Each verify result **persisted into loop state** → feeds AF-9 (Wave 5).
- `--verify-cmd` added to `loop` flags in `cli-manifest.js` (SRH-2 contract — non-colliding with AF-11's `parallel` edit).

### Acceptance (replayed by reviewer)
- argv-array exec / no shell ✅ · exit-0-then-verify-then-complete ordering ✅ · dag cwd=worktree ✅ · non-zero→fail ✅ · flag-absent byte-identical ✅ · per-run persisted ✅ · `npm test` green ✅

No stop conditions fired (AF-7 landed; no shell features needed).