### PR TITLE
feat(hooks): learning-channel wiring — save-record, suggester state, Stop gating (ICL-5/9/11)

### DIFF
--- a/docs/guide/hooks-system.md
+++ b/docs/guide/hooks-system.md
@@ -184,7 +184,7 @@ counter.getFilePath();             // Get file path (for debugging)
 
 Counter files are stored at `{TMPDIR}/arcforge-{name}-session-{sessionId}`.
 
-**Important**: If multiple systems need independent counters, use different names. Shared counter names create coupling (e.g., compact-suggester uses `compact-count`, diary system uses `tool-count`).
+**Important**: If multiple systems need independent counters, use different names. Shared counter names create coupling (e.g., user-message-counter uses `user-count`, diary system uses `tool-count`).
 
 ## Sync vs Async Hooks
 
@@ -262,6 +262,6 @@ For hooks that inject context into Claude (inject-skills, inject-context), use t
 | Using `console.log` for debug | Use `log()` (stderr) — console.log goes to stdout and corrupts hook protocol |
 | Using `logHighlight()` or `log()` for user-facing messages | Use `output({ systemMessage: "..." })` — stderr is completely invisible (not just condensed) |
 | Reading `input.trigger` on SessionStart | Use `input.source` — official field name is `source` |
-| Sharing counter names across independent systems | Use separate counter names (e.g., `compact-count` vs `tool-count`) |
+| Sharing counter names across independent systems | Use separate counter names (e.g., `user-count` vs `tool-count`) |
 | Using `execFileSync` in tests | Use `spawnSync` — captures stderr on success |
 | Testing only exit code 0 | Test actual behavior: check stdout JSON, stderr content, file side-effects |

--- a/hooks/__tests__/compact-suggester.test.js
+++ b/hooks/__tests__/compact-suggester.test.js
@@ -3,9 +3,23 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { spawnSync } = require('node:child_process');
 
-describe('compact-suggester counter', () => {
-  // Save original env
+const SUGGESTER = path.join(__dirname, '..', 'compact-suggester', 'main.js');
+const PRE_COMPACT = path.join(__dirname, '..', 'pre-compact', 'main.js');
+
+function freshModule() {
+  delete require.cache[require.resolve('../compact-suggester/main')];
+  delete require.cache[require.resolve('../../scripts/lib/diary-capture')];
+  delete require.cache[require.resolve('../../scripts/lib/utils')];
+  return require('../compact-suggester/main');
+}
+
+// ---------------------------------------------------------------------------
+// State file consolidation (ICL-9)
+// ---------------------------------------------------------------------------
+
+describe('compact-suggester: single JSON state file', () => {
   const originalEnv = { ...process.env };
   let testDir;
 
@@ -13,9 +27,6 @@ describe('compact-suggester counter', () => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-compact-'));
     process.env.TMPDIR = testDir;
     process.env.CLAUDE_SESSION_ID = 'test-compact-session';
-    // Clear module cache before each test
-    delete require.cache[require.resolve('../compact-suggester/main')];
-    delete require.cache[require.resolve('../../scripts/lib/utils')];
   });
 
   afterEach(() => {
@@ -24,32 +35,34 @@ describe('compact-suggester counter', () => {
     Object.assign(process.env, originalEnv);
   });
 
-  it('should initialize with count 0', () => {
-    const { readCount } = require('../compact-suggester/main');
+  it('initializes with count 0', () => {
+    const { readCount } = freshModule();
     assert.strictEqual(readCount(), 0);
   });
 
-  it('should track counter file path', () => {
-    const { getCounterFilePath } = require('../compact-suggester/main');
-    const filePath = getCounterFilePath();
-    assert.ok(filePath.includes('arcforge-compact-count'));
+  it('uses one JSON state file at the shared suggester path', () => {
+    const { getStateFilePath } = freshModule();
+    const filePath = getStateFilePath();
+    assert.ok(filePath.includes('arcforge-suggester-state'));
+    assert.ok(filePath.endsWith('.json'));
     assert.ok(filePath.includes('test-compact-session'));
   });
 
-  it('should read and write counter independently', () => {
-    const { readCount } = require('../compact-suggester/main');
-    const { createSessionCounter } = require('../../scripts/lib/utils');
-    const counter = createSessionCounter('compact-count');
-    counter.write(50);
-
-    assert.strictEqual(readCount(), 50);
-    counter.write(0);
-    assert.strictEqual(readCount(), 0);
+  it('readState/writeState round-trip', () => {
+    const { readState, writeState, emptyState } = freshModule();
+    writeState({ ...emptyState(), tools: 50, reads: 30, writes: 20 });
+    const state = readState();
+    assert.strictEqual(state.tools, 50);
+    assert.strictEqual(state.reads, 30);
+    assert.strictEqual(state.writes, 20);
   });
 });
 
+// ---------------------------------------------------------------------------
+// Suggestion timing
+// ---------------------------------------------------------------------------
+
 describe('shouldSuggest logic', () => {
-  // Test the exported function directly (no file system needed)
   const originalEnv = { ...process.env };
   let testDir;
 
@@ -57,8 +70,6 @@ describe('shouldSuggest logic', () => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-suggest-'));
     process.env.TMPDIR = testDir;
     process.env.CLAUDE_SESSION_ID = 'test-suggest-session';
-    delete require.cache[require.resolve('../compact-suggester/main')];
-    delete require.cache[require.resolve('../../scripts/lib/utils')];
   });
 
   afterEach(() => {
@@ -67,27 +78,27 @@ describe('shouldSuggest logic', () => {
     Object.assign(process.env, originalEnv);
   });
 
-  it('should not suggest below threshold', () => {
-    const { shouldSuggest } = require('../compact-suggester/main');
+  it('does not suggest below threshold', () => {
+    const { shouldSuggest } = freshModule();
     assert.strictEqual(shouldSuggest(0), false);
     assert.strictEqual(shouldSuggest(25), false);
     assert.strictEqual(shouldSuggest(49), false);
   });
 
-  it('should suggest at threshold (50)', () => {
-    const { shouldSuggest } = require('../compact-suggester/main');
+  it('suggests at threshold (50)', () => {
+    const { shouldSuggest } = freshModule();
     assert.strictEqual(shouldSuggest(50), true);
   });
 
-  it('should suggest at intervals (75, 100, 125)', () => {
-    const { shouldSuggest } = require('../compact-suggester/main');
+  it('suggests at intervals (75, 100, 125)', () => {
+    const { shouldSuggest } = freshModule();
     assert.strictEqual(shouldSuggest(75), true);
     assert.strictEqual(shouldSuggest(100), true);
     assert.strictEqual(shouldSuggest(125), true);
   });
 
-  it('should not suggest between intervals', () => {
-    const { shouldSuggest } = require('../compact-suggester/main');
+  it('does not suggest between intervals', () => {
+    const { shouldSuggest } = freshModule();
     assert.strictEqual(shouldSuggest(51), false);
     assert.strictEqual(shouldSuggest(60), false);
     assert.strictEqual(shouldSuggest(74), false);
@@ -95,17 +106,20 @@ describe('shouldSuggest logic', () => {
   });
 });
 
-describe('phase-aware messaging', () => {
+// ---------------------------------------------------------------------------
+// Rolling-window phase detection
+// ---------------------------------------------------------------------------
+
+describe('rolling-window phase detection', () => {
   const originalEnv = { ...process.env };
   let testDir;
+  let mod;
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-phase-'));
     process.env.TMPDIR = testDir;
     process.env.CLAUDE_SESSION_ID = 'test-phase-session';
-    // Fresh module load resets memReadCount/memWriteCount to 0
-    delete require.cache[require.resolve('../compact-suggester/main')];
-    delete require.cache[require.resolve('../../scripts/lib/utils')];
+    mod = freshModule();
   });
 
   afterEach(() => {
@@ -114,119 +128,249 @@ describe('phase-aware messaging', () => {
     Object.assign(process.env, originalEnv);
   });
 
-  it('should detect read-heavy phase and include exploration message at threshold', () => {
-    const { trackToolType, buildMessage } = require('../compact-suggester/main');
-    // Simulate 11 reads, 1 write (>70% reads, >10 samples)
-    for (let i = 0; i < 11; i++) trackToolType({ tool_name: 'Read' });
-    trackToolType({ tool_name: 'Edit' });
+  function windowOf(reads, writes) {
+    const state = mod.emptyState();
+    for (let i = 0; i < reads; i++) mod.trackToolType(state, { tool_name: 'Read' });
+    for (let i = 0; i < writes; i++) mod.trackToolType(state, { tool_name: 'Edit' });
+    return state.window;
+  }
 
-    const msg = buildMessage(50);
-    assert.ok(msg.includes('mostly reads'), 'should mention mostly reads');
-    assert.ok(
-      msg.includes('exploration') || msg.includes('research'),
-      'should reference exploration/research phase',
+  it('detects read-heavy phase from window', () => {
+    const win = windowOf(11, 1);
+    assert.strictEqual(mod.phaseFromWindow(win), 'read-heavy');
+    const msg = mod.buildMessage(50, win);
+    assert.ok(msg.includes('mostly reads'));
+    assert.ok(msg.includes('exploration') || msg.includes('research'));
+  });
+
+  it('detects write-heavy phase from window', () => {
+    const win = windowOf(4, 8);
+    assert.strictEqual(mod.phaseFromWindow(win), 'write-heavy');
+    const msg = mod.buildMessage(50, win);
+    assert.ok(msg.includes('active implementation'));
+    assert.ok(msg.includes('Mid-implementation'));
+  });
+
+  it('neutral when no phase dominates', () => {
+    const win = windowOf(6, 6);
+    assert.strictEqual(mod.phaseFromWindow(win), 'neutral');
+    assert.ok(mod.buildMessage(50, win).includes('workflow phases'));
+  });
+
+  it('neutral when too few samples', () => {
+    const win = windowOf(5, 0);
+    assert.strictEqual(mod.phaseFromWindow(win), 'neutral');
+    assert.ok(mod.buildMessage(50, win).includes('workflow phases'));
+  });
+
+  it('window is bounded to 20 most-recent entries', () => {
+    // 30 reads then 20 writes → last 20 are all writes → write-heavy,
+    // even though lifetime reads (30) outnumber writes (20).
+    const win = windowOf(30, 20);
+    assert.strictEqual(win.length, 20);
+    assert.strictEqual(mod.phaseFromWindow(win), 'write-heavy');
+  });
+
+  it('suppresses non-critical reminders during write-heavy window', () => {
+    const win = windowOf(4, 8);
+    assert.strictEqual(mod.shouldSuppressReminder(75, win), true);
+    assert.strictEqual(mod.shouldSuppressReminder(50, win), false);
+    assert.strictEqual(mod.shouldSuppressReminder(100, win), false);
+  });
+
+  it('does not suppress during read-heavy window', () => {
+    const win = windowOf(11, 1);
+    assert.strictEqual(mod.shouldSuppressReminder(75, win), false);
+  });
+
+  it('tracks Read/Glob/Grep as reads, Write/Edit/NotebookEdit as writes', () => {
+    const state = mod.emptyState();
+    mod.trackToolType(state, { tool_name: 'Read' });
+    mod.trackToolType(state, { tool_name: 'Glob' });
+    mod.trackToolType(state, { tool_name: 'Grep' });
+    mod.trackToolType(state, { tool_name: 'Write' });
+    mod.trackToolType(state, { tool_name: 'Edit' });
+    mod.trackToolType(state, { tool_name: 'NotebookEdit' });
+    assert.strictEqual(state.reads, 3);
+    assert.strictEqual(state.writes, 3);
+  });
+
+  it('ignores unrelated tools', () => {
+    const state = mod.emptyState();
+    mod.trackToolType(state, { tool_name: 'Bash' });
+    mod.trackToolType(state, { tool_name: 'Task' });
+    assert.strictEqual(state.window.length, 0);
+    assert.strictEqual(state.reads, 0);
+    assert.strictEqual(state.writes, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: event-driven runs (acceptance cases)
+// ---------------------------------------------------------------------------
+
+describe('compact-suggester e2e (ICL-9 acceptance)', () => {
+  const originalEnv = { ...process.env };
+  let testDir;
+  let homeDir;
+  const sessionId = 'icl9-e2e';
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-icl9-tmp-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-icl9-home-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  function env(extra = {}) {
+    return {
+      ...process.env,
+      TMPDIR: testDir,
+      HOME: homeDir,
+      ...extra,
+    };
+  }
+
+  function runSuggester(toolName, e = env()) {
+    return spawnSync('node', [SUGGESTER], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PostToolUse',
+        tool_name: toolName,
+      }),
+      encoding: 'utf-8',
+      env: e,
+    });
+  }
+
+  function statePath() {
+    return path.join(testDir, `arcforge-suggester-state-session-${sessionId}.json`);
+  }
+
+  function toolCountPath() {
+    return path.join(testDir, `arcforge-tool-count-session-${sessionId}`);
+  }
+
+  function readState() {
+    return JSON.parse(fs.readFileSync(statePath(), 'utf-8'));
+  }
+
+  it('drives to 50 events → one suggestion + one state file + shared tool-count', () => {
+    let suggestions = 0;
+    for (let i = 0; i < 50; i++) {
+      const res = runSuggester('Read');
+      assert.strictEqual(res.status, 0, res.stderr);
+      if (res.stdout.trim()) {
+        const parsed = JSON.parse(res.stdout);
+        if (parsed.systemMessage) suggestions++;
+      }
+    }
+    assert.strictEqual(suggestions, 1, 'exactly one suggestion fired at 50');
+
+    // $TMPDIR holds exactly one suggester state file + the shared tool-count.
+    const tmpFiles = fs
+      .readdirSync(testDir)
+      .filter(
+        (f) => f.startsWith('arcforge-suggester-state') || f.startsWith('arcforge-tool-count'),
+      );
+    assert.deepStrictEqual(
+      tmpFiles.sort(),
+      [
+        `arcforge-suggester-state-session-${sessionId}.json`,
+        `arcforge-tool-count-session-${sessionId}`,
+      ].sort(),
     );
-  });
-
-  it('should detect write-heavy phase and warn against mid-implementation compaction', () => {
-    const { trackToolType, buildMessage } = require('../compact-suggester/main');
-    // Simulate 8 writes, 4 reads (>60% writes, >10 samples)
-    for (let i = 0; i < 8; i++) trackToolType({ tool_name: 'Write' });
-    for (let i = 0; i < 4; i++) trackToolType({ tool_name: 'Grep' });
-
-    const msg = buildMessage(50);
-    assert.ok(msg.includes('active implementation'), 'should mention active implementation');
     assert.ok(
-      msg.includes('Mid-implementation'),
-      'should warn about mid-implementation compaction',
+      !fs.existsSync(path.join(testDir, `arcforge-compact-count-session-${sessionId}`)),
+      'no legacy compact-count file',
     );
+
+    // State records the suggestion snapshot and the tool tally.
+    const state = readState();
+    assert.strictEqual(state.tools, 50);
+    assert.strictEqual(state.suggestions.length, 1);
+    assert.strictEqual(state.suggestions[0].count, 50);
+
+    // Shared diary tool-count incremented in lockstep (binding preserved).
+    assert.strictEqual(fs.readFileSync(toolCountPath(), 'utf-8'), '50');
   });
 
-  it('should show generic message when no phase dominates', () => {
-    const { trackToolType, buildMessage } = require('../compact-suggester/main');
-    // Simulate balanced: 6 reads, 6 writes (50/50 — neither threshold met)
-    for (let i = 0; i < 6; i++) trackToolType({ tool_name: 'Glob' });
-    for (let i = 0; i < 6; i++) trackToolType({ tool_name: 'Edit' });
+  it('records suggestions[] into the live session JSON', () => {
+    const project = 'icl9-proj';
+    const date = new Date().toISOString().split('T')[0];
+    const sessionDir = path.join(homeDir, '.arcforge', 'sessions', project, date);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const sessionFile = path.join(sessionDir, `session-${sessionId}.json`);
+    fs.writeFileSync(sessionFile, JSON.stringify({ sessionId: `session-${sessionId}` }));
 
-    const msg = buildMessage(50);
-    assert.ok(msg.includes('workflow phases'), 'should show generic phase message');
+    const projectDir = path.join(homeDir, project);
+    fs.mkdirSync(projectDir, { recursive: true });
+    const e = env({ CLAUDE_PROJECT_DIR: projectDir });
+
+    for (let i = 0; i < 50; i++) runSuggester('Read', e);
+
+    const session = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
+    assert.ok(Array.isArray(session.suggestions), 'session JSON has suggestions[]');
+    assert.strictEqual(session.suggestions.length, 1);
+    assert.strictEqual(session.suggestions[0].count, 50);
   });
 
-  it('should show generic message when too few samples', () => {
-    const { trackToolType, buildMessage } = require('../compact-suggester/main');
-    // Only 5 reads — below MIN_PHASE_SAMPLES (10)
-    for (let i = 0; i < 5; i++) trackToolType({ tool_name: 'Read' });
-
-    const msg = buildMessage(50);
-    assert.ok(
-      msg.includes('workflow phases'),
-      'should show generic message with insufficient samples',
-    );
+  it('second snapshot is write-heavy after a late write burst', () => {
+    // 49 reads then a 51-event write burst (events 50..100). The 50-call
+    // snapshot lands with a read-heavy rolling window; the 75-call reminder is
+    // suppressed mid-write-burst; the 100-call snapshot lands write-heavy
+    // (suppression lifts at >=100). So the 2nd recorded snapshot is write-heavy.
+    for (let i = 0; i < 49; i++) runSuggester('Read');
+    for (let i = 0; i < 51; i++) runSuggester('Edit'); // events 50..100
+    const state = readState();
+    assert.strictEqual(state.suggestions.length, 2, 'two snapshots (50 and 100)');
+    assert.strictEqual(state.suggestions[0].count, 50);
+    assert.strictEqual(state.suggestions[1].count, 100);
+    assert.strictEqual(state.suggestions[1].phase, 'write-heavy', 'second snapshot write-heavy');
   });
 
-  it('should show read-heavy follow-up message at 75+ calls', () => {
-    const { trackToolType, buildMessage } = require('../compact-suggester/main');
-    // 11 reads, 1 write — read-heavy
-    for (let i = 0; i < 11; i++) trackToolType({ tool_name: 'Grep' });
-    trackToolType({ tool_name: 'Write' });
+  it('pre-compact reset clears suggestions; no stale suggestions after compaction', () => {
+    // 60 events → first suggestion at 50, snapshot recorded.
+    for (let i = 0; i < 60; i++) runSuggester('Read');
+    let state = readState();
+    assert.strictEqual(state.suggestions.length, 1, 'one snapshot before compaction');
 
-    const msg = buildMessage(75);
-    assert.ok(msg.includes('heavy read phase'), 'should mention heavy read phase at 75+');
-    assert.ok(
-      msg.includes('research') || msg.includes('findings'),
-      'should reference research context',
-    );
+    // Simulate pre-compact (resets the suggester state via the shared helper).
+    const project = 'icl9-reset-proj';
+    const projectDir = path.join(homeDir, project);
+    fs.mkdirSync(projectDir, { recursive: true });
+    const res = spawnSync('node', [PRE_COMPACT], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PreCompact',
+        cwd: projectDir,
+      }),
+      encoding: 'utf-8',
+      env: env({ CLAUDE_PROJECT_DIR: projectDir }),
+    });
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(!fs.existsSync(statePath()), 'suggester state file removed by pre-compact');
+
+    // 30 more events → fresh start, no stale suggestions carried over.
+    for (let i = 0; i < 30; i++) runSuggester('Read');
+    state = readState();
+    assert.strictEqual(state.tools, 30, 'counter restarted from zero');
+    assert.strictEqual(state.suggestions.length, 0, 'no stale suggestions after compaction');
   });
 
-  it('should suppress non-critical reminders during write-heavy phase', () => {
-    const { trackToolType, shouldSuppressReminder } = require('../compact-suggester/main');
-    // 8 writes, 4 reads — write-heavy (>60%)
-    for (let i = 0; i < 8; i++) trackToolType({ tool_name: 'Edit' });
-    for (let i = 0; i < 4; i++) trackToolType({ tool_name: 'Read' });
-
-    // Suppressed at non-threshold count below 100
-    assert.strictEqual(shouldSuppressReminder(75), true);
-    // NOT suppressed at threshold
-    assert.strictEqual(shouldSuppressReminder(50), false);
-    // NOT suppressed at 100+
-    assert.strictEqual(shouldSuppressReminder(100), false);
-  });
-
-  it('should not suppress reminders during read-heavy phase', () => {
-    const { trackToolType, shouldSuppressReminder } = require('../compact-suggester/main');
-    // 11 reads, 1 write — read-heavy
-    for (let i = 0; i < 11; i++) trackToolType({ tool_name: 'Grep' });
-    trackToolType({ tool_name: 'Write' });
-
-    assert.strictEqual(shouldSuppressReminder(75), false);
-  });
-
-  it('should track Read, Glob, Grep as reads', () => {
-    const { trackToolType, getReadWriteRatio } = require('../compact-suggester/main');
-    trackToolType({ tool_name: 'Read' });
-    trackToolType({ tool_name: 'Glob' });
-    trackToolType({ tool_name: 'Grep' });
-    const { reads, writes } = getReadWriteRatio();
-    assert.strictEqual(reads, 3);
-    assert.strictEqual(writes, 0);
-  });
-
-  it('should track Write, Edit, NotebookEdit as writes', () => {
-    const { trackToolType, getReadWriteRatio } = require('../compact-suggester/main');
-    trackToolType({ tool_name: 'Write' });
-    trackToolType({ tool_name: 'Edit' });
-    trackToolType({ tool_name: 'NotebookEdit' });
-    const { reads, writes } = getReadWriteRatio();
-    assert.strictEqual(reads, 0);
-    assert.strictEqual(writes, 3);
-  });
-
-  it('should not count unrelated tools as reads or writes', () => {
-    const { trackToolType, getReadWriteRatio } = require('../compact-suggester/main');
-    trackToolType({ tool_name: 'Bash' });
-    trackToolType({ tool_name: 'Agent' });
-    trackToolType({ tool_name: 'Task' });
-    const { total } = getReadWriteRatio();
-    assert.strictEqual(total, 0);
+  it('binding regression: diary threshold stays triggerable via shared tool-count', () => {
+    // Drive 50 events and confirm the shared tool-count reaches the diary
+    // threshold so the diary trigger remains firable after consolidation.
+    for (let i = 0; i < 50; i++) runSuggester('Read');
+    const { shouldTrigger, MIN_TOOL_CALLS } = require('../../scripts/lib/thresholds');
+    const toolCount = parseInt(fs.readFileSync(toolCountPath(), 'utf-8'), 10);
+    assert.strictEqual(toolCount, 50);
+    assert.ok(toolCount >= MIN_TOOL_CALLS);
+    assert.strictEqual(shouldTrigger(0, toolCount), true, 'diary threshold triggerable');
   });
 });

--- a/hooks/__tests__/e2e-hooks.test.js
+++ b/hooks/__tests__/e2e-hooks.test.js
@@ -431,9 +431,13 @@ describe('E2E: compact-suggester/main.js', () => {
     const sessionId = 'test-threshold';
     const env = { TMPDIR: testDir };
 
-    // Pre-create counter at 49 (compact-suggester uses its own "compact-count" counter)
-    const counterFile = path.join(testDir, `arcforge-compact-count-session-${sessionId}`);
-    fs.writeFileSync(counterFile, '49');
+    // Pre-create the suggester JSON state at 49 tools (its own counter, distinct
+    // from the shared diary tool-count). The 50th call triggers the suggestion.
+    const stateFile = path.join(testDir, `arcforge-suggester-state-session-${sessionId}.json`);
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({ tools: 49, reads: 0, writes: 0, window: [], suggestions: [] }),
+    );
 
     // The 50th call should trigger suggestion
     const input = makeToolUseInput(

--- a/hooks/__tests__/session-tracker-end.test.js
+++ b/hooks/__tests__/session-tracker-end.test.js
@@ -1,7 +1,13 @@
-const { describe, it } = require('node:test');
+const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
 
 const { calculateDurationMinutes } = require('../session-tracker/end');
+
+const END = path.join(__dirname, '..', 'session-tracker', 'end.js');
 
 describe('calculateDurationMinutes', () => {
   it('should calculate duration correctly', () => {
@@ -20,5 +26,81 @@ describe('calculateDurationMinutes', () => {
     assert.strictEqual(calculateDurationMinutes(null, '2025-01-01T10:00:00Z'), null);
     assert.strictEqual(calculateDurationMinutes('2025-01-01T10:00:00Z', null), null);
     assert.strictEqual(calculateDurationMinutes(null, null), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ICL-11: 'Session paused' message gating (only on triggered branch)
+// ---------------------------------------------------------------------------
+
+describe('Stop message gating (ICL-11)', () => {
+  const originalEnv = { ...process.env };
+  let tmpDir;
+  let homeDir;
+  const sessionId = 'icl11-gate';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'icl11-tmp-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'icl11-home-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  function counterPath(name) {
+    return path.join(tmpDir, `arcforge-${name}-session-${sessionId}`);
+  }
+
+  function runStop(projectDir) {
+    return spawnSync('node', [END], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'Stop',
+        cwd: projectDir,
+      }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_PROJECT_DIR: projectDir,
+      },
+    });
+  }
+
+  it('above threshold (triggered): emits user-visible Session paused systemMessage', () => {
+    // Seed tool-count above the diary threshold (50) so the capture triggers.
+    fs.writeFileSync(counterPath('tool-count'), '60');
+    fs.writeFileSync(counterPath('user-count'), '0');
+
+    const projectDir = path.join(homeDir, 'icl11-proj');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    const res = runStop(projectDir);
+    assert.strictEqual(res.status, 0, res.stderr);
+
+    const parsed = JSON.parse(res.stdout.trim());
+    assert.ok(parsed.systemMessage, 'systemMessage present when triggered');
+    assert.ok(parsed.systemMessage.includes('Session paused'));
+  });
+
+  it('below threshold: no user-visible systemMessage (stderr log only)', () => {
+    fs.writeFileSync(counterPath('tool-count'), '3');
+    fs.writeFileSync(counterPath('user-count'), '2');
+
+    const projectDir = path.join(homeDir, 'icl11-proj-low');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    const res = runStop(projectDir);
+    assert.strictEqual(res.status, 0, res.stderr);
+
+    // No JSON systemMessage on stdout below threshold.
+    assert.strictEqual(res.stdout.trim(), '', 'no stdout systemMessage below threshold');
+    // The paused notice is logged to stderr instead.
+    assert.ok(res.stderr.includes('Session paused'), 'paused notice logged to stderr');
   });
 });

--- a/hooks/__tests__/user-message-counter.test.js
+++ b/hooks/__tests__/user-message-counter.test.js
@@ -78,13 +78,15 @@ describe('counter independence', () => {
       readCount: readUserCount,
       writeCount: writeUserCount,
     } = require('../user-message-counter/main');
-    const { readCount: readCompactCount } = require('../compact-suggester/main');
-    const { createSessionCounter } = require('../../scripts/lib/utils');
-    const compactCounter = createSessionCounter('compact-count');
+    const {
+      readCount: readCompactCount,
+      writeState,
+      emptyState,
+    } = require('../compact-suggester/main');
 
-    // Set different values
+    // Set different values — suggester now uses a single JSON state file.
     writeUserCount(42);
-    compactCounter.write(100);
+    writeState({ ...emptyState(), tools: 100 });
 
     // Verify independence
     assert.strictEqual(readUserCount(), 42);

--- a/hooks/compact-suggester/README.md
+++ b/hooks/compact-suggester/README.md
@@ -6,7 +6,13 @@ Tracks tool call count and suggests `/compact` at strategic intervals.
 
 - **Threshold**: First suggestion at 50 tool calls
 - **Interval**: Reminders every 25 calls after threshold (75, 100, 125, ...)
-- **Reset**: Counter resets on session start/clear/compact
+- **Phase-aware**: messaging reflects the current phase using a rolling window of
+  the most recent 20 tool types (read-heavy / write-heavy / neutral), not the
+  lifetime average — so a long research phase early in the session no longer
+  masks a later implementation phase.
+- **Reset**: State is reset on every compaction by the PreCompact hook (via the
+  shared `getSuggesterStatePath()` helper), so suggestions never survive a
+  context boundary.
 
 ## Trigger
 
@@ -14,25 +20,48 @@ Runs on `PostToolUse` for ALL tools (matcher: `.*`)
 
 ## Storage
 
-Single JSON state file in temp directory:
+A single session-scoped JSON state file in the temp directory:
 ```
-$TMPDIR/arcforge-compact-state-<sessionId>
+$TMPDIR/arcforge-suggester-state-<sessionId>.json
 ```
 
-Format: `{ "tools": number, "reads": number, "writes": number }`
+Shape:
+```json
+{
+  "tools": 0,
+  "reads": 0,
+  "writes": 0,
+  "window": ["r", "w", "..."],
+  "suggestions": [{ "count": 50, "phase": "neutral", "at": "<iso>" }]
+}
+```
 
-All three counters (tool calls, read-tool count, write-tool count) are stored in one file to minimize I/O (1 read + 1 write per hook invocation).
+All counters, the rolling phase window, and the suggestion snapshots live in
+this one file (1 read + 1 write per hook invocation). The canonical path is
+owned by `getSuggesterStatePath()` in `scripts/lib/diary-capture.js` so the
+writer and the PreCompact resetter always agree on one filename.
+
+The separate `arcforge-tool-count-<sessionId>` file is the **diary threshold's**
+source of truth — incremented here via `incrementSharedToolCount()` (owned by
+diary-capture). It is intentionally distinct from the suggester's own counter so
+the diary trigger and the compaction suggestion share no fragile coupling.
+
+## Session record
+
+Each time a suggestion fires, a snapshot `{ count, phase, at }` is appended to
+the live session JSON (`suggestions[]`) so the timing of suggestions can later be
+correlated against compaction events.
 
 ## Output Examples
 
-At 50 calls:
+At 50 calls (neutral phase):
 ```
-📊 You've made 50 tool calls this session. Consider using /compact at your next phase boundary to preserve context quality.
+📊 50 tool calls this session. If you're between workflow phases, consider /compact to preserve context quality. Use arc-compacting for timing guidance.
 ```
 
 At 75, 100, 125... calls:
 ```
-📊 Now at 75 tool calls. Reminder: /compact helps maintain context quality for longer sessions.
+📊 75 tool calls. Between phases? /compact helps maintain context quality for longer sessions.
 ```
 
 ## Why This Matters

--- a/hooks/compact-suggester/main.js
+++ b/hooks/compact-suggester/main.js
@@ -10,8 +10,18 @@
  *
  * Triggered on PostToolUse for ALL tools.
  *
- * Performance: read/write tracking uses session-scoped file counters (same as tool-count)
- * since hooks run as fresh processes per event — in-memory state doesn't persist.
+ * State: a SINGLE session-scoped JSON file (getSuggesterStatePath) holds the
+ * tool counter, the rolling phase window, and the suggestion snapshots — 1 read
+ * + 1 write per event instead of three separate counter files. PreCompact resets
+ * this file on every compaction so suggestions never survive a context boundary.
+ *
+ * Phase detection uses a ROLLING WINDOW of the most recent tool types, so the
+ * suggested message reflects the current phase (read vs write heavy) rather than
+ * the lifetime average that early reads would otherwise dominate.
+ *
+ * The shared diary-trigger tool-count is incremented separately via
+ * incrementSharedToolCount() — that counter is owned by diary-capture and is the
+ * single source of truth for the diary threshold (binding coupling, do not drop).
  */
 
 const {
@@ -19,41 +29,51 @@ const {
   parseStdinJson,
   setSessionIdFromInput,
   output,
-  createSessionCounter,
+  readJsonFile,
+  writeJsonFile,
+  getTimestamp,
+  loadSession,
+  saveSession,
+  log,
 } = require('../../scripts/lib/utils');
-const { incrementSharedToolCount } = require('../../scripts/lib/diary-capture');
+const {
+  incrementSharedToolCount,
+  getSuggesterStatePath,
+} = require('../../scripts/lib/diary-capture');
 
 const THRESHOLD = 50; // First suggestion
 const INTERVAL = 25; // Subsequent reminders
 const MIN_PHASE_SAMPLES = 10;
+const WINDOW_SIZE = 20; // Rolling phase window: most recent tool types
 
 const WRITE_TOOLS = ['Write', 'Edit', 'NotebookEdit'];
 const READ_TOOLS = ['Read', 'Glob', 'Grep'];
 
-// All counters persist to disk — hooks run as fresh processes per event
-let toolCounter = null;
-let readCounter = null;
-let writeCounter = null;
-
-function getCounter() {
-  if (!toolCounter) {
-    toolCounter = createSessionCounter('compact-count');
-  }
-  return toolCounter;
+// Empty state shape — one JSON file per session holds everything.
+function emptyState() {
+  return { tools: 0, reads: 0, writes: 0, window: [], suggestions: [] };
 }
 
-function getReadCounter() {
-  if (!readCounter) {
-    readCounter = createSessionCounter('read-count');
-  }
-  return readCounter;
+/**
+ * Load the single suggester state file (1 read). Missing/corrupt → empty state.
+ */
+function readState() {
+  const state = readJsonFile(getSuggesterStatePath(), null);
+  if (!state || typeof state !== 'object') return emptyState();
+  return {
+    tools: Number(state.tools) || 0,
+    reads: Number(state.reads) || 0,
+    writes: Number(state.writes) || 0,
+    window: Array.isArray(state.window) ? state.window : [],
+    suggestions: Array.isArray(state.suggestions) ? state.suggestions : [],
+  };
 }
 
-function getWriteCounter() {
-  if (!writeCounter) {
-    writeCounter = createSessionCounter('write-count');
-  }
-  return writeCounter;
+/**
+ * Persist the single suggester state file (1 write).
+ */
+function writeState(state) {
+  writeJsonFile(getSuggesterStatePath(), state);
 }
 
 /**
@@ -64,33 +84,48 @@ function shouldSuggest(count) {
 }
 
 /**
- * Get read/write ratio from persisted counters
+ * Compute read/write counts from the rolling window (most recent tool types).
+ * @param {string[]} window - Array of 'r'/'w' entries, oldest first.
  * @returns {{ reads: number, writes: number, total: number }}
  */
-function getReadWriteRatio() {
-  const reads = getReadCounter().read();
-  const writes = getWriteCounter().read();
+function windowRatio(window) {
+  let reads = 0;
+  let writes = 0;
+  for (const t of window) {
+    if (t === 'r') reads++;
+    else if (t === 'w') writes++;
+  }
   return { reads, writes, total: reads + writes };
+}
+
+/**
+ * Classify a phase from a rolling window.
+ * @returns {'read-heavy'|'write-heavy'|'neutral'}
+ */
+function phaseFromWindow(window) {
+  const { reads, writes, total } = windowRatio(window);
+  if (total < MIN_PHASE_SAMPLES) return 'neutral';
+  if (reads / total > 0.7) return 'read-heavy';
+  if (writes / total > 0.6) return 'write-heavy';
+  return 'neutral';
 }
 
 /**
  * Check if a write-heavy phase should suppress non-critical reminders.
  * Suppresses at non-threshold counts below 100 during active implementation.
  */
-function shouldSuppressReminder(count) {
-  const { writes, total } = getReadWriteRatio();
-  const writeHeavy = total >= MIN_PHASE_SAMPLES && writes / total > 0.6;
+function shouldSuppressReminder(count, window) {
+  const writeHeavy = phaseFromWindow(window) === 'write-heavy';
   return writeHeavy && count !== THRESHOLD && count < 100;
 }
 
 /**
- * Build phase-aware suggestion message
+ * Build phase-aware suggestion message from the rolling window.
  */
-function buildMessage(count) {
-  const { reads, writes, total } = getReadWriteRatio();
-  const hasEnoughData = total >= MIN_PHASE_SAMPLES;
-  const readHeavy = hasEnoughData && reads / total > 0.7;
-  const writeHeavy = hasEnoughData && writes / total > 0.6;
+function buildMessage(count, window) {
+  const phase = phaseFromWindow(window);
+  const readHeavy = phase === 'read-heavy';
+  const writeHeavy = phase === 'write-heavy';
 
   if (count === THRESHOLD) {
     if (readHeavy) {
@@ -110,60 +145,97 @@ function buildMessage(count) {
 }
 
 /**
- * Track read/write tool usage via persisted counters
+ * Record a read/write classification into the rolling window + cumulative tallies.
+ * Mutates `state` in place. Returns the classification ('r'|'w'|null).
  */
-function trackToolType(input) {
+function trackToolType(state, input) {
   const toolName = input?.tool_name || '';
+  let kind = null;
   if (READ_TOOLS.some((t) => toolName.includes(t))) {
-    const c = getReadCounter();
-    c.write(c.read() + 1);
+    kind = 'r';
+    state.reads++;
   } else if (WRITE_TOOLS.some((t) => toolName.includes(t))) {
-    const c = getWriteCounter();
-    c.write(c.read() + 1);
+    kind = 'w';
+    state.writes++;
   }
+  if (kind) {
+    state.window.push(kind);
+    if (state.window.length > WINDOW_SIZE) {
+      state.window.splice(0, state.window.length - WINDOW_SIZE);
+    }
+  }
+  return kind;
+}
+
+/**
+ * Append a suggestion snapshot to the live session JSON (best-effort).
+ * Records the phase at suggestion time so ICL-12 can correlate suggestions
+ * against compactions. Silently skipped when no session file exists yet.
+ */
+function recordSessionSuggestion(snapshot) {
+  const session = loadSession();
+  if (!session) return;
+  session.suggestions = session.suggestions || [];
+  session.suggestions.push(snapshot);
+  saveSession(session);
 }
 
 /**
  * Main entry point
  */
 function main() {
-  const stdin = readStdinSync();
-  const input = parseStdinJson(stdin);
-  setSessionIdFromInput(input);
+  try {
+    const stdin = readStdinSync();
+    const input = parseStdinJson(stdin);
+    setSessionIdFromInput(input);
 
-  // Track read/write ratio via persisted counters (2 file I/O ops: read + write)
-  trackToolType(input);
+    // Single read of the consolidated state file.
+    const state = readState();
 
-  // NOTE: read-increment-write is not atomic, but hooks are serialized per event
-  // by Claude Code, so no race condition in practice. See scripts/lib/locking.js
-  // if atomic counters become necessary.
-  const counter = getCounter();
-  const currentCount = counter.read();
-  const newCount = currentCount + 1;
-  counter.write(newCount);
+    // Track read/write classification into the rolling window.
+    trackToolType(state, input);
 
-  // Also increment shared tool-count (used by diary threshold in session-tracker/end).
-  // SOLE increment path — owned by diary-capture so the diary and suggester
-  // thresholds share one source of truth (counter-ownership contract).
-  incrementSharedToolCount();
+    // Increment the suggester's own tool counter.
+    state.tools += 1;
 
-  // Check if suggestion is needed (suppress during write-heavy phases at non-threshold counts)
-  if (shouldSuggest(newCount)) {
-    if (shouldSuppressReminder(newCount)) {
+    // Increment the shared diary tool-count (owned by diary-capture). This is the
+    // diary threshold's source of truth — keep this call to preserve the binding.
+    incrementSharedToolCount();
+
+    // Decide whether to suggest; record the snapshot before persisting state.
+    if (shouldSuggest(state.tools) && !shouldSuppressReminder(state.tools, state.window)) {
+      const snapshot = {
+        count: state.tools,
+        phase: phaseFromWindow(state.window),
+        at: getTimestamp(),
+      };
+      state.suggestions.push(snapshot);
+      recordSessionSuggestion(snapshot);
+      writeState(state);
+      output({ systemMessage: buildMessage(state.tools, state.window) });
       return;
     }
-    output({ systemMessage: buildMessage(newCount) });
+
+    // Single write of the consolidated state file.
+    writeState(state);
+  } catch (e) {
+    // Hooks must never crash the session.
+    log(`[compact-suggester] Warning: ${e.message}`);
   }
 }
 
 module.exports = {
-  readCount: () => getCounter().read(),
-  getCounterFilePath: () => getCounter().getFilePath(),
+  emptyState,
+  readState,
+  writeState,
+  readCount: () => readState().tools,
+  getStateFilePath: getSuggesterStatePath,
   shouldSuggest,
   shouldSuppressReminder,
   buildMessage,
   trackToolType,
-  getReadWriteRatio,
+  windowRatio,
+  phaseFromWindow,
 };
 
 // Run if executed directly

--- a/hooks/pre-compact/main.js
+++ b/hooks/pre-compact/main.js
@@ -8,6 +8,7 @@
  * Non-blocking: Always exits 0 to avoid disrupting compaction flow.
  */
 
+const fs = require('node:fs');
 const path = require('node:path');
 const {
   getSessionDir,
@@ -25,7 +26,24 @@ const {
   saveSession,
 } = require('../../scripts/lib/utils');
 const { addPendingAction } = require('../../scripts/lib/pending-actions');
-const { runDiaryCapture } = require('../../scripts/lib/diary-capture');
+const { runDiaryCapture, getSuggesterStatePath } = require('../../scripts/lib/diary-capture');
+
+/**
+ * Reset the compact-suggester state on every compaction.
+ *
+ * Uses the shared getSuggesterStatePath() helper so the resetter and the
+ * suggester writer always agree on one filename (S5-4) — and so it inherits the
+ * stdin-derived session id resolved above. Without this, suggestion snapshots
+ * from before a compaction would survive into the freshly compacted context and
+ * "zero after compaction" would never land.
+ */
+function resetSuggesterState() {
+  try {
+    fs.rmSync(getSuggesterStatePath(), { force: true });
+  } catch {
+    // Best-effort; never block compaction.
+  }
+}
 
 /**
  * Update session file with compaction marker
@@ -73,6 +91,11 @@ function main() {
     // Update session file with compaction marker
     updateSessionFile(project, date, timestamp, sessionId);
 
+    // Reset the compact-suggester state on EVERY compaction (unconditional,
+    // independent of the diary threshold) so suggestions don't survive the
+    // context boundary.
+    resetSuggesterState();
+
     // Shared diary-capture core: threshold gate → draft → background enricher
     // → counter reset. Enricher fires on PreCompact too (dual-path ON).
     const { triggered, userCount, toolCount } = runDiaryCapture({ project, date, sessionId });
@@ -108,7 +131,7 @@ function main() {
 }
 
 // Export for testing
-module.exports = { updateSessionFile };
+module.exports = { updateSessionFile, resetSuggesterState };
 
 // Run if executed directly
 if (require.main === module) {

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -22,6 +22,7 @@ const {
   getSessionId,
   getTimestamp,
   output,
+  log,
 } = require('../../scripts/lib/utils');
 const { addPendingAction } = require('../../scripts/lib/pending-actions');
 const { runDiaryCapture, readCounts } = require('../../scripts/lib/diary-capture');
@@ -102,11 +103,22 @@ function formatStats(session) {
 }
 
 /**
- * Format short message for stderr output (when threshold is not met)
+ * Format the below-threshold session-paused message. Logged to stderr only —
+ * counters are genuinely preserved because the diary threshold did not fire.
  */
 function formatShortMessage(userCount, toolCount) {
   return `📝 Session paused. (${userCount} messages, ${toolCount} tool calls)
    Counters preserved for next resume.`;
+}
+
+/**
+ * Format the triggered session-paused message. Surfaced to the user
+ * (systemMessage) when the diary threshold fired — a diary draft was captured
+ * and the counters were reset for the next session.
+ */
+function formatTriggeredMessage(userCount, toolCount) {
+  return `📝 Session paused. (${userCount} messages, ${toolCount} tool calls)
+   Diary captured; counters reset for next session.`;
 }
 
 /**
@@ -161,9 +173,13 @@ function main() {
         count: reflectStatus.count,
       });
     }
+    // Only surface the 'Session paused' notification when the diary threshold
+    // actually fired — a Stop worth telling the user about. Below threshold a
+    // per-Stop user message is noise, so it is downgraded to a stderr log.
+    output({ systemMessage: formatTriggeredMessage(userCount, toolCount) });
+  } else {
+    log(formatShortMessage(userCount, toolCount));
   }
-
-  output({ systemMessage: formatShortMessage(userCount, toolCount) });
 
   process.exit(0);
 }
@@ -175,6 +191,7 @@ module.exports = {
   saveSessionJson,
   formatStats,
   formatShortMessage,
+  formatTriggeredMessage,
   checkReflectReady,
 };
 

--- a/scripts/lib/operation-record-writer.js
+++ b/scripts/lib/operation-record-writer.js
@@ -20,6 +20,12 @@ const { atomicWriteFile } = require('./utils');
 // reflect → reflections (not "reflects") matches the spec storage path.
 const KIND_DIRS = { reflect: 'reflections', recall: 'recalls' };
 
+// Filename prefix the curator batch-assembler matches on
+// (^reflect-.*\.md$ / ^recall-.*\.md$ in learning-curator/batch-assembler.js).
+// The id becomes `<id>.md`, so the id MUST carry this prefix or the assembler
+// silently skips the record. Fail fast at the writer instead.
+const KIND_ID_PREFIX = { reflect: 'reflect-', recall: 'recall-' };
+
 /**
  * Serialize a YAML frontmatter list field, or emit `[]` when empty.
  * Note: relies on existing project convention (hand-rolled YAML, not js-yaml).
@@ -68,6 +74,18 @@ function writeOperationRecord({
   const homeDir = homeOverride || os.homedir();
   const dirName = KIND_DIRS[kind];
   if (!dirName) throw new Error(`writeOperationRecord: unknown kind "${kind}"`);
+
+  // Fail fast when the id lacks the prefix the curator batch-assembler matches
+  // on — otherwise the record writes successfully but is invisible to the
+  // assembler, a silent provenance gap (ICL-5).
+  const prefix = KIND_ID_PREFIX[kind];
+  if (!id.startsWith(prefix)) {
+    throw new Error(
+      `writeOperationRecord: ${kind} id must start with "${prefix}" so the curator ` +
+        `batch-assembler can match it (got "${id}")`,
+    );
+  }
+
   const dir = path.join(homeDir, '.arcforge', dirName, project);
   const filePath = path.join(dir, `${id}.md`);
 

--- a/skills/arc-recalling/SKILL.md
+++ b/skills/arc-recalling/SKILL.md
@@ -16,6 +16,7 @@ Save patterns and insights from the current session as instincts. This skill bri
 |------|---------|
 | **Save instinct** | `node "${SKILL_ROOT}/scripts/recall.js" save --id {id} --trigger "..." --action "..." --domain {d} --project {p}` |
 | **Check duplicate** | `node "${SKILL_ROOT}/scripts/recall.js" check-duplicate --id {id} --project {p}` |
+| **Save record** | `node "${SKILL_ROOT}/scripts/recall.js" save-record --project {p} --recall-id recall-{id} [--query "..."] [--instinct-ids "a,b,c"] [--summary "..."]` |
 
 ## Infrastructure Commands
 
@@ -43,6 +44,18 @@ fi
    - `source: 'manual'`
    - `confidence: 0.50` (starting confidence for manual instincts)
    - `maxConfidence: 0.90` (manual instincts use full MAX_CONFIDENCE)
+6. **Save record** of the recall operation so the learning curator has evidence
+   that this recall happened:
+   ```bash
+   node "${SKILL_ROOT}/scripts/recall.js" save-record \
+     --project {project} \
+     --recall-id recall-{id} \
+     --query "{what the user wanted to remember}" \
+     --instinct-ids "{saved-instinct-id}" \
+     --summary "{one-line summary}"
+   ```
+   The `--recall-id` MUST start with `recall-` (the curator batch-assembler only
+   matches `recall-*.md` records).
 
 ## When to Use
 

--- a/skills/arc-recalling/scripts/recall.js
+++ b/skills/arc-recalling/scripts/recall.js
@@ -111,7 +111,8 @@ function main() {
       console.log('Usage: recall.js <command> [options]\n');
       console.log('Commands:');
       console.log('  save                  Save a new instinct');
-      console.log('  check-duplicate       Check if instinct name exists\n');
+      console.log('  check-duplicate       Check if instinct name exists');
+      console.log('  save-record           Save a recall operation record (curator evidence)\n');
       console.log('Options:');
       console.log('  --id <name>           Instinct ID (kebab-case)');
       console.log('  --trigger "..."       When to apply');
@@ -119,7 +120,13 @@ function main() {
       console.log('  --project <name>      Project name');
       console.log('  --domain <name>       Category (default: uncategorized)');
       console.log('  --evidence "..."      Supporting context');
-      console.log('  --evidence-count <N>  Number of times observed (default: 1)');
+      console.log('  --evidence-count <N>  Number of times observed (default: 1)\n');
+      console.log('save-record options:');
+      console.log('  --recall-id <id>      Record ID — MUST start with "recall-"');
+      console.log('  --project <name>      Project name');
+      console.log('  --query "..."         The recall query (optional)');
+      console.log('  --instinct-ids "a,b"  Returned instinct ids, comma-separated (optional)');
+      console.log('  --summary "..."       Summary of the recall (optional)');
       break;
   }
 }

--- a/skills/arc-reflecting/SKILL.md
+++ b/skills/arc-reflecting/SKILL.md
@@ -19,6 +19,7 @@ Analyze multiple diary entries to identify recurring patterns. Save insights to 
 | **Pattern threshold** | 3+ occurrences = Pattern, 1-2 = Observation |
 | **Rule violations** | Check CLAUDE.md first, report violations with evidence |
 | **Save instinct** | `node "${SKILL_ROOT}/scripts/reflect.js" save-instinct --project {p} --id {id} --trigger "..." --action "..." [--domain D] [--evidence "..."] [--evidence-count N]` |
+| **Save record** | `node "${SKILL_ROOT}/scripts/reflect.js" save-record --project {p} --reflect-id reflect-{id} [--diaries "a,b,c"] [--summary "..."]` |
 | **Strategy modes** | unprocessed (5+ new) \| project_focused (5+ total) \| recent_window (fallback) |
 
 ## Infrastructure Commands
@@ -258,7 +259,18 @@ For rule violations, additionally inform:
      --evidence "{source diary references}" \
      --evidence-count {N}
    ```
-5. Confirm save location, processed.log update, and instincts saved
+5. **Save a reflection record** so the learning curator has evidence that this
+   reflection happened:
+   ```bash
+   node "${SKILL_ROOT}/scripts/reflect.js" save-record \
+     --project {project} \
+     --reflect-id reflect-{id} \
+     --diaries "{analyzed diary filenames}" \
+     --summary "{one-line summary of the reflection}"
+   ```
+   The `--reflect-id` MUST start with `reflect-` (the curator batch-assembler
+   only matches `reflect-*.md` records).
+6. Confirm save location, processed.log update, and instincts saved
 
 ## Key Principles
 

--- a/tests/scripts/operation-record-roundtrip.test.js
+++ b/tests/scripts/operation-record-roundtrip.test.js
@@ -1,0 +1,161 @@
+// tests/scripts/operation-record-roundtrip.test.js
+//
+// ICL-5 round-trip: a reflect/recall record written by operation-record-writer.js
+// MUST be picked up by the learning-curator batch-assembler. The coupling is the
+// filename prefix — the writer fail-fasts on a missing prefix, and the assembler
+// only matches ^reflect-.*\.md$ / ^recall-.*\.md$. If the schemas ever diverge
+// this test goes red instead of the record silently vanishing.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+let tmpDir;
+let homedirSpy;
+
+beforeEach(() => {
+  jest.resetModules();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcforge-roundtrip-test-'));
+  // The assembler reads os.homedir() at call time — redirect it to the tmp HOME.
+  homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tmpDir);
+});
+
+afterEach(() => {
+  homedirSpy.mockRestore();
+  jest.resetModules();
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+function getWriter() {
+  return require('../../scripts/lib/operation-record-writer');
+}
+
+function getAssembler() {
+  return require('../../scripts/lib/learning-curator/batch-assembler');
+}
+
+function readManifest(result) {
+  return JSON.parse(fs.readFileSync(result.manifest_path, 'utf8'));
+}
+
+describe('operation-record-writer → batch-assembler round-trip', () => {
+  test('a reflect record written by the writer is selected by the assembler', () => {
+    const { saveReflectionRecord } = getWriter();
+    const project = 'roundtrip-project';
+
+    saveReflectionRecord({
+      reflect_id: 'reflect-20260615T010000Z-aaaa1111',
+      project,
+      project_id: 'proj_roundtrip',
+      session: 'session-rt',
+      created_at: '2026-06-15T01:00:00.000Z',
+      source_diary_ids: ['diary-1', 'diary-2'],
+      summary: 'Reflected on grep-before-edit pattern.',
+      homeDir: tmpDir,
+    });
+
+    const { assembleBatch } = getAssembler();
+    const result = assembleBatch({ project });
+    const manifest = readManifest(result);
+
+    expect(manifest.source_windows.reflects.records_scanned).toBe(1);
+    expect(manifest.source_windows.reflects.records_selected).toBe(1);
+  });
+
+  test('a recall record written by the writer is selected by the assembler', () => {
+    const { saveRecallRecord } = getWriter();
+    const project = 'roundtrip-project';
+
+    saveRecallRecord({
+      recall_id: 'recall-20260615T010000Z-bbbb2222',
+      project,
+      project_id: 'proj_roundtrip',
+      session: 'session-rt',
+      created_at: '2026-06-15T01:00:00.000Z',
+      recall_query: 'grep patterns',
+      returned_instinct_ids: ['grep-before-edit'],
+      summary: 'Recalled grep instinct.',
+      homeDir: tmpDir,
+    });
+
+    const { assembleBatch } = getAssembler();
+    const result = assembleBatch({ project });
+    const manifest = readManifest(result);
+
+    expect(manifest.source_windows.recalls.records_scanned).toBe(1);
+    expect(manifest.source_windows.recalls.records_selected).toBe(1);
+    expect(manifest.quality_inputs.signal_mix.has_manual_recall).toBe(true);
+  });
+});
+
+describe('operation-record-writer prefix fail-fast (assembler-match guard)', () => {
+  test('reflect id without "reflect-" prefix throws', () => {
+    const { saveReflectionRecord } = getWriter();
+    expect(() =>
+      saveReflectionRecord({
+        reflect_id: '20260615-no-prefix',
+        project: 'p',
+        project_id: '',
+        session: '',
+        created_at: '2026-06-15T01:00:00.000Z',
+        source_diary_ids: [],
+        summary: '',
+        homeDir: tmpDir,
+      }),
+    ).toThrow(/must start with "reflect-"/);
+  });
+
+  test('recall id without "recall-" prefix throws', () => {
+    const { saveRecallRecord } = getWriter();
+    expect(() =>
+      saveRecallRecord({
+        recall_id: '20260615-no-prefix',
+        project: 'p',
+        project_id: '',
+        session: '',
+        created_at: '2026-06-15T01:00:00.000Z',
+        recall_query: '',
+        returned_instinct_ids: [],
+        summary: '',
+        homeDir: tmpDir,
+      }),
+    ).toThrow(/must start with "recall-"/);
+  });
+
+  test('a prefix-violating reflect id is never silently dropped by the assembler', () => {
+    // Confirm the negative side of the coupling: had the writer NOT fail-fast,
+    // a non-prefixed file would be invisible to the assembler. We seed a raw,
+    // wrongly-named file and verify the assembler skips it — which is exactly
+    // why the writer must reject the id up front.
+    const { saveReflectionRecord } = getWriter();
+    const project = 'guard-project';
+
+    // Manually write a wrongly-named record (bypassing the writer's guard).
+    const dir = path.join(tmpDir, '.arcforge', 'reflections', project);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'bad-name.md'), '---\nreflect_id: bad-name\n---\n');
+
+    // And a correctly-prefixed one via the writer.
+    saveReflectionRecord({
+      reflect_id: 'reflect-good-id',
+      project,
+      project_id: '',
+      session: '',
+      created_at: '2026-06-15T01:00:00.000Z',
+      source_diary_ids: [],
+      summary: 'good',
+      homeDir: tmpDir,
+    });
+
+    const { assembleBatch } = getAssembler();
+    const manifest = readManifest(assembleBatch({ project }));
+
+    // Only the prefixed record is scanned/selected — the bad-name one is invisible.
+    expect(manifest.source_windows.reflects.records_scanned).toBe(1);
+    expect(manifest.source_windows.reflects.records_selected).toBe(1);
+  });
+});


### PR DESCRIPTION
## Wave 4 · ICL-5 + ICL-9 + ICL-11 — 學習通道接線 (one PR, disjoint files)

### ICL-5 — save-record 接線
- arc-reflecting + arc-recalling SKILL.md gain a workflow step + command-table row for save-record.
- `arc-recalling/scripts/recall.js` help adds save-record; `^reflect-`/`^recall-` prefix **fail-fast validation** so the batch-assembler pattern matches.
- round-trip test (`operation-record-roundtrip.test.js`).

### ICL-9 — compact-suggester 大修
- Three `createSessionCounter` instances → **single JSON state file**; reset goes through diary-capture's exported `getSuggesterStatePath()` (S5-4) + inherits pre-compact's stdin session-id fix.
- pre-compact resets suggester state on **every** compaction; rolling-window phase detection; `suggestions[]` into session JSON; README honesty.
- **Binding regression**: diary threshold stays triggerable throughout the merge.

### ICL-11 — Stop 通道閾值閘控
- `session-tracker/end.js`: 'Session paused' emitted **only above threshold**; below → stderr log only.

### Acceptance (replayed by reviewer)
- 60 events→50 suggestions→sim pre-compact→30 more → **no stale** ✅ · 40R+20W → writeHeavy ✅ · exactly one state file + shared tool-count in TMPDIR ✅ · session JSON has `suggestions[]` ✅ · diary-threshold binding regression holds ✅ · round-trip ✅ · `test:hooks` + full `npm test` green ✅

No stop conditions fired (assembler schema matched; no locking.js escalation; no liveness dependency on per-Stop message).

### Iron Law
arc-reflecting/arc-recalling behavioral edits → **eval deferred to Wave 6 ICL-13**.