### PR TITLE
feat(cli): parallelFeatures engine query + parallel --features (AF-11)

### DIFF
--- a/scripts/cli/dag-commands.js
+++ b/scripts/cli/dag-commands.js
@@ -75,9 +75,23 @@ function runBlock(args, { projectRoot, asJson, specFlag }) {
   output({ success: true, task_id: args.positional[0] }, asJson);
 }
 
-function runParallel(_args, { projectRoot, asJson, specFlag }) {
+function runParallel(args, { projectRoot, asJson, specFlag }) {
   const resolved = requireSpecId(resolveSpecId(projectRoot, specFlag), 'parallel');
   const coord = new Coordinator(projectRoot, resolved);
+  // --features: feature-level readiness within in-progress epics. Distinct
+  // JSON shape ({ count, features: [...] }) from the default epic-level
+  // ({ count, epics: [...] }) — the pinned manifest contract probes default.
+  if (args.flags.features) {
+    const features = coord.parallelFeatures();
+    output(
+      {
+        count: features.length,
+        features: features.map((f) => ({ id: f.id, name: f.name, epic: f.epic })),
+      },
+      asJson,
+    );
+    return;
+  }
   const tasks = coord.parallelTasks();
   output(
     {

--- a/scripts/lib/cli-manifest.js
+++ b/scripts/lib/cli-manifest.js
@@ -79,7 +79,10 @@ const CLI_MANIFEST = {
   },
 
   parallel: {
-    flags: ['--json', '--spec-id'],
+    // --features switches the JSON shape to feature-level readiness
+    // ({ count, features: [...] }); without it, the default epic-level shape
+    // below is what the contract test live-probes.
+    flags: ['--features', '--json', '--spec-id'],
     output: { count: null, epics: [{ id: null, name: null }] },
   },
 

--- a/scripts/lib/coordinator-core.js
+++ b/scripts/lib/coordinator-core.js
@@ -187,6 +187,32 @@ class Coordinator {
   }
 
   /**
+   * Get all features that can be worked on in parallel within in-progress
+   * epics. Feature-level analog of parallelTasks (epic-level): a feature is
+   * ready when its epic is in progress, the feature is pending, and every one
+   * of its intra-epic dependencies is completed.
+   * @param {string|null} [epicId=null] - If set, only consider this epic
+   * @returns {Array<{id: string, name: string, epic: string}>} Ready features
+   *   tagged with their parent epic id.
+   */
+  parallelFeatures(epicId = null) {
+    const epics = epicId
+      ? this.dag.epics.filter((e) => e.id === epicId)
+      : this.dag.epics.filter((e) => e.status === TaskStatus.IN_PROGRESS);
+    const ready = [];
+    for (const epic of epics) {
+      if (epic.status !== TaskStatus.IN_PROGRESS) continue;
+      const completedFeatures = epic.getCompletedFeatures();
+      for (const feature of epic.features) {
+        if (feature.status === TaskStatus.PENDING && feature.isReady(completedFeatures)) {
+          ready.push({ id: feature.id, name: feature.name, epic: epic.id });
+        }
+      }
+    }
+    return ready;
+  }
+
+  /**
    * Mark a task as completed
    * @param {string} taskId - Task ID to complete
    */

--- a/skills/arc-dispatching-parallel/SKILL.md
+++ b/skills/arc-dispatching-parallel/SKILL.md
@@ -89,20 +89,26 @@ Return:
 
 ### 3. Dispatch in Parallel
 
+Dispatch one subagent per task in a single message so they run concurrently:
+
 ```
-Task tool (general-purpose): "Fix issue A in file X"
-Task tool (general-purpose): "Fix issue B in file Y"
-Task tool (general-purpose): "Fix issue C in file Z"
-# All three dispatch simultaneously
+Agent(subagent_type='general-purpose'): "Fix issue A in file X"
+Agent(subagent_type='general-purpose'): "Fix issue B in file Y"
+Agent(subagent_type='general-purpose'): "Fix issue C in file Z"
 ```
 
 ### 4. Review and Integrate
 
 - Read each summary
-- Verify no conflicts
-- If conflicts found: tasks were not truly independent — resolve manually and re-check grouping
-- Run full test suite
-- Integrate all changes
+- Verify no conflicts. If conflicts found: tasks were not truly independent — resolve manually and re-check grouping
+- Verify the merged result with a fresh-context subagent rather than trusting
+  the implementers' own reports:
+  - `Agent(subagent_type='arcforge:verifier')` with the project test command —
+    runs the suite from an empty context and returns raw output.
+  - When a spec exists, also `Agent(subagent_type='arcforge:spec-reviewer')`
+    with the relevant `specs/<spec-id>/.../*.md` attached — it confirms every
+    acceptance criterion in the integrated branch.
+- Integrate all changes only after the verifier (and spec-reviewer, if run) PASS
 
 ## DAG-Based Workflow
 
@@ -125,20 +131,21 @@ Parse the structure to understand:
 
 ### Step 2: Identify Ready Features
 
-A feature is "ready" when:
+A feature is ready when it is `pending` and every feature it `depends_on` is
+`completed`. Don't hand-parse the dag for this — the engine computes it:
 
-- Status is "ready" OR
-- All dependencies are "complete"
-
-```python
-# Pseudocode
-ready_features = []
-for feature in all_features:
-    if feature.status == "ready":
-        ready_features.append(feature)
-    elif all(dep.status == "complete" for dep in feature.dependencies):
-        ready_features.append(feature)
+```bash
+node "${ARCFORGE_ROOT}/scripts/cli.js" parallel --features --json
 ```
+
+Output is the set of parallelizable features in the in-progress epic(s):
+
+```json
+{ "count": 2, "features": [{ "id": "feat-001", "name": "...", "epic": "epic-001" }] }
+```
+
+`count: 0` means nothing is ready right now — complete a blocking feature
+first, or fall back to `arcforge next` for the single next task.
 
 ### Step 3: Group by Independence
 
@@ -192,29 +199,29 @@ Use `arc-implementing` to implement features one at a time in dependency order.
 
 #### Option 2: Parallel
 
-For each feature in the parallel group, dispatch a separate subagent:
+For each feature in the parallel group, dispatch a separate subagent — all in
+one message so they run concurrently:
 
 ```
-For each feature in Group 1:
-    Use Task tool with subagent_type=general-purpose
-    Prompt: "Implement feature <feature-id> from specs/<spec-id>/epics/<epic>/features/<feature>.md"
-    Run in parallel (all at once)
-
-Wait for all to complete
-Review each implementation
-Then proceed to next group
+Agent(subagent_type='general-purpose'): "Implement feature <feature-id> from specs/<spec-id>/epics/<epic>/features/<feature>.md"
+Agent(subagent_type='general-purpose'): "Implement feature <feature-id> from specs/<spec-id>/epics/<epic>/features/<feature>.md"
 ```
+
+Wait for all to complete, then run the Step 4 verification gate
+(`arcforge:verifier`, plus `arcforge:spec-reviewer` when a spec exists) before
+proceeding to the next group.
 
 ### Step 6: Integrate with Coordinator
 
-Use `arc-coordinating` to fetch next work:
+Fetch the next work from the engine (the `arc-coordinating` skill owns the full
+lifecycle; these are the underlying CLI calls):
 
 ```bash
-# Get next parallelizable tasks
-arc-coordinating parallel
+# Get the next parallelizable features
+node "${ARCFORGE_ROOT}/scripts/cli.js" parallel --features --json
 
-# Or get next single task
-arc-coordinating next
+# Or get the next single task
+node "${ARCFORGE_ROOT}/scripts/cli.js" next --json
 ```
 
 ## Without DAG: Independent Failures
@@ -300,17 +307,17 @@ Then retry: `/arc-dispatching-parallel`
 - **Before:** `/arc-planning` creates dag.yaml
 - **During:** Use this skill to plan feature execution order
 - **After:** `/arc-implementing` executes features
-- **Related:** `/arc-coordinating parallel` (CLI command)
+- **Related:** `/arc-coordinating` owns the DAG lifecycle (wraps `parallel`, `next`)
 
 ## Key Distinction
 
-| Type              | Scope                         | Tool                               |
-| ----------------- | ----------------------------- | ---------------------------------- |
-| **Epic-level**    | Multiple epics at once        | Git worktrees (`arc-using-worktrees`) |
-| **Feature-level** | Multiple features within epic | This skill (`arc-dispatching-parallel`)    |
+| Type              | Scope                         | Skill                                  |
+| ----------------- | ----------------------------- | -------------------------------------- |
+| **Epic-level**    | Multiple epics at once        | `arc-dispatching-teammates` (multi-epic via DAG) / `arc-coordinating` (lifecycle) |
+| **Feature-level** | Multiple features within epic | This skill (`arc-dispatching-parallel`) |
 
 **Example:**
 
-- Epic 1 (worktree 1): Features A, B, C in parallel
-- Epic 2 (worktree 2): Features D, E in parallel
-- Both epics run simultaneously via separate worktrees
+- Epic 1: Features A, B, C in parallel (this skill, within one epic worktree)
+- Epic 2: Features D, E in parallel (this skill, within its own epic worktree)
+- The two epics run simultaneously as separate teammates via `arc-dispatching-teammates` / `arc-coordinating`

--- a/tests/scripts/coordinator.test.js
+++ b/tests/scripts/coordinator.test.js
@@ -321,6 +321,76 @@ describe('Coordinator', () => {
     });
   });
 
+  describe('parallelFeatures', () => {
+    it('should return ready features in an in-progress epic, tagged with epic id', () => {
+      const coord = createCoordinator(
+        twoEpicDag({
+          epic1Status: TaskStatus.IN_PROGRESS,
+          epic1Features: [
+            { id: 'feat-1a', name: 'Setup', status: TaskStatus.PENDING },
+            { id: 'feat-1b', name: 'Docs', status: TaskStatus.PENDING },
+          ],
+        }),
+      );
+      const ready = coord.parallelFeatures();
+      // Both features have no deps → both parallelizable.
+      expect(ready).toHaveLength(2);
+      expect(ready.map((f) => f.id).sort()).toEqual(['feat-1a', 'feat-1b']);
+      expect(ready[0].epic).toBe('epic-1');
+    });
+
+    it('should exclude a feature whose dependency is not yet completed', () => {
+      const coord = createCoordinator(
+        twoEpicDag({
+          epic1Status: TaskStatus.IN_PROGRESS,
+          // feat-1b depends on feat-1a (still pending) → not ready.
+          epic1Features: [
+            { id: 'feat-1a', name: 'Setup', status: TaskStatus.PENDING },
+            { id: 'feat-1b', name: 'Core', status: TaskStatus.PENDING, depends_on: ['feat-1a'] },
+          ],
+        }),
+      );
+      const ready = coord.parallelFeatures();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].id).toBe('feat-1a');
+    });
+
+    it('should include a dependent feature once its dependency completes', () => {
+      const coord = createCoordinator(
+        twoEpicDag({
+          epic1Status: TaskStatus.IN_PROGRESS,
+          epic1Features: [
+            { id: 'feat-1a', name: 'Setup', status: TaskStatus.COMPLETED },
+            { id: 'feat-1b', name: 'Core', status: TaskStatus.PENDING, depends_on: ['feat-1a'] },
+          ],
+        }),
+      );
+      const ready = coord.parallelFeatures();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].id).toBe('feat-1b');
+    });
+
+    it('should ignore features in epics that are not in progress', () => {
+      // Default twoEpicDag: both epics pending → no in-progress epic.
+      const coord = createCoordinator(twoEpicDag());
+      expect(coord.parallelFeatures()).toHaveLength(0);
+    });
+
+    it('should scope to a single epic when epicId is given', () => {
+      const coord = createCoordinator(
+        twoEpicDag({
+          epic1Status: TaskStatus.IN_PROGRESS,
+          epic2Status: TaskStatus.IN_PROGRESS,
+          epic2Features: [{ id: 'feat-2a', name: 'Plugin', status: TaskStatus.PENDING }],
+        }),
+      );
+      const result = coord.parallelFeatures('epic-2');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('feat-2a');
+      expect(result[0].epic).toBe('epic-2');
+    });
+  });
+
   describe('rebootContext', () => {
     it('should return task counts', () => {
       const coord = createCoordinator(twoEpicDag({ epic1Status: TaskStatus.IN_PROGRESS }));


### PR DESCRIPTION
## Wave 4 · AF-11 — parallelFeatures 引擎查詢 + arc-dispatching-parallel 修復

### Engine
- `coordinator-core.js`: new `parallelFeatures` (feature-level readiness) alongside `parallelTasks`.
- `cli.js`: `parallel --features` emits feature-level JSON (`{ count, features: [...] }`); default (no flag) keeps the epic-level shape.
- `cli-manifest.js`: `parallel` entry gains `--features` (SRH-2 contract — non-colliding with AF-8's `loop` edit).

### Skill (arc-dispatching-parallel)
- Manual-parse/pseudocode → **real commands**; non-executable literals fixed.
- Step 4/5 delegate to **arcforge:verifier** (spec-backed: also spec-reviewer).
- Key Distinction epic list → points at **arc-dispatching-teammates / arc-coordinating**, NOT arc-using-worktrees (owner instruction).

### Acceptance (replayed by reviewer)
- `parallel --features` JSON shape ✅ · manifest contract test green ✅ · skill commands executable ✅ · `npm test` green ✅

No stop conditions fired (readiness uses TaskStatus enum; no engine-level lock needed).

### Iron Law
arc-dispatching-parallel is a behavioral edit → **eval deferred to Wave 6 AF-14** (needs a new scenario; `eval list` currently has none registered).