### PR TITLE
feat(cli): flip doc-refs R4 skill-name resolution to gating (SRH-5 R4-flip)

### DIFF
--- a/docs/guide/skills-reference.md
+++ b/docs/guide/skills-reference.md
@@ -865,8 +865,8 @@ arc-brainstorming --> arc-refining --> arc-planning --> arc-using-worktrees
                               arc-coordinating --> arc-implementing
                                    |                    |
                                    v                    v
-                              arc-dispatching      arc-agent-driven
-                              -parallel                 |
+                          arc-dispatching-parallel  arc-agent-driven
+                                                        |
                                                         v
                                                   arc-finishing
 ```
@@ -951,6 +951,6 @@ ArcForge's Living SDD pipeline assigns each spec-related job to exactly one owne
 |-------|------|--------------|
 | `arc-refining` | Formalizing design docs into authoritative `specs/<spec-id>/spec.xml` + `details/*.xml` | Completion-claim verification; post-implementation spec sync |
 | `arc-verifying` | Producing fresh evidence before completion claims | Authoring spec artifacts; reconciling spec/code drift |
-| `arc-syncing-spec` (future, optional) | Post-implementation / drift sync of spec artifacts from code, tests, and decisions | Initial formalization; gating completion claims |
+| `arc-syncing-spec` (future, optional) | Post-implementation / drift sync of spec artifacts from code, tests, and decisions | Initial formalization; gating completion claims | <!-- doc-ref-lint: ignore R4 arc-syncing-spec is an intentional test-pinned boundary reference to a future opt-in skill that does not ship today (plan §1.11) -->
 
-`arc-syncing-spec` is not a shipped skill today. If and when it is added, it MUST ship as a separate opt-in workflow skill — never as language injected by the SessionStart bootstrap, the `arc-using` router, or any always-on instruction surface. The minimal-toolkit posture and harness/eval isolation depend on this boundary holding.
+`arc-syncing-spec` is not a shipped skill today. If and when it is added, it MUST ship as a separate opt-in workflow skill — never as language injected by the SessionStart bootstrap, the `arc-using` router, or any always-on instruction surface. The minimal-toolkit posture and harness/eval isolation depend on this boundary holding. <!-- doc-ref-lint: ignore R4 arc-syncing-spec is an intentional test-pinned boundary reference to a future opt-in skill that does not ship today (plan §1.11) -->

--- a/hooks/arc-remind/README.md
+++ b/hooks/arc-remind/README.md
@@ -59,7 +59,7 @@ PostToolUse cannot block; this hook only ever reminds.
 
 ## State
 
-Tracks a per-session `arc-remind-test-seen` counter (incremented when a test
+Tracks a per-session `arc-remind-test-seen` counter (incremented when a test <!-- doc-ref-lint: ignore R4 arc-remind-test-seen is a per-session state counter name, not a skill/hook/agent reference -->
 runner command is seen) so the reminder can note when no verification ran, and
 a hook-local per-session JSON list of the SKILL.md paths edited this session
 (feeding the freshness comparison above).

--- a/scripts/check-doc-refs.js
+++ b/scripts/check-doc-refs.js
@@ -9,11 +9,10 @@
  * skill names (R4) match what the engine actually ships.
  *
  * Exit code reflects GATING findings only: any finding whose severity is
- * 'error' fails the check (exit 1). 'warn'-severity findings (R4 today — see
- * doc-refs.js R4_SEVERITY) are printed but do NOT affect the exit code, so the
- * pre-WT-6 tree (which still carries skills/arc-finishing-epic/ and live
- * references to it) stays green. R4 flips to gating in the SRH-5 CI follow-up
- * once WT-6 has merged.
+ * 'error' fails the check (exit 1). All four rules now gate — R4 flipped to
+ * 'error' in the SRH-5 R4-flip follow-up (WT-6 has merged, so the finishing
+ * twin no longer dangles). 'warn'-severity findings, if any are ever added,
+ * are printed but do NOT affect the exit code.
  *
  * CLI tier: prints a human-readable report and exits 0/1.
  */
@@ -56,9 +55,18 @@ function pathExists(relPath, docDir) {
   return false;
 }
 
-/** Existence probe for a skill directory. */
-function skillExists(skillName) {
-  return fs.existsSync(path.join(repoRoot, 'skills', skillName));
+/**
+ * Existence probe for a backticked arc-<name> reference. Resolves against all
+ * three component trees a doc may legitimately name: a skill dir, a hook dir,
+ * or an agent file. (arc-guard / arc-remind are hooks; arc-auditing-spec-*
+ * are dispatched agents — neither lives under skills/.)
+ */
+function skillExists(name) {
+  return (
+    fs.existsSync(path.join(repoRoot, 'skills', name)) ||
+    fs.existsSync(path.join(repoRoot, 'hooks', name)) ||
+    fs.existsSync(path.join(repoRoot, 'agents', `${name}.md`))
+  );
 }
 
 function gatherFiles() {

--- a/scripts/lib/doc-refs.js
+++ b/scripts/lib/doc-refs.js
@@ -16,14 +16,14 @@
  *                 promise tied to a command) must exist in that command's
  *                 manifest `output` shape (only checked for commands whose
  *                 shape is pinned — `output !== null`).
- *   R4  skills  — a backticked `arc-<name>` skill reference must resolve to an
- *                 existing `skills/<name>/` directory. SHIPPED WARN-ONLY in this
- *                 PR: WT-6 (the finishing-twin merge that deletes
- *                 skills/arc-finishing-epic/) has not landed yet, so gating R4
- *                 now would false-positive on the live tree and on sibling
- *                 Wave-3 branches that still reference the old name. R4 flips to
- *                 gating (severity 'error') in the SRH-5 CI follow-up once WT-6
- *                 has merged. See R4_SEVERITY below.
+ *   R4  skills  — a backticked `arc-<name>` reference must resolve to an
+ *                 existing `skills/<name>/` directory, `hooks/<name>/` directory,
+ *                 or `agents/<name>.md` file (the caller-supplied skillExists
+ *                 probe resolves against all three component trees, since a
+ *                 backticked arc-<name> token equally names a skill, a hook, or
+ *                 a dispatched agent). GATING (severity 'error') as of the
+ *                 SRH-5 R4-flip follow-up — WT-6 has merged, so the finishing
+ *                 twin no longer dangles. See R4_SEVERITY below.
  *
  * The manifest (scripts/lib/cli-manifest.js) is the SINGLE source of truth for
  * R2 flags and R3 field promises — this engine reads it and is FORBIDDEN a
@@ -41,8 +41,8 @@
 
 const { CLI_MANIFEST } = require('./cli-manifest');
 
-// R4 ships warn-only this PR; flips to 'error' (gating) after WT-6 lands.
-const R4_SEVERITY = 'warn';
+// R4 is gating (WT-6 has merged; the finishing twin no longer dangles).
+const R4_SEVERITY = 'error';
 
 // Top-level dirs whose paths we are willing to assert exist. Restricted to the
 // engine/agent/skill/hook/template CODE surface — the layers whose paths are a
@@ -414,6 +414,15 @@ function scanR4Skills(file, spans, skillExists) {
   for (const { text, line } of spans) {
     for (const m of text.matchAll(re)) {
       const name = m[0];
+      const before = m.index > 0 ? text[m.index - 1] : '';
+      const after = text[m.index + name.length] || '';
+      // Skip arc-<name> embedded in a path (`skills/arc-releasing/SKILL.md`):
+      // that is a path component, owned by R1, not a standalone skill reference.
+      if (before === '/' || after === '/') continue;
+      // Skip eval-scenario identifiers (`eval-arc-using-harness-isolation`):
+      // these are eval labels, not a claim that a component named arc-<name>
+      // ships. R4 polices handoff/reference promises, not the eval catalog.
+      if (text.slice(Math.max(0, m.index - 5), m.index) === 'eval-') continue;
       if (!skillExists(name)) {
         findings.push(
           makeFinding(
@@ -421,7 +430,7 @@ function scanR4Skills(file, spans, skillExists) {
             R4_SEVERITY,
             file,
             line,
-            `skill reference does not resolve to skills/${name}/ (warn-only until WT-6; flips to gating in SRH-5)`,
+            `reference does not resolve to skills/${name}/, hooks/${name}/, or agents/${name}.md`,
           ),
         );
       }

--- a/skills/arc-refining/SKILL.md
+++ b/skills/arc-refining/SKILL.md
@@ -23,13 +23,13 @@ Transform design documents into structured XML specifications. The spec becomes 
 
 ## Boundary
 
-`arc-refining` owns formalizing design docs into authoritative `specs/<spec-id>/spec.xml` and `details/*.xml`. It does not own completion-claim verification (that is `arc-verifying`) and it does not own post-implementation spec sync or spec/code drift reconciliation (that is the optional, separate, future `arc-syncing-spec` workflow — never folded into the SessionStart bootstrap or the `arc-using` router).
+`arc-refining` owns formalizing design docs into authoritative `specs/<spec-id>/spec.xml` and `details/*.xml`. It does not own completion-claim verification (that is `arc-verifying`) and it does not own post-implementation spec sync or spec/code drift reconciliation (that is the optional, separate, future `arc-syncing-spec` workflow — never folded into the SessionStart bootstrap or the `arc-using` router). <!-- doc-ref-lint: ignore R4 arc-syncing-spec is an intentional test-pinned boundary reference to a future opt-in skill that does not ship today (plan §1.11) -->
 
 ## When NOT to Use
 
 - No design doc exists yet (run `/arc-brainstorming` first)
 - Task is small enough that a structured spec is overhead
-- Spec is already authoritative and the work is reconciling it with post-implementation reality — that is the `arc-syncing-spec` job (separate, opt-in workflow), not refiner
+- Spec is already authoritative and the work is reconciling it with post-implementation reality — that is the `arc-syncing-spec` job (separate, opt-in workflow), not refiner <!-- doc-ref-lint: ignore R4 arc-syncing-spec is an intentional test-pinned boundary reference to a future opt-in skill that does not ship today (plan §1.11) -->
 
 ## Core Rules
 

--- a/skills/arc-verifying/SKILL.md
+++ b/skills/arc-verifying/SKILL.md
@@ -11,7 +11,7 @@ description: Use when you need to verify work is complete before making completi
 
 ## Boundary
 
-`arc-verifying` owns producing fresh evidence for completion claims. It does not own authoring spec artifacts (that is `arc-refining`) and it does not own reconciling spec/code drift after implementation (that is the optional, separate, future `arc-syncing-spec` workflow — never folded into the SessionStart bootstrap or the `arc-using` router). Spec/code drift checks may quote verification evidence as input, but verification itself is not a spec-sync skill.
+`arc-verifying` owns producing fresh evidence for completion claims. It does not own authoring spec artifacts (that is `arc-refining`) and it does not own reconciling spec/code drift after implementation (that is the optional, separate, future `arc-syncing-spec` workflow — never folded into the SessionStart bootstrap or the `arc-using` router). Spec/code drift checks may quote verification evidence as input, but verification itself is not a spec-sync skill. <!-- doc-ref-lint: ignore R4 arc-syncing-spec is an intentional test-pinned boundary reference to a future opt-in skill that does not ship today (plan §1.11) -->
 
 ## The Iron Law
 

--- a/skills/arc-writing-skills/SKILL.md
+++ b/skills/arc-writing-skills/SKILL.md
@@ -264,9 +264,9 @@ Use words Claude would search for:
 | `arc-<acronym>` | Well-known abbreviation | `arc-tdd` |
 
 **Avoid:**
-- Agent-nouns: `arc-coordinator` → `arc-coordinating`
-- Bare verbs: `arc-debug` → `arc-debugging`
-- Noun-first: `arc-task-writer` → `arc-writing-tasks`
+- Agent-nouns: `arc-coordinator` → `arc-coordinating` <!-- doc-ref-lint: ignore R4 deliberately-wrong naming anti-pattern shown for teaching, not a skill reference -->
+- Bare verbs: `arc-debug` → `arc-debugging` <!-- doc-ref-lint: ignore R4 deliberately-wrong naming anti-pattern shown for teaching, not a skill reference -->
+- Noun-first: `arc-task-writer` → `arc-writing-tasks` <!-- doc-ref-lint: ignore R4 deliberately-wrong naming anti-pattern shown for teaching, not a skill reference -->
 
 ### 4. Token Efficiency
 

--- a/tests/scripts/doc-refs.test.js
+++ b/tests/scripts/doc-refs.test.js
@@ -9,9 +9,13 @@
  *     real cli-manifest.js (no second copy of flag data).
  *   - R3 (field): a `--json` field promise absent from the command's pinned
  *     output shape; plus a NEGATIVE case proving piped-jq selectors validate.
- *   - R4 (skill): a backticked `arc-<name>` that does not resolve to a skill
- *     dir — asserted as WARN severity (warn-only this PR; flips after WT-6),
- *     plus a good skill name that produces nothing.
+ *   - R4 (skill): a backticked `arc-<name>` that does not resolve to a skill,
+ *     hook, or agent — asserted as ERROR severity (GATING as of the SRH-5
+ *     R4-flip), plus a good name that produces nothing. The R4-flip regression
+ *     proves a genuinely-dangling reference still trips gating after the
+ *     false-positive-reducing heuristics were added (hook/agent resolution,
+ *     eval-scenario skip, path-component skip) — the analog of the deliberate
+ *     broken-commit proof: a hollow gate that exempted everything would fail it.
  *   - ignore: a directive suppresses the matching rule on its line; a
  *     reason-less directive is itself a finding.
  */
@@ -140,7 +144,7 @@ describe('doc-refs engine (SRH-4)', () => {
     });
   });
 
-  describe('R4 — skill references (WARN-ONLY this PR)', () => {
+  describe('R4 — skill/hook/agent references (GATING since the SRH-5 R4-flip)', () => {
     test('a good skill name (resolves to a skill dir) produces nothing', () => {
       const doc = 'Hand off to `arc-finishing` when done.\n';
       const { findings } = lintDoc('skills/x/SKILL.md', doc, {
@@ -150,7 +154,9 @@ describe('doc-refs engine (SRH-4)', () => {
       expect(findings.filter((f) => f.rule === 'R4')).toHaveLength(0);
     });
 
-    test('a bad skill name is a WARN finding (dangling-skill-name defect class)', () => {
+    test('R4-flip: a genuinely-dangling reference is a GATING (error) finding', () => {
+      // The deliberate-break proof — the analog of SRH-5's broken-commit gate
+      // proof. The false-positive heuristics below must NOT swallow a real one.
       const doc = 'Hand off to `arc-finishing-epic` when done.\n';
       const { findings } = lintDoc('skills/x/SKILL.md', doc, {
         pathExists: () => true,
@@ -158,9 +164,43 @@ describe('doc-refs engine (SRH-4)', () => {
       });
       const r4 = findings.filter((f) => f.rule === 'R4');
       expect(r4).toHaveLength(1);
-      expect(r4[0].severity).toBe('warn');
+      expect(r4[0].severity).toBe('error');
       expect(r4[0].severity).toBe(R4_SEVERITY);
       expect(r4[0].message).toContain('arc-finishing-epic');
+    });
+
+    test('a name that resolves only as a hook or agent (not a skill) produces nothing', () => {
+      // arc-guard/arc-remind are hooks; arc-auditing-spec-* are agents — the
+      // caller-supplied probe resolves arc-<name> against all three trees.
+      const doc = 'See `arc-guard` and `arc-auditing-spec-internal-consistency`.\n';
+      const { findings } = lintDoc('hooks/README.md', doc, {
+        pathExists: () => true,
+        skillExists: (name) =>
+          name === 'arc-guard' || name === 'arc-auditing-spec-internal-consistency',
+      });
+      expect(findings.filter((f) => f.rule === 'R4')).toHaveLength(0);
+    });
+
+    test('an eval-scenario identifier (eval-arc-<name>) is not an R4 finding', () => {
+      // `eval-arc-using-harness-isolation` is an eval label, not a claim that a
+      // component named arc-using-harness-isolation ships.
+      const doc = 'Scenario `eval-arc-using-harness-isolation` covers isolation.\n';
+      const { findings } = lintDoc('docs/guide/composable-skill-eval-coverage.md', doc, {
+        pathExists: () => true,
+        skillExists: () => false,
+      });
+      expect(findings.filter((f) => f.rule === 'R4')).toHaveLength(0);
+    });
+
+    test('arc-<name> embedded in a path is a path component (R1 owns it), not R4', () => {
+      // `skills/arc-releasing/SKILL.md` — the arc-releasing segment is a path,
+      // not a standalone skill reference, so R4 must not fire on it.
+      const doc = 'Target `skills/arc-releasing/SKILL.md`.\n';
+      const { findings } = lintDoc('docs/guide/x.md', doc, {
+        pathExists: () => true, // path resolves → no R1 either; isolate R4
+        skillExists: () => false,
+      });
+      expect(findings.filter((f) => f.rule === 'R4')).toHaveLength(0);
     });
   });
 
@@ -228,10 +268,10 @@ describe('doc-refs engine (SRH-4)', () => {
       expect(rulesOf(findings)).toEqual(['R3']);
     });
 
-    test('R4 mutation: residual arc-finishing-epic reference (warn-only)', () => {
+    test('R4 mutation: residual arc-finishing-epic reference (gating)', () => {
       const { findings } = lintDoc('skills/x/SKILL.md', 'Then run `arc-finishing-epic`.', probes);
       expect(rulesOf(findings)).toEqual(['R4']);
-      expect(findings[0].severity).toBe('warn');
+      expect(findings[0].severity).toBe('error');
     });
   });
 


### PR DESCRIPTION
## Wave 5 · SRH-5 R4-flip — 完成 SRH-5（#101 延後的設計修復）

Flips doc-refs **R4** (backticked `arc-<name>` skill-name resolution) from warn-only → **GATING**. The naive flip surfaced ~43 R4 warnings, **mostly false positives** of R4's heuristic — fixed the **heuristic**, not by deleting references.

### Breakdown (43 → 0 gating, no refs removed)
- **33 cleared by heuristic**: `skillExists` now resolves `arc-<name>` against `skills/<name>/` **+ `hooks/<name>/` + `agents/<name>.md`** (arc-guard/arc-remind are hooks; arc-auditing-spec-* are 3 real shipped agents). Plus eval-scenario-context skip (`eval-arc-<name>`) + path-component skip + one ASCII-diagram realign.
- **9 reasoned ignore-directives** for genuinely-intentional dangling: `arc-syncing-spec` ×5 (test-pinned boundary refs the plan **forbids removing**, §1.11), 3 teaching anti-patterns, 1 counter name — each `<!-- doc-ref-lint: ignore R4 <reason> -->`.

### Anti-hollow proof (advisor-flagged)
"check:docs exit 0" alone is a trap (exempt-everything passes green). Added a regression test: a genuinely-dangling `arc-<name>` ref **still trips gating R4** — reverting `R4_SEVERITY` to warn makes exactly those 2 tests FAIL; live-verified `arc-nonexistent-skill-xyz` in README trips exit-1.

### Acceptance
- `check:docs` exit 0, R4_SEVERITY='error' ✅ · RED-without-fix/GREEN-with-fix regression ✅ · hook+agent resolution ✅ · arc-syncing-spec suppressed not deleted ✅ · `npm test` (5 runners) + doc-refs suite (27) green ✅

**Positive deviation**: resolved against `agents/` too (spec said skills/+hooks/) — strengthens the gate (15 findings become genuine references vs exempted noise). SKILL.md edits are HTML ignore-comments + a diagram realign = zero behavioral footprint (exempt per arc-evaluating).

**Merge note: this PR should merge LAST in the wave** — sibling PRs add new `arc-<name>` refs in worktrees this branch never saw; the merged tree is simulated against gating check:docs before merge.