### PR TITLE
feat(cli): verifier-agent gate + verbatim-feedback retry on the acceptance floor (AF-9)

### DIFF
--- a/scripts/cli/dag-commands.js
+++ b/scripts/cli/dag-commands.js
@@ -10,6 +10,7 @@
 const { Coordinator, syncAllSpecs, rebootAllSpecs } = require('../lib/coordinator');
 const { getWorktreePath } = require('../lib/worktree-paths');
 const { parseVerifyCommand } = require('../lib/loop-verify');
+const { DEFAULT_MAX_RETRIES } = require('../lib/loop-verifier');
 const { output } = require('./shared');
 const {
   resolveSpecId,
@@ -244,6 +245,19 @@ function runLoop(args, { projectRoot, specFlag }) {
     }
   }
 
+  // --verifier (opt-in) + --max-retries: the AF-9 verifier-agent gate layered
+  // ON TOP of the --verify-cmd floor. --verifier is a boolean flag; --max-retries
+  // bounds the verbatim-feedback retry loop before the task is blocked.
+  const verifier = Boolean(args.flags.verifier);
+  let maxRetries = DEFAULT_MAX_RETRIES;
+  if (args.options['max-retries'] !== undefined) {
+    maxRetries = parseInt(args.options['max-retries'], 10);
+    if (Number.isNaN(maxRetries) || maxRetries < 0) {
+      console.error('Error: --max-retries must be a non-negative integer');
+      process.exit(1);
+    }
+  }
+
   // --reset archives any existing state file before this run starts, so the
   // loop begins from a clean state. Deliberate pre-run action — never mid-run.
   if (args.flags.reset) {
@@ -268,6 +282,8 @@ function runLoop(args, { projectRoot, specFlag }) {
     permissionMode: args.options['permission-mode'] || null,
     allowedTools: args.options['allowed-tools'] || null,
     verifyCommand,
+    verifier,
+    maxRetries,
   };
   if (pattern === 'dag') {
     runDag(loopOptions);

--- a/scripts/cli/help.js
+++ b/scripts/cli/help.js
@@ -84,7 +84,8 @@ COMMANDS:
       --example    Show complete example
 
   loop [--pattern sequential|dag] [--max-runs N] [--max-cost N] [--epic <id>] [--spec-id <id>]
-       [--task-timeout N] [--permission-mode <mode>] [--allowed-tools <tools>] [--verify-cmd "..."] [--reset]
+       [--task-timeout N] [--permission-mode <mode>] [--allowed-tools <tools>] [--verify-cmd "..."]
+       [--verifier] [--max-retries N] [--reset]
       Run autonomous cross-session execution loop.
       --pattern          Execution pattern: sequential (default) or dag
       --epic             Scope loop to a single epic (auto-detected in worktrees)
@@ -94,6 +95,9 @@ COMMANDS:
       --permission-mode  Pass --permission-mode through to spawned claude sessions
       --allowed-tools    Pass --allowed-tools through to spawned claude sessions
       --verify-cmd       Acceptance floor run after each session exits 0; non-zero fails the task
+      --verifier         After the floor passes, spawn an independent verifier agent;
+                         FAIL → retry with feedback, exhausted/unparseable → block (opt-in)
+      --max-retries      Verifier feedback retries before blocking (default: 2)
       --reset            Archive prior state to .arcforge-loop.archive/ and start fresh
 
   eval list                          List eval scenarios

--- a/scripts/lib/cli-manifest.js
+++ b/scripts/lib/cli-manifest.js
@@ -139,6 +139,8 @@ const CLI_MANIFEST = {
       '--permission-mode',
       '--allowed-tools',
       '--verify-cmd',
+      '--verifier',
+      '--max-retries',
     ],
     output: null,
   },

--- a/scripts/lib/loop-dag.js
+++ b/scripts/lib/loop-dag.js
@@ -12,9 +12,10 @@
  * keeps the loop.js → loop-dag.js dependency one-directional.
  */
 
-const { spawnSessionAsync } = require('./loop-session');
+const { spawnSession, spawnSessionAsync } = require('./loop-session');
 const { saveLoopState, recordError } = require('./loop-state');
 const { runVerify, recordVerifyResult } = require('./loop-verify');
+const { runVerifierGate, blockOnVerdict } = require('./loop-verifier');
 const { getTimestamp } = require('./utils');
 
 /**
@@ -167,6 +168,61 @@ function verifyEpic(coord, epic, worktreePath, state, options) {
 }
 
 /**
+ * Run the AF-9 verifier gate for a dag epic whose session exited 0 AND passed
+ * the verify-cmd floor, in the epic's OWN worktree cwd. Layered ON TOP of the
+ * floor: a no-op returning true when `--verifier` is off (no extra session).
+ * Verifier + verbatim-feedback retries run synchronously here in the sequential
+ * integration phase (the initial concurrent batch already ran); both reuse the
+ * sync spawnSession. On FAIL-exhausted or an unparseable verdict the epic is
+ * blocked (never merged/completed) and its worktree retained — PASS is never
+ * inferred from an exit code.
+ * @param {Coordinator} coord - Coordinator instance
+ * @param {Object} epic - Epic whose session + floor passed
+ * @param {string} worktreePath - The epic's worktree cwd to verify in
+ * @param {Object} state - Loop state
+ * @param {Object} options - Loop options
+ * @param {Function} buildTaskPrompt - (task, coord, projectRoot, workspaceRoot)=>string
+ * @returns {boolean} Whether the verifier passed (or was skipped/off)
+ */
+function verifyEpicAgent(coord, epic, worktreePath, state, options, buildTaskPrompt) {
+  const { projectRoot } = options;
+  const outcome = runVerifierGate({
+    coord,
+    task: epic,
+    state,
+    options,
+    cwd: worktreePath,
+    projectRoot,
+    spawnImplementer: (prompt, cwd) => spawnSession(prompt, cwd, options),
+    spawnVerifier: (prompt, cwd) => spawnSession(prompt, cwd, options),
+    buildImplementerPrompt: (feedback) => {
+      const base = buildTaskPrompt(epic, coord, projectRoot, worktreePath);
+      return feedback ? `${feedback}\n\n---\n\n${base}` : base;
+    },
+    runFloor: (cwd) => verifyEpicFloorOnly(epic, cwd, state, options),
+  });
+  if (outcome.passed) return true;
+  return blockOnVerdict(coord, epic, state, outcome);
+}
+
+/**
+ * Re-run the deterministic --verify-cmd floor on retried work (no blocking side
+ * effects — the verifier gate owns the block decision). Returns whether it
+ * passed; a no-op returning true when no --verify-cmd is configured.
+ * @param {Object} epic - Epic being re-verified
+ * @param {string} cwd - Worktree cwd
+ * @param {Object} state - Loop state (verify result persisted)
+ * @param {Object} options - Loop options
+ * @returns {boolean} Whether the floor passed (or was not configured)
+ */
+function verifyEpicFloorOnly(epic, cwd, state, options) {
+  if (!options.verifyCommand) return true;
+  const result = runVerify(options.verifyCommand, cwd, { timeoutMs: options.taskTimeoutMs });
+  recordVerifyResult(state, epic.id, result);
+  return result.exitCode === 0;
+}
+
+/**
  * Run one isolated-worktree round: expand each batch epic, spawn a session
  * in its worktree, and integrate the successful ones. Returns whether any
  * epic made progress.
@@ -226,6 +282,9 @@ async function runDagRound(coord, batch, state, options, buildTaskPrompt) {
     // Deterministic acceptance floor: a clean session exit alone is not enough
     // to merge — the verify command must pass in the epic's worktree first.
     if (!verifyEpic(coord, epic, worktreePath, state, options)) continue;
+    // AF-9 verifier gate (opt-in, layered on the floor): an independent verdict
+    // must also PASS before merge; FAIL → retry, exhausted/unparseable → block.
+    if (!verifyEpicAgent(coord, epic, worktreePath, state, options, buildTaskPrompt)) continue;
     if (integrateEpic(coord, epic, state)) anySuccess = true;
   }
 
@@ -238,6 +297,8 @@ module.exports = {
   selectRoundEpics,
   prepareEpicWorktree,
   verifyEpic,
+  verifyEpicAgent,
+  verifyEpicFloorOnly,
   integrateEpic,
   runDagRound,
 };

--- a/scripts/lib/loop-verifier.js
+++ b/scripts/lib/loop-verifier.js
@@ -1,0 +1,419 @@
+/**
+ * loop-verifier.js - Verifier-agent gate + feedback retry protocol (AF-9).
+ *
+ * Layers ON TOP of AF-8's deterministic acceptance floor (loop-verify.js): when
+ * `--verifier` is on, a session that exits 0 AND passes the --verify-cmd floor is
+ * NOT yet trusted. An independent verifier session is spawned in the work cwd
+ * (the epic worktree in dag mode), assembled at runtime from agents/verifier.md's
+ * body + the epic's acceptance criteria + the verify-cmd evidence + an
+ * assembler-layer "Final verdict: PASS|FAIL" instruction. The verifier's verdict
+ * is parsed from its text result — NEVER inferred from an exit code.
+ *
+ * On FAIL the implementer is re-spawned with verbatim cumulative feedback
+ * prepended, up to --max-retries (default 2). Exhausted retries → the caller
+ * blocks the task with the last verdict. An UNPARSEABLE verdict is a hard stop:
+ * the task is blocked (never completed) and the caller surfaces it for the
+ * verdict-protocol escalation — the floor's exit-code is never used to infer PASS.
+ *
+ * S4-8 missing-criteria degradation: criteria come from
+ * specs/<spec-id>/epics/<epic-id>/ when present, else the epic's spec_path
+ * contents + dag feature names. When NEITHER yields any criteria the verifier is
+ * SKIPPED (with a warning) rather than spawned on empty criteria — AF-8's
+ * deterministic floor still gates, so the task may still complete.
+ *
+ * The agent prompt assembly never edits agents/verifier.md (read-only here).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { readFileSafe } = require('./utils');
+const { recordError } = require('./loop-state');
+
+/** Default retry budget for the verifier feedback loop. */
+const DEFAULT_MAX_RETRIES = 2;
+
+/** Cap assembled criteria text so a huge spec doc can't blow the prompt. */
+const CRITERIA_CAP = 8000;
+
+/** agents/verifier.md, resolved relative to THIS file (not cwd, not env). */
+const VERIFIER_AGENT_PATH = path.join(__dirname, '..', '..', 'agents', 'verifier.md');
+
+/**
+ * Strip YAML frontmatter from an agent markdown file, returning the body only.
+ * `claude -p` does not honor an agent's `model:` field; we assemble the body.
+ * @param {string} content - Raw agent .md content
+ * @returns {string} Body after the frontmatter
+ */
+function stripFrontmatter(content) {
+  const match = content.match(/^---\n[\s\S]*?\n---\n?/);
+  return match ? content.slice(match[0].length).trim() : content.trim();
+}
+
+/**
+ * Load the verifier agent body (frontmatter stripped). Read-only — this never
+ * edits agents/verifier.md. Returns null when the agent file is unreadable so
+ * the caller can degrade rather than spawn an empty-bodied verifier.
+ * @returns {string|null} Verifier agent body, or null when unavailable
+ */
+function loadVerifierBody() {
+  const content = readFileSafe(VERIFIER_AGENT_PATH);
+  if (!content) return null;
+  const body = stripFrontmatter(content);
+  return body || null;
+}
+
+/**
+ * Resolve the epic's spec_path to an absolute existing file (S4-8 fallback leg).
+ * Mirrors loop.js resolveSpecPath order: spec-dir-relative first, then
+ * project-root-relative; only an existing file is returned.
+ * @param {string} specPath - Raw spec_path value from dag.yaml
+ * @param {string} projectRoot - Project root
+ * @param {string|null} specId - Spec id for spec-dir-relative resolution
+ * @returns {string|null} Absolute path to an existing spec doc, or null
+ */
+function resolveSpecDoc(specPath, projectRoot, specId) {
+  if (!specPath || typeof specPath !== 'string') return null;
+  const candidates = [];
+  if (specId) candidates.push(path.resolve(projectRoot, 'specs', specId, specPath));
+  candidates.push(path.resolve(projectRoot, specPath));
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Read every markdown file directly under specs/<spec-id>/epics/<epic-id>/
+ * (non-recursive), concatenated. This is the primary criteria source.
+ * @param {string} projectRoot - Project root
+ * @param {string|null} specId - Spec id
+ * @param {string} epicId - Epic id
+ * @returns {string} Concatenated epic-dir markdown, or '' when absent
+ */
+function readEpicDir(projectRoot, specId, epicId) {
+  if (!specId || !epicId) return '';
+  const epicDir = path.join(projectRoot, 'specs', specId, 'epics', epicId);
+  let entries;
+  try {
+    entries = fs.readdirSync(epicDir, { withFileTypes: true });
+  } catch {
+    return '';
+  }
+  const docs = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const content = readFileSafe(path.join(epicDir, entry.name));
+    if (content) docs.push(content.trim());
+  }
+  return docs.join('\n\n');
+}
+
+/**
+ * Build the acceptance criteria text for an epic, applying the S4-8 degradation
+ * ladder: epics/<id>/ markdown → spec_path doc contents → dag feature names.
+ * Returns the assembled criteria (capped). An empty string means NO criteria
+ * could be resolved — the caller MUST skip the verifier rather than spawn it
+ * with empty criteria.
+ * @param {Object} coord - Coordinator (provides specId)
+ * @param {Object} epic - Epic carrying id/spec_path/features
+ * @param {string} projectRoot - Project root
+ * @returns {string} Criteria text ('' when none resolvable)
+ */
+function loadVerifierCriteria(coord, epic, projectRoot) {
+  const specId = coord?.specId || null;
+  const epicId = epic?.id;
+
+  const epicDir = readEpicDir(projectRoot, specId, epicId);
+  if (epicDir) return epicDir.slice(0, CRITERIA_CAP);
+
+  const parts = [];
+  const specDoc = resolveSpecDoc(epic?.spec_path, projectRoot, specId);
+  if (specDoc) {
+    const content = readFileSafe(specDoc);
+    if (content?.trim()) parts.push(content.trim());
+  }
+  const features = Array.isArray(epic?.features) ? epic.features : [];
+  const featureNames = features.map((f) => f?.name).filter(Boolean);
+  if (featureNames.length > 0) {
+    parts.push(`Feature acceptance targets:\n${featureNames.map((n) => `- ${n}`).join('\n')}`);
+  }
+  return parts.join('\n\n').slice(0, CRITERIA_CAP);
+}
+
+/**
+ * Assemble the verifier session prompt at runtime. NEVER edits agents/verifier.md.
+ * Layers: agent body → epic identity + acceptance criteria → verify-cmd evidence
+ * instruction → a forceful verdict-protocol override. The override deliberately
+ * supersedes the agent body's own SHIP/NEEDS WORK/BLOCKED report vocabulary so a
+ * real session emits a parseable `Final verdict:` line, not a divergent verdict.
+ * @param {Object} args
+ * @param {string} args.agentBody - Verifier agent body (frontmatter stripped)
+ * @param {Object} args.task - Task/epic being verified (id, name)
+ * @param {string} args.criteria - Acceptance criteria text (non-empty)
+ * @param {string[]|null} args.verifyCommand - The --verify-cmd argv (or null)
+ * @param {string} [args.feedback] - Verbatim cumulative feedback to prepend
+ * @returns {string} The assembled verifier prompt
+ */
+function assembleVerifierPrompt({ agentBody, task, criteria, verifyCommand, feedback }) {
+  const parts = [];
+  if (feedback?.trim()) {
+    parts.push('## Prior Verification Feedback (address every point before re-verifying)', '');
+    parts.push(feedback.trim(), '');
+    parts.push('---', '');
+  }
+  parts.push(agentBody, '');
+  parts.push('## Work Under Verification', '');
+  parts.push(`Task: ${task.name} (${task.id})`, '');
+  parts.push('## Acceptance Criteria', '');
+  parts.push(criteria.trim(), '');
+  if (Array.isArray(verifyCommand) && verifyCommand.length > 0) {
+    parts.push('## Deterministic Acceptance Floor', '');
+    parts.push(
+      `A deterministic floor command already passed: \`${verifyCommand.join(' ')}\`. ` +
+        'Re-run it yourself and read its real output as part of your evidence — ' +
+        'do not take its prior pass on trust.',
+      '',
+    );
+  }
+  parts.push('## Verdict Protocol (overrides any report format above)', '');
+  parts.push(
+    'Disregard the SHIP / NEEDS WORK / BLOCKED wording in the report format above. ' +
+      'After your verification, your response MUST end with a single line that is ' +
+      'EXACTLY one of:',
+    '',
+    'Final verdict: PASS',
+    'Final verdict: FAIL',
+    '',
+    'PASS only when every acceptance criterion is met with fresh evidence you ran ' +
+      'this session. Otherwise FAIL, and list what failed above the verdict line so ' +
+      'the implementer can act on it. Nothing may follow the verdict line.',
+  );
+  return parts.join('\n');
+}
+
+/**
+ * Parse a PASS/FAIL verdict from the verifier session's text result. Takes the
+ * LAST `Final verdict:` line (tolerating markdown emphasis / surrounding
+ * whitespace). Returns 'PASS' | 'FAIL', or null when no parseable verdict line
+ * is present (the STOP signal). NEVER maps SHIP→PASS and NEVER inspects an exit
+ * code — an unparseable verdict must route to block, not an inferred PASS.
+ * @param {string} text - Verifier session stdout (the text result)
+ * @returns {'PASS'|'FAIL'|null}
+ */
+function parseVerdict(text) {
+  if (typeof text !== 'string' || !text) return null;
+  const re = /final\s+verdict\s*:\s*\**\s*(PASS|FAIL)\b/gi;
+  let verdict = null;
+  let match = re.exec(text);
+  while (match !== null) {
+    verdict = match[1].toUpperCase();
+    match = re.exec(text);
+  }
+  return verdict;
+}
+
+/**
+ * Append a verifier attempt to loop state (round-trips via saveLoopState as
+ * plain JSON). This is the AF-9 attempts schema — kept in LOOP state, distinct
+ * from the DAG blocked-item `attempts` field (which this never touches). Mutates
+ * state in place.
+ * @param {Object} state - Loop state
+ * @param {string} taskId - Task/epic id verified
+ * @param {Object} attempt - { attempt, verdict, feedback, cost_usd }
+ * @returns {Object} The recorded entry
+ */
+function recordVerifierAttempt(state, taskId, attempt) {
+  if (!Array.isArray(state.verifier_attempts)) state.verifier_attempts = [];
+  const entry = {
+    task_id: taskId,
+    iteration: state.iteration,
+    attempt: attempt.attempt,
+    verdict: attempt.verdict,
+    feedback: attempt.feedback || '',
+    cost_usd: attempt.cost_usd || 0,
+    timestamp: new Date().toISOString(),
+  };
+  if (state.run_id) entry.run_id = state.run_id;
+  state.verifier_attempts.push(entry);
+  return entry;
+}
+
+/**
+ * Spawn the verifier session and return its parsed verdict + cost. cwd is the
+ * work cwd (the epic worktree in dag mode). The verdict is parsed from the text
+ * result — never from the exit code. A non-zero verifier session exit yields an
+ * unparseable verdict (null) UNLESS its text still carries a `Final verdict:`
+ * line, so a verifier that crashes can never be read as PASS.
+ * @param {Object} args
+ * @param {Function} args.spawn - (prompt, cwd) => { stdout, costUsd, ... }
+ * @param {string} args.prompt - Assembled verifier prompt
+ * @param {string} args.cwd - Work cwd to verify in
+ * @returns {{ verdict: 'PASS'|'FAIL'|null, costUsd: number, output: string }}
+ */
+function spawnVerifierSession({ spawn, prompt, cwd }) {
+  const result = spawn(prompt, cwd) || {};
+  const output = typeof result.stdout === 'string' ? result.stdout : '';
+  return {
+    verdict: parseVerdict(output),
+    costUsd: typeof result.costUsd === 'number' ? result.costUsd : 0,
+    output,
+  };
+}
+
+/**
+ * Run the AF-9 verifier gate + verbatim-feedback retry sub-loop for a task whose
+ * session already exited 0 AND passed the AF-8 deterministic floor.
+ *
+ * Synchronous by design: the sequential path keeps byte-identical behavior when
+ * `--verifier` is off (a no-op returning `{ passed: true, skipped: true }` with
+ * NO extra session), and the dag path calls this in its sequential integration
+ * phase so retries reuse the same synchronous spawn. The whole gate+retry loop
+ * lives here — neither caller forks it.
+ *
+ * Flow per attempt: spawn the verifier in `cwd`, parse its verdict.
+ *  - PASS → `{ passed: true }`.
+ *  - null (unparseable) → `{ passed: false, unparseable: true, verdict: null }`
+ *    — the caller blocks; PASS is NEVER inferred from an exit code.
+ *  - FAIL → re-spawn the IMPLEMENTER with verbatim cumulative feedback, re-run
+ *    the floor, then re-verify, up to maxRetries. Cost-stop (cost > retry) is
+ *    checked BEFORE each re-spawn: if the next attempt would cross maxCost, stop
+ *    retrying without spawning. Exhausted → `{ passed: false, verdict: <last> }`.
+ *
+ * @param {Object} ctx
+ * @param {Object} ctx.coord - Coordinator (provides specId)
+ * @param {Object} ctx.task - Task/epic under verification
+ * @param {Object} ctx.state - Loop state (cost + attempts persisted here)
+ * @param {Object} ctx.options - Loop options (maxRetries, maxCost, verifyCommand)
+ * @param {string} ctx.cwd - Work cwd (epic worktree in dag mode)
+ * @param {string} ctx.projectRoot - Project root for criteria resolution
+ * @param {Function} ctx.spawnImplementer - (prompt, cwd) => sync session result
+ * @param {Function} ctx.spawnVerifier - (prompt, cwd) => sync session result
+ * @param {Function} ctx.buildImplementerPrompt - (feedback) => string
+ * @param {Function} ctx.runFloor - (cwd) => boolean (re-run AF-8 floor)
+ * @returns {{ passed: boolean, skipped?: boolean, unparseable?: boolean, verdict?: string|null }}
+ */
+function runVerifierGate(ctx) {
+  const { coord, task, state, options, cwd, projectRoot } = ctx;
+  if (!options.verifier) return { passed: true, skipped: true };
+
+  const agentBody = loadVerifierBody();
+  const criteria = loadVerifierCriteria(coord, task, projectRoot);
+  // S4-8: never spawn the verifier with empty criteria (or no agent body) —
+  // skip it with a warning. The AF-8 deterministic floor still gated upstream.
+  if (!agentBody || !criteria) {
+    const why = !agentBody ? 'verifier agent unavailable' : 'no acceptance criteria resolvable';
+    console.error(
+      `[loop] Verifier skipped for ${task.id} — ${why}; deterministic floor still gated`,
+    );
+    return { passed: true, skipped: true };
+  }
+
+  const maxRetries =
+    typeof options.maxRetries === 'number' ? options.maxRetries : DEFAULT_MAX_RETRIES;
+  let feedback = '';
+  let lastVerdict = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const prompt = assembleVerifierPrompt({
+      agentBody,
+      task,
+      criteria,
+      verifyCommand: options.verifyCommand || null,
+      feedback,
+    });
+    console.log(`[loop] Verifying ${task.id} (verifier attempt ${attempt + 1})`);
+    const { verdict, costUsd, output } = spawnVerifierSession({
+      spawn: ctx.spawnVerifier,
+      prompt,
+      cwd,
+    });
+    state.total_cost += costUsd;
+    lastVerdict = verdict;
+    recordVerifierAttempt(state, task.id, {
+      attempt: attempt + 1,
+      verdict,
+      feedback,
+      cost_usd: costUsd,
+    });
+
+    if (verdict === 'PASS') return { passed: true, verdict: 'PASS' };
+    if (verdict === null) {
+      // Unparseable verdict — the AF-9 stop condition. Block, never infer PASS.
+      console.error(
+        `[loop] Verifier verdict UNPARSEABLE for ${task.id} — blocking (never inferring PASS)`,
+      );
+      return { passed: false, unparseable: true, verdict: null };
+    }
+
+    // FAIL: accumulate verbatim feedback for the next implementer attempt.
+    feedback = feedback
+      ? `${feedback}\n\n--- Verifier attempt ${attempt + 1} (FAIL) ---\n${output.trim()}`
+      : `--- Verifier attempt ${attempt + 1} (FAIL) ---\n${output.trim()}`;
+
+    if (attempt === maxRetries) break; // budget exhausted; block with last verdict
+
+    // Cost-stop > retry: do not re-spawn the implementer if doing so would cross
+    // maxCost. Stop retrying and block with the last FAIL verdict.
+    if (options.maxCost && state.total_cost >= options.maxCost) {
+      console.log(
+        `[loop] Cost limit reached before verifier retry ($${state.total_cost}) — blocking`,
+      );
+      break;
+    }
+
+    console.log(`[loop] Verifier FAIL for ${task.id} — re-spawning implementer with feedback`);
+    const implResult = ctx.spawnImplementer(ctx.buildImplementerPrompt(feedback), cwd) || {};
+    state.total_cost += typeof implResult.costUsd === 'number' ? implResult.costUsd : 0;
+    if (implResult.exitCode !== 0) {
+      console.log(`[loop] Implementer retry session failed for ${task.id} — blocking`);
+      return { passed: false, verdict: lastVerdict };
+    }
+    // Re-run the AF-8 deterministic floor on the retried work before re-verifying.
+    if (!ctx.runFloor(cwd)) {
+      console.log(`[loop] Floor failed on retried work for ${task.id} — blocking`);
+      return { passed: false, verdict: lastVerdict };
+    }
+  }
+
+  return { passed: false, verdict: lastVerdict };
+}
+
+/**
+ * Block a task on a non-passing verifier outcome, recording the reason in loop
+ * state. Shared by both loop callers (sequential + dag) so the block tail isn't
+ * forked. An unparseable verdict is reported distinctly for the verdict-protocol
+ * escalation; PASS is never inferred. A failed blockTask is logged, never thrown.
+ * @param {Object} coord - Coordinator (provides blockTask)
+ * @param {Object} task - Task/epic to block
+ * @param {Object} state - Loop state (error + failed_tasks recorded here)
+ * @param {{ unparseable?: boolean, verdict?: string|null }} outcome - Gate outcome
+ * @returns {false} Always false (callers `return blockOnVerdict(...)`)
+ */
+function blockOnVerdict(coord, task, state, outcome) {
+  const reason = outcome.unparseable
+    ? 'Loop: verifier verdict UNPARSEABLE (escalate verdict protocol)'
+    : `Loop: verifier FAIL after retries (last verdict: ${outcome.verdict})`;
+  recordError(state, task.id, reason, 1);
+  if (!Array.isArray(state.failed_tasks)) state.failed_tasks = [];
+  state.failed_tasks.push(task.id);
+  try {
+    coord.blockTask(task.id, reason);
+  } catch (err) {
+    console.error(`[loop] Warning: could not block task ${task.id}: ${err.message}`);
+  }
+  return false;
+}
+
+module.exports = {
+  DEFAULT_MAX_RETRIES,
+  VERIFIER_AGENT_PATH,
+  stripFrontmatter,
+  loadVerifierBody,
+  loadVerifierCriteria,
+  assembleVerifierPrompt,
+  parseVerdict,
+  recordVerifierAttempt,
+  spawnVerifierSession,
+  runVerifierGate,
+  blockOnVerdict,
+};

--- a/scripts/loop.js
+++ b/scripts/loop.js
@@ -30,6 +30,7 @@ const {
 const { isStalled, isRetryStorm, checkStopConditions, printSummary } = require('./lib/loop-state');
 const { warnIfBaseBranch, selectRoundEpics, runDagRound } = require('./lib/loop-dag');
 const { parseVerifyCommand, runVerify, recordVerifyResult } = require('./lib/loop-verify');
+const { runVerifierGate, blockOnVerdict, DEFAULT_MAX_RETRIES } = require('./lib/loop-verifier');
 const { Feature } = require('./lib/models');
 const {
   detectPackageManager,
@@ -61,6 +62,8 @@ function parseLoopArgs(args) {
     permissionMode: null,
     allowedTools: null,
     verifyCommand: null,
+    verifier: false,
+    maxRetries: DEFAULT_MAX_RETRIES,
     projectRoot: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
   };
 
@@ -123,6 +126,16 @@ function parseLoopArgs(args) {
           process.exit(1);
         }
         break;
+      case '--verifier':
+        options.verifier = true;
+        break;
+      case '--max-retries':
+        options.maxRetries = parseInt(args[++i], 10);
+        if (Number.isNaN(options.maxRetries) || options.maxRetries < 0) {
+          console.error('Error: --max-retries must be a non-negative integer');
+          process.exit(1);
+        }
+        break;
       case '--help':
       case '-h':
         printLoopHelp();
@@ -160,6 +173,10 @@ OPTIONS:
   --allowed-tools <tools>    Pass --allowed-tools through to spawned claude sessions
   --verify-cmd "<cmd>"       Run this command after each session exits 0; a
                              non-zero exit fails the task (retry/block, no complete)
+  --verifier                 After the --verify-cmd floor passes, spawn an
+                             independent verifier agent; FAIL → retry with verbatim
+                             feedback, exhausted → block (opt-in; off by default)
+  --max-retries N            Verifier feedback retries before blocking (default: 2)
   --help, -h                 Show this help
 
 PATTERNS:
@@ -380,6 +397,39 @@ function runVerifyFloor(task, state, options, cwd, attempt) {
 }
 
 /**
+ * Run the AF-9 verifier gate for a task whose session exited 0 and passed the
+ * AF-8 floor, in `cwd`. Layered ON TOP of the floor: when `--verifier` is off
+ * this is a no-op returning true (no extra session — sequential behavior stays
+ * byte-identical). The verbatim-feedback retry loop and verdict parsing live in
+ * loop-verifier.js; this only wires the loop's spawn/floor/prompt callbacks and
+ * blocks the task on FAIL-exhausted or an unparseable verdict (never inferring
+ * PASS). `buildPrompt` re-builds the implementer prompt with prepended feedback.
+ * @param {Object} task - Task whose session succeeded
+ * @param {Coordinator} coord - Coordinator instance
+ * @param {Object} state - Loop state
+ * @param {Object} options - Loop options
+ * @param {string} cwd - Work cwd (epic worktree in dag mode)
+ * @param {Function} buildPrompt - (feedback) => implementer prompt string
+ * @returns {boolean} Whether the verifier passed (or was skipped/off)
+ */
+function runVerifierGateFor(task, coord, state, options, cwd, buildPrompt) {
+  const outcome = runVerifierGate({
+    coord,
+    task,
+    state,
+    options,
+    cwd,
+    projectRoot: options.projectRoot,
+    spawnImplementer: (prompt, c) => spawnSession(prompt, c, options),
+    spawnVerifier: (prompt, c) => spawnSession(prompt, c, options),
+    buildImplementerPrompt: buildPrompt,
+    runFloor: (c) => runVerifyFloor(task, state, options, c, 1),
+  });
+  if (outcome.passed) return true;
+  return blockOnVerdict(coord, task, state, outcome);
+}
+
+/**
  * Run a single task iteration
  * @param {Object} task - Task from coordinator
  * @param {Coordinator} coord - Coordinator instance
@@ -419,6 +469,16 @@ function runTask(task, coord, state, options) {
       }
       return false;
     }
+  }
+
+  // AF-9 verifier gate (opt-in): the floor passed, but with --verifier on an
+  // independent verdict must also PASS before completing. A no-op when off.
+  if (
+    !runVerifierGateFor(task, coord, state, options, projectRoot, (feedback) =>
+      feedback ? `${feedback}\n\n---\n\n${prompt}` : prompt,
+    )
+  ) {
+    return false;
   }
 
   // Success — update DAG before recording in state

--- a/tests/scripts/loop-verifier-dag.test.js
+++ b/tests/scripts/loop-verifier-dag.test.js
@@ -1,0 +1,98 @@
+/**
+ * loop-verifier-dag.test.js — AF-9 verifier gate in the DAG path (loop-dag.js).
+ *
+ * Pins the dag-specific invariant: the verifier session is spawned in the epic's
+ * OWN worktree cwd (never the base projectRoot), and its cost is accounted into
+ * loop state. The verifier + verbatim-feedback retries run synchronously in the
+ * integration phase via the sync spawnSession (the initial concurrent batch
+ * already ran), so both reuse the same mock.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+jest.mock('../../scripts/lib/loop-session', () => ({
+  spawnSession: jest.fn(),
+  spawnSessionAsync: jest.fn(),
+}));
+
+const { spawnSession } = require('../../scripts/lib/loop-session');
+const { verifyEpicAgent } = require('../../scripts/lib/loop-dag');
+
+let tmp;
+let worktree;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af9-dag-'));
+  worktree = path.join(tmp, 'worktree-epic-a');
+  fs.mkdirSync(worktree, { recursive: true });
+  // Criteria fixture under projectRoot so the gate has non-empty criteria.
+  const dir = path.join(tmp, 'specs', 'spec1', 'epics', 'epic-a');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'epic.md'), '# Acceptance\n- ship it\n');
+  spawnSession.mockReset();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  jest.restoreAllMocks();
+});
+
+function makeCoord() {
+  return {
+    specId: 'spec1',
+    blocked: [],
+    blockTask(id, reason) {
+      this.blocked.push({ id, reason });
+    },
+  };
+}
+
+const epic = { id: 'epic-a', name: 'Epic A' };
+const buildTaskPrompt = (_t, _c, _root, _ws) => 'IMPL PROMPT';
+
+describe('verifyEpicAgent (dag)', () => {
+  it('--verifier OFF → no-op, no verifier session', () => {
+    const coord = makeCoord();
+    const state = { iteration: 1, total_cost: 0, failed_tasks: [], errors: [] };
+    const ok = verifyEpicAgent(coord, epic, worktree, state, { verifier: false }, buildTaskPrompt);
+    expect(ok).toBe(true);
+    expect(spawnSession).not.toHaveBeenCalled();
+  });
+
+  it('spawns the verifier in the epic WORKTREE cwd and accounts cost', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: 'Final verdict: PASS', costUsd: 0.4 });
+    const coord = makeCoord();
+    const state = { iteration: 1, total_cost: 0, failed_tasks: [], errors: [] };
+    const options = { verifier: true, maxRetries: 2, projectRoot: tmp, verifyCommand: null };
+
+    const ok = verifyEpicAgent(coord, epic, worktree, state, options, buildTaskPrompt);
+
+    expect(ok).toBe(true);
+    expect(spawnSession).toHaveBeenCalledTimes(1);
+    // cwd argument (2nd positional) is the epic worktree, not the base projectRoot.
+    expect(spawnSession.mock.calls[0][1]).toBe(worktree);
+    expect(state.total_cost).toBeCloseTo(0.4);
+    expect(state.verifier_attempts[0].verdict).toBe('PASS');
+  });
+
+  it('FAIL exhausted → blocks the epic with the last verdict', () => {
+    spawnSession.mockImplementation((prompt) =>
+      prompt.includes('Final verdict: PASS')
+        ? { exitCode: 0, stdout: 'broken\nFinal verdict: FAIL', costUsd: 0.1 }
+        : { exitCode: 0, stdout: '', costUsd: 0.5 },
+    );
+    const coord = makeCoord();
+    const state = { iteration: 1, total_cost: 0, failed_tasks: [], errors: [] };
+    const options = { verifier: true, maxRetries: 1, projectRoot: tmp, verifyCommand: null };
+
+    const ok = verifyEpicAgent(coord, epic, worktree, state, options, buildTaskPrompt);
+
+    expect(ok).toBe(false);
+    expect(coord.blocked[0].id).toBe('epic-a');
+    expect(coord.blocked[0].reason).toContain('FAIL');
+    expect(state.failed_tasks).toContain('epic-a');
+  });
+});

--- a/tests/scripts/loop-verifier-floor.test.js
+++ b/tests/scripts/loop-verifier-floor.test.js
@@ -1,0 +1,226 @@
+/**
+ * loop-verifier-floor.test.js — AF-9 verifier gate wired into the SEQUENTIAL
+ * runTask path (loop.js), layered ON TOP of AF-8's deterministic floor.
+ *
+ * spawnSession is mocked. The same mock serves both the implementer session and
+ * the verifier session; they are distinguished by the verifier prompt's verdict
+ * instruction. Criteria resolve from a temp specs/<spec>/epics/<epic>/ fixture so
+ * the gate does not skip. Pins the end-to-end acceptance:
+ *   - --verifier OFF → exactly one session (byte-identical to AF-8).
+ *   - FAIL → verbatim-feedback retry → PASS → completeTask, attempts persisted.
+ *   - FAIL exhausted → blocked with the last verdict (no completeTask).
+ *   - UNPARSEABLE verdict → blocked, NEVER inferred PASS.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+jest.mock('../../scripts/lib/loop-session', () => ({
+  spawnSession: jest.fn(),
+  spawnSessionAsync: jest.fn(),
+}));
+
+const { spawnSession } = require('../../scripts/lib/loop-session');
+const { runTask } = require('../../scripts/loop');
+
+/** Coordinator stub: records complete/block; taskContext throws (tolerated). */
+function makeCoord(projectRoot) {
+  return {
+    completed: [],
+    blocked: [],
+    specId: 'spec1',
+    projectRoot,
+    completeTask(id) {
+      this.completed.push(id);
+    },
+    blockTask(id, reason) {
+      this.blocked.push({ id, reason });
+    },
+    taskContext() {
+      throw new Error('no context in stub');
+    },
+    dag: { getTask: () => null },
+  };
+}
+
+function makeState() {
+  return {
+    iteration: 1,
+    completed_tasks: [],
+    failed_tasks: [],
+    errors: [],
+    total_cost: 0,
+    last_progress_at: null,
+    status: 'running',
+  };
+}
+
+/** Distinguish a verifier prompt from an implementer prompt by its verdict line. */
+function isVerifierPrompt(prompt) {
+  return typeof prompt === 'string' && prompt.includes('Final verdict: PASS');
+}
+
+const task = { id: 'epic-a', name: 'Epic A' };
+let tmp;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af9-floor-'));
+  // Criteria fixture so the gate has non-empty criteria (no S4-8 skip).
+  const dir = path.join(tmp, 'specs', 'spec1', 'epics', 'epic-a');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'epic.md'), '# Acceptance\n- the criterion\n');
+  spawnSession.mockReset();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  jest.restoreAllMocks();
+});
+
+describe('runTask verifier gate (sequential)', () => {
+  it('--verifier OFF → exactly one session, no verifier (byte-identical)', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: '', stderr: '', costUsd: 0 });
+    const coord = makeCoord(tmp);
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: tmp });
+
+    expect(ok).toBe(true);
+    expect(coord.completed).toEqual(['epic-a']);
+    expect(spawnSession).toHaveBeenCalledTimes(1); // no verifier session
+    expect(state.verifier_attempts).toBeUndefined();
+  });
+
+  it('verifier PASS → completes; one implementer + one verifier session', () => {
+    spawnSession.mockImplementation((prompt) =>
+      isVerifierPrompt(prompt)
+        ? { exitCode: 0, stdout: 'Final verdict: PASS', stderr: '', costUsd: 0.2 }
+        : { exitCode: 0, stdout: '', stderr: '', costUsd: 1 },
+    );
+    const coord = makeCoord(tmp);
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: tmp, verifier: true });
+
+    expect(ok).toBe(true);
+    expect(coord.completed).toEqual(['epic-a']);
+    expect(spawnSession).toHaveBeenCalledTimes(2); // implementer + verifier
+    expect(state.verifier_attempts).toHaveLength(1);
+    expect(state.verifier_attempts[0].verdict).toBe('PASS');
+    expect(state.total_cost).toBeCloseTo(1.2);
+  });
+
+  it('verifier FAIL → verbatim-feedback retry → PASS → completes', () => {
+    let verifierCalls = 0;
+    spawnSession.mockImplementation((prompt) => {
+      if (isVerifierPrompt(prompt)) {
+        verifierCalls++;
+        return verifierCalls === 1
+          ? {
+              exitCode: 0,
+              stdout: 'missing coverage\nFinal verdict: FAIL',
+              stderr: '',
+              costUsd: 0.2,
+            }
+          : { exitCode: 0, stdout: 'Final verdict: PASS', stderr: '', costUsd: 0.2 };
+      }
+      return { exitCode: 0, stdout: '', stderr: '', costUsd: 1 };
+    });
+    const coord = makeCoord(tmp);
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: tmp, verifier: true });
+
+    expect(ok).toBe(true);
+    expect(coord.completed).toEqual(['epic-a']);
+    expect(state.verifier_attempts.map((a) => a.verdict)).toEqual(['FAIL', 'PASS']);
+  });
+
+  it('verifier FAIL exhausted → blocked with last verdict, no complete', () => {
+    spawnSession.mockImplementation((prompt) =>
+      isVerifierPrompt(prompt)
+        ? { exitCode: 0, stdout: 'still broken\nFinal verdict: FAIL', stderr: '', costUsd: 0.1 }
+        : { exitCode: 0, stdout: '', stderr: '', costUsd: 1 },
+    );
+    const coord = makeCoord(tmp);
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: tmp, verifier: true, maxRetries: 1 });
+
+    expect(ok).toBe(false);
+    expect(coord.completed).toEqual([]);
+    expect(coord.blocked[0].id).toBe('epic-a');
+    expect(coord.blocked[0].reason).toContain('FAIL');
+    expect(state.failed_tasks).toContain('epic-a');
+  });
+
+  it('verifier UNPARSEABLE verdict → blocked, never inferred PASS', () => {
+    spawnSession.mockImplementation((prompt) =>
+      isVerifierPrompt(prompt)
+        ? { exitCode: 0, stdout: '### Assessment\nSHIP', stderr: '', costUsd: 0.1 }
+        : { exitCode: 0, stdout: '', stderr: '', costUsd: 1 },
+    );
+    const coord = makeCoord(tmp);
+    const state = makeState();
+
+    const ok = runTask(task, coord, state, { projectRoot: tmp, verifier: true });
+
+    expect(ok).toBe(false);
+    expect(coord.completed).toEqual([]);
+    expect(coord.blocked[0].reason).toContain('UNPARSEABLE');
+  });
+});
+
+// --- S4-8: missing-criteria degradation, the verify-cmd floor STILL gates -------
+// An epic with no epics/ dir, no spec_path, and no features → no criteria → the
+// verifier is SKIPPED with a warning. The deterministic floor must still gate, so
+// the task only completes when verify-cmd passes (the skip never weakens the floor).
+
+const PASS = ['node', '-e', 'process.exit(0)'];
+const FAIL = ['node', '-e', 'process.exit(1)'];
+
+describe('runTask verifier skip on missing criteria — verify-cmd still gates', () => {
+  // A no-fixture epic: makeCoord's specId (spec1) has no epics/no-crit/ dir, and
+  // this task carries no spec_path/features → loadVerifierCriteria returns ''.
+  const noCritTask = { id: 'no-crit', name: 'No Criteria Epic' };
+
+  it('missing criteria + verify-cmd PASS → completes, verifier skipped, warning fires', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: '', stderr: '', costUsd: 1 });
+    const coord = makeCoord(tmp);
+    const state = makeState();
+
+    const ok = runTask(noCritTask, coord, state, {
+      projectRoot: tmp,
+      verifier: true,
+      verifyCommand: PASS,
+    });
+
+    expect(ok).toBe(true);
+    expect(coord.completed).toEqual(['no-crit']);
+    // Exactly one (implementer) session — the verifier was skipped, not spawned.
+    expect(spawnSession).toHaveBeenCalledTimes(1);
+    expect(state.verifier_attempts).toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Verifier skipped'));
+  });
+
+  it('missing criteria + verify-cmd FAIL → blocked at the floor, verifier never reached', () => {
+    spawnSession.mockReturnValue({ exitCode: 0, stdout: '', stderr: '', costUsd: 1 });
+    const coord = makeCoord(tmp);
+    const state = makeState();
+
+    const ok = runTask(noCritTask, coord, state, {
+      projectRoot: tmp,
+      verifier: true,
+      verifyCommand: FAIL,
+    });
+
+    expect(ok).toBe(false);
+    expect(coord.completed).toEqual([]);
+    expect(coord.blocked[0].id).toBe('no-crit');
+    // The floor failed both attempts → the verifier (and its skip path) never ran.
+    expect(state.verifier_attempts).toBeUndefined();
+    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Verifier skipped'));
+  });
+});

--- a/tests/scripts/loop-verifier.test.js
+++ b/tests/scripts/loop-verifier.test.js
@@ -1,0 +1,306 @@
+/**
+ * loop-verifier.test.js — AF-9 verifier-agent gate + verbatim-feedback retry.
+ *
+ * Layered ON TOP of AF-8's deterministic floor. The verifier session spawn is a
+ * stub callback (no real `claude -p`); the verdict is parsed from its text
+ * result, never inferred from an exit code. Invariants pinned here:
+ *   - parseVerdict: explicit `Final verdict:` line, last-wins, markdown-tolerant;
+ *     SHIP/garbage/empty → null (the stub-vs-real divergence STOP signal).
+ *   - --verifier OFF → no extra session, byte-identical (no-op gate).
+ *   - FAIL → verbatim feedback re-spawn → PASS → completeTask.
+ *   - FAIL exhausted → block with last verdict; attempts round-trip persisted.
+ *   - UNPARSEABLE verdict → block, NEVER inferred PASS.
+ *   - cost-stop > retry: maxCost crossing stops the retry without re-spawning.
+ *   - S4-8: missing-criteria fixture → verifier skipped (not blocked).
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  DEFAULT_MAX_RETRIES,
+  parseVerdict,
+  loadVerifierBody,
+  loadVerifierCriteria,
+  assembleVerifierPrompt,
+  recordVerifierAttempt,
+  runVerifierGate,
+} = require('../../scripts/lib/loop-verifier');
+
+// --- parseVerdict: the verdict-protocol STOP boundary --------------------------
+
+describe('parseVerdict', () => {
+  it('parses an explicit PASS line', () => {
+    expect(parseVerdict('evidence...\nFinal verdict: PASS')).toBe('PASS');
+  });
+  it('parses an explicit FAIL line', () => {
+    expect(parseVerdict('Final verdict: FAIL\n')).toBe('FAIL');
+  });
+  it('tolerates markdown emphasis and whitespace', () => {
+    expect(parseVerdict('  **Final verdict:  PASS** ')).toBe('PASS');
+  });
+  it('takes the LAST verdict line when multiple appear', () => {
+    expect(parseVerdict('Final verdict: FAIL\nrecheck\nFinal verdict: PASS')).toBe('PASS');
+  });
+  it('returns null for SHIP-only output (verifier.md vocabulary divergence)', () => {
+    // The agent body's own report format says SHIP/NEEDS WORK/BLOCKED — that must
+    // NEVER be mapped to PASS. No `Final verdict:` line → null → block.
+    expect(parseVerdict('### Final Assessment\nSHIP')).toBeNull();
+  });
+  it('returns null for garbage / no verdict line', () => {
+    expect(parseVerdict('lorem ipsum, all good, looks fine')).toBeNull();
+  });
+  it('returns null for empty / non-string input', () => {
+    expect(parseVerdict('')).toBeNull();
+    expect(parseVerdict(undefined)).toBeNull();
+  });
+});
+
+// --- agent body + assembly (read-only; never edits agents/verifier.md) ----------
+
+describe('loadVerifierBody', () => {
+  it('reads agents/verifier.md and strips frontmatter', () => {
+    const body = loadVerifierBody();
+    expect(body).toBeTruthy();
+    expect(body.startsWith('---')).toBe(false);
+    expect(body).toContain('Verifier');
+  });
+});
+
+describe('assembleVerifierPrompt', () => {
+  const base = {
+    agentBody: 'AGENT BODY',
+    task: { id: 'epic-a', name: 'Epic A' },
+    criteria: 'criterion one',
+    verifyCommand: ['npm', 'test'],
+  };
+
+  it('layers body + criteria + verify-cmd evidence + verdict override', () => {
+    const prompt = assembleVerifierPrompt(base);
+    expect(prompt).toContain('AGENT BODY');
+    expect(prompt).toContain('criterion one');
+    expect(prompt).toContain('npm test');
+    expect(prompt).toContain('Final verdict: PASS');
+    expect(prompt).toContain('Final verdict: FAIL');
+    // The override must forcefully supersede the SHIP/NEEDS WORK/BLOCKED wording.
+    expect(prompt).toContain('Disregard the SHIP');
+  });
+
+  it('prepends verbatim feedback when provided', () => {
+    const prompt = assembleVerifierPrompt({ ...base, feedback: 'PRIOR FAIL DETAIL' });
+    expect(prompt).toContain('PRIOR FAIL DETAIL');
+    expect(prompt.indexOf('PRIOR FAIL DETAIL')).toBeLessThan(prompt.indexOf('AGENT BODY'));
+  });
+});
+
+// --- S4-8 criteria degradation ladder ------------------------------------------
+
+describe('loadVerifierCriteria (S4-8 degradation)', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af9-crit-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  function coord(specId) {
+    return { specId };
+  }
+
+  it('uses specs/<spec>/epics/<epic>/ markdown when present', () => {
+    const dir = path.join(tmp, 'specs', 'spec1', 'epics', 'epic-a');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'epic.md'), '# Acceptance\n- do the thing\n');
+    const criteria = loadVerifierCriteria(coord('spec1'), { id: 'epic-a' }, tmp);
+    expect(criteria).toContain('do the thing');
+  });
+
+  it('falls back to spec_path contents + feature names when epics/ dir absent', () => {
+    fs.writeFileSync(path.join(tmp, 'spec-doc.md'), 'SPEC BODY CRITERIA');
+    const epic = {
+      id: 'epic-a',
+      spec_path: 'spec-doc.md',
+      features: [{ name: 'Feature One' }, { name: 'Feature Two' }],
+    };
+    const criteria = loadVerifierCriteria(coord('spec1'), epic, tmp);
+    expect(criteria).toContain('SPEC BODY CRITERIA');
+    expect(criteria).toContain('Feature One');
+    expect(criteria).toContain('Feature Two');
+  });
+
+  it('returns empty string when no epics/, no spec_path, and no features', () => {
+    const criteria = loadVerifierCriteria(coord('spec1'), { id: 'epic-a', features: [] }, tmp);
+    expect(criteria).toBe('');
+  });
+});
+
+// --- attempts round-trip persistence -------------------------------------------
+
+describe('recordVerifierAttempt round-trip', () => {
+  it('persists attempts to loop state and survives JSON serialize/parse', () => {
+    const state = { iteration: 2, run_id: 'r1' };
+    recordVerifierAttempt(state, 'epic-a', {
+      attempt: 1,
+      verdict: 'FAIL',
+      feedback: 'x',
+      cost_usd: 0.5,
+    });
+    recordVerifierAttempt(state, 'epic-a', {
+      attempt: 2,
+      verdict: 'PASS',
+      feedback: '',
+      cost_usd: 0.7,
+    });
+    const roundTripped = JSON.parse(JSON.stringify(state));
+    expect(roundTripped.verifier_attempts).toHaveLength(2);
+    expect(roundTripped.verifier_attempts[0]).toMatchObject({
+      task_id: 'epic-a',
+      attempt: 1,
+      verdict: 'FAIL',
+      run_id: 'r1',
+    });
+    expect(roundTripped.verifier_attempts[1].verdict).toBe('PASS');
+  });
+});
+
+// --- runVerifierGate: the gate + retry sub-loop --------------------------------
+
+describe('runVerifierGate', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af9-gate-'));
+    // A resolvable criteria source so the gate does not skip on missing criteria.
+    const dir = path.join(tmp, 'specs', 'spec1', 'epics', 'epic-a');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'epic.md'), '# Acceptance\n- ship it\n');
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  const task = { id: 'epic-a', name: 'Epic A' };
+  function ctxBase(overrides = {}) {
+    return {
+      coord: { specId: 'spec1' },
+      task,
+      state: { iteration: 1, total_cost: 0 },
+      options: { verifier: true, maxRetries: 2, verifyCommand: ['true'] },
+      cwd: tmp,
+      projectRoot: tmp,
+      spawnImplementer: jest.fn(() => ({ exitCode: 0, stdout: '', costUsd: 1 })),
+      spawnVerifier: jest.fn(),
+      buildImplementerPrompt: (fb) => `IMPL ${fb}`,
+      runFloor: jest.fn(() => true),
+      ...overrides,
+    };
+  }
+
+  it('--verifier OFF → no-op, NO verifier session spawned (byte-identical)', () => {
+    const ctx = ctxBase({ options: { verifier: false } });
+    const out = runVerifierGate(ctx);
+    expect(out.passed).toBe(true);
+    expect(out.skipped).toBe(true);
+    expect(ctx.spawnVerifier).not.toHaveBeenCalled();
+    expect(ctx.spawnImplementer).not.toHaveBeenCalled();
+  });
+
+  it('verdict PASS first try → passes, no implementer re-spawn', () => {
+    const ctx = ctxBase();
+    ctx.spawnVerifier.mockReturnValue({ exitCode: 0, stdout: 'Final verdict: PASS', costUsd: 0.3 });
+    const out = runVerifierGate(ctx);
+    expect(out.passed).toBe(true);
+    expect(ctx.spawnImplementer).not.toHaveBeenCalled();
+    expect(ctx.state.verifier_attempts).toHaveLength(1);
+    expect(ctx.state.total_cost).toBeCloseTo(0.3);
+  });
+
+  it('FAIL → verbatim feedback re-spawn → PASS → passes', () => {
+    const ctx = ctxBase();
+    ctx.spawnVerifier
+      .mockReturnValueOnce({
+        exitCode: 0,
+        stdout: 'missing test X\nFinal verdict: FAIL',
+        costUsd: 0.2,
+      })
+      .mockReturnValueOnce({ exitCode: 0, stdout: 'Final verdict: PASS', costUsd: 0.2 });
+    const out = runVerifierGate(ctx);
+    expect(out.passed).toBe(true);
+    expect(ctx.spawnImplementer).toHaveBeenCalledTimes(1);
+    // The implementer re-spawn received the verbatim FAIL feedback.
+    expect(ctx.spawnImplementer.mock.calls[0][0]).toContain('missing test X');
+    expect(ctx.state.verifier_attempts.map((a) => a.verdict)).toEqual(['FAIL', 'PASS']);
+  });
+
+  it('FAIL exhausted → blocked with last verdict; attempts persisted', () => {
+    const ctx = ctxBase({ options: { verifier: true, maxRetries: 1, verifyCommand: ['true'] } });
+    ctx.spawnVerifier.mockReturnValue({
+      exitCode: 0,
+      stdout: 'nope\nFinal verdict: FAIL',
+      costUsd: 0.1,
+    });
+    const out = runVerifierGate(ctx);
+    expect(out.passed).toBe(false);
+    expect(out.verdict).toBe('FAIL');
+    // maxRetries=1 → 2 verifier attempts (initial + 1 retry), 1 implementer re-spawn.
+    expect(ctx.spawnVerifier).toHaveBeenCalledTimes(2);
+    expect(ctx.spawnImplementer).toHaveBeenCalledTimes(1);
+    expect(ctx.state.verifier_attempts).toHaveLength(2);
+  });
+
+  it('UNPARSEABLE verdict → blocked, NEVER inferred PASS (verifier exit 0)', () => {
+    const ctx = ctxBase();
+    // SHIP-only — the agent body's own vocabulary, no parseable verdict line.
+    ctx.spawnVerifier.mockReturnValue({
+      exitCode: 0,
+      stdout: '### Assessment\nSHIP',
+      costUsd: 0.1,
+    });
+    const out = runVerifierGate(ctx);
+    expect(out.passed).toBe(false);
+    expect(out.unparseable).toBe(true);
+    expect(out.verdict).toBeNull();
+    // No retry on unparseable — it blocks immediately for escalation.
+    expect(ctx.spawnImplementer).not.toHaveBeenCalled();
+  });
+
+  it('cost-stop > retry: maxCost crossing stops retry without re-spawning implementer', () => {
+    const ctx = ctxBase({
+      options: { verifier: true, maxRetries: 5, maxCost: 1, verifyCommand: ['true'] },
+      state: { iteration: 1, total_cost: 0 },
+    });
+    // First verifier FAILs and its cost crosses maxCost (1) → no implementer re-spawn.
+    ctx.spawnVerifier.mockReturnValue({
+      exitCode: 0,
+      stdout: 'fail\nFinal verdict: FAIL',
+      costUsd: 1.5,
+    });
+    const out = runVerifierGate(ctx);
+    expect(out.passed).toBe(false);
+    expect(out.verdict).toBe('FAIL');
+    expect(ctx.spawnVerifier).toHaveBeenCalledTimes(1);
+    expect(ctx.spawnImplementer).not.toHaveBeenCalled();
+  });
+
+  it('S4-8: missing criteria → verifier SKIPPED (not blocked), no session, warning fires', () => {
+    // Empty epic dir, no spec_path, no features → no criteria resolvable.
+    const ctx = ctxBase({
+      coord: { specId: 'spec-none' },
+      task: { id: 'epic-z', name: 'Epic Z', features: [] },
+    });
+    const out = runVerifierGate(ctx);
+    expect(out.passed).toBe(true);
+    expect(out.skipped).toBe(true);
+    expect(ctx.spawnVerifier).not.toHaveBeenCalled();
+    // The skip must emit a warning (acceptance: "verifier 跳過 + warning").
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Verifier skipped'));
+  });
+});
+
+describe('DEFAULT_MAX_RETRIES', () => {
+  it('defaults to 2', () => {
+    expect(DEFAULT_MAX_RETRIES).toBe(2);
+  });
+});


### PR DESCRIPTION
## Wave 5 · AF-9 — verifier-agent + retry 協議（疊在 AF-8 floor 上）

New `scripts/lib/loop-verifier.js` owns the whole gate+retry sub-loop, layered on AF-8's `--verify-cmd` deterministic floor.

### Design
- `--verifier` flag (opt-in, off by default → **zero extra session, byte-identical when absent**). Added to `cli-manifest.js` loop flags (SRH-2 contract green).
- Verifier prompt **assembled at runtime** = `agents/verifier.md` body + epic acceptance criteria + verify-cmd evidence instruction + a forceful `Final verdict: PASS|FAIL` override — **`agents/verifier.md` is NOT edited** (`git diff --stat` empty).
- **`parseVerdict` has NO exit-code fallback** — last `Final verdict: PASS|FAIL` line, markdown-tolerant; SHIP/garbage/empty → null → **block, never infer PASS**. This is the task's reason for existing.
- **S4-8 missing-criteria degradation**: `specs/<id>/epics/<id>/` md → spec_path doc + feature names → `''` = **skip verifier + warning** (never spawn with empty criteria; AF-8 floor still gates).
- FAIL → verbatim cumulative feedback prepended → re-spawn ≤ `--max-retries` (default 2) → blockTask with last verdict; cost → total_cost; **maxCost checked before each re-spawn (cost-stop > retry)**.

### Acceptance (replayed by reviewer)
FAIL→retry→PASS→complete ✅ · FAIL exhausted→blocked+verdict ✅ · attempts round-trip (real saveLoopState/.arcforge-loop.json) ✅ · verifier cwd=worktree, cost accounted ✅ · --verifier absent byte-identical ✅ · verifier.md untouched ✅ · missing-epics→skip+warning ✅ · `npm test` green ✅

**Notes**: loop-verifier.js 419 lines (cohesion-justified, ~45% JSDoc, <700 cap). In sequential mode `nextTask` returns Features (no criteria) → verifier skips-with-warning; `--verifier` is effectively dag/epic-oriented (the north-star path). Iron Law: no SKILL.md edit → no eval (AF-14 if any follow-up).