### PR TITLE
feat(learning): instinct→candidate lifecycle alignment + learning-surface truth sweep (ICL-6, ICL-7)

### DIFF
--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -1,20 +1,46 @@
 # Session Tracker Hook
 
-Provides session persistence across Claude Code sessions.
+Provides session persistence and SessionStart context injection.
+
+## Scripts
+
+| Script | Event | Mode | Role |
+|--------|-------|------|------|
+| `inject-context.js` | SessionStart | sync | Inject context to Claude + a user summary |
+| `start.js` | SessionStart | async | Background init (session file, observer daemon, decay) |
+| `end.js` | Stop | — | Session metrics + diary-capture |
 
 ## Features
 
-### On Session Start
-- Loads context from recent sessions (last 7 days)
-- Shows notes, tool counts, and modified files from previous session
-- Initializes new session file
-- Filters out diary files (`diary-*.md`) from session loading
+### On Session Start — context injection (`inject-context.js`, sync)
 
-**Note:** Counters are NOT reset on session start. They accumulate across sessions until the threshold is met (in `pre-compact/main.js` or `session-tracker/end.js`).
+Emits one combined JSON with two channels (see `hooks.md` → Output Visibility):
 
-### On Session End (Stop)
+- **additionalContext** (Claude-visible): activated behavioral instincts,
+  pending action notifications, stale-draft warnings.
+- **systemMessage** (user-visible): a brief one-line summary, plus
+  discoverability hints (available session aliases, recent global promotions).
+
+Activated instincts are **activation-gated** (ICL-4): an instinct is injected
+only when a reviewer explicitly activated it on the dashboard and has not since
+deactivated it. Confidence sorts and caps the list at the **top 5** — it is never
+a threshold. The `inject_activated_instincts` kill-switch is **default ON**; an
+explicit `false` in the global learning config silences injection.
+
+### On Session Start — background tasks (`start.js`, async)
+
+- Initializes the new session file (filters out diary files `diary-*.md`)
+- Checks/starts the observer daemon
+- Runs decay cycles on instincts
+
+**Note:** Diary-trigger counters are NOT reset on session start. They accumulate
+across sessions until the threshold is met; reset is owned exclusively by
+`diary-capture.js` (run from `end.js` and `pre-compact/main.js`).
+
+### On Session End (Stop) — `end.js`
 - Saves session metrics (duration, tool calls)
 - Records modified files from git status
+- Runs diary-capture (threshold-gated draft + counter reset)
 - Outputs session summary
 
 ## Triggers

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -5,15 +5,12 @@
  * Runs SYNCHRONOUSLY on SessionStart with dual output:
  *
  * systemMessage (user-visible):
- * - Brief summary: instinct count, pending actions
+ * - Brief summary: instinct count, pending actions, session aliases,
+ *   recent global promotions
  *
  * additionalContext (Claude-visible):
  * - Full instinct details with confidence scores
  * - Pending action notifications
- *
- * stderr (internal diagnostics):
- * - Available session aliases
- * - Global instinct promotions
  */
 
 const fs = require('node:fs');
@@ -26,7 +23,6 @@ const {
   getProjectDiariesDir,
   getProjectSessionsDir,
   outputCombined,
-  log,
 } = require('../../scripts/lib/utils');
 
 const {
@@ -295,28 +291,30 @@ function loadPendingActions(project) {
 }
 
 /**
- * Load session aliases and log to stderr for discoverability.
+ * Build a user-summary line for available session aliases (discoverability).
+ * @returns {string|null} summary line, or null when there are no aliases
  */
-function logAvailableAliases(project) {
+function loadAvailableAliases(project) {
   try {
     const { listAliases } = require('../../scripts/lib/session-aliases');
     const aliases = listAliases(project);
     if (aliases.length > 0) {
-      const names = aliases.map((a) => a.name).join(', ');
-      log(`${aliases.length} session aliases available: ${names}`);
+      return `${aliases.length} session alias${aliases.length === 1 ? '' : 'es'}`;
     }
   } catch {
     // session-aliases not available yet — skip
   }
+  return null;
 }
 
 /**
- * Check global index for newly promoted patterns (stderr only)
+ * Build a user-summary line for patterns promoted to global in the last week.
+ * @returns {string|null} summary line, or null when there are none
  */
-function checkNewGlobalPromotions() {
+function loadNewGlobalPromotions() {
   try {
     const indexPath = getInstinctsGlobalIndex();
-    if (!fs.existsSync(indexPath)) return;
+    if (!fs.existsSync(indexPath)) return null;
 
     const content = fs.readFileSync(indexPath, 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
@@ -336,12 +334,12 @@ function checkNewGlobalPromotions() {
       .filter((entry) => new Date(entry.promoted) > weekAgo);
 
     if (recent.length > 0) {
-      const ids = recent.map((e) => e.id).join(', ');
-      log(`New global instincts (found in multiple projects): ${ids}`);
+      return `${recent.length} new global promotion${recent.length === 1 ? '' : 's'}`;
     }
   } catch {
     // silent
   }
+  return null;
 }
 
 /**
@@ -384,9 +382,15 @@ function main() {
     userParts.push(`${staleWarning.count} unenriched draft${staleWarning.count === 1 ? '' : 's'}`);
   }
 
-  // Stderr-only (internal diagnostics)
-  logAvailableAliases(project);
-  checkNewGlobalPromotions();
+  // Session aliases + recent global promotions — surfaced to the USER summary
+  // (the stderr versions were invisible: Claude Code condenses stderr to
+  // "N hooks ran"). These are discoverability hints for the user, not Claude
+  // context, so they go to userParts only.
+  const aliasSummary = loadAvailableAliases(project);
+  if (aliasSummary) userParts.push(aliasSummary);
+
+  const promotionSummary = loadNewGlobalPromotions();
+  if (promotionSummary) userParts.push(promotionSummary);
 
   const claudeContext = contextParts.length > 0 ? contextParts.join('\n\n') : null;
   const userMessage = userParts.length > 0 ? userParts.join(' | ') : null;
@@ -406,8 +410,8 @@ module.exports = {
   loadStaleDraftWarning,
   renderLoopFinished,
   renderRatifyPending,
-  logAvailableAliases,
-  checkNewGlobalPromotions,
+  loadAvailableAliases,
+  loadNewGlobalPromotions,
 };
 
 // Run if executed directly

--- a/hooks/user-message-counter/README.md
+++ b/hooks/user-message-counter/README.md
@@ -1,19 +1,38 @@
 # User Message Counter Hook
 
-Counts user prompt submissions for session evaluation.
+Counts user prompt submissions toward the diary-capture trigger.
 
 ## Purpose
 
-Tracks the number of user messages in a session to determine if the session is "long enough" to potentially contain extractable learning patterns.
+Tracks the number of user messages in a session so diary-capture can decide
+whether the session is "long enough" to potentially contain extractable
+learning patterns.
 
 ## How It Works
 
-1. **UserPromptSubmit hook** increments a counter on each user message
-2. Counter stored in temp file: `$TMPDIR/arcforge-user-count-<project>-<date>`
-3. Counter read by `session-tracker` on Stop to evaluate session
-4. Counter resets **only when threshold is met** (in `pre-compact/main.js` or `session-tracker/end.js`)
+1. **UserPromptSubmit hook** increments the `user-count` counter on each user message.
+2. Counter stored in a session-scoped temp file (see [Counter File](#counter-file)).
+3. The counter is **read and reset only by `diary-capture.js`** (via `readCounts()` /
+   `resetCounters()`), invoked from the Stop hook (`session-tracker/end.js`) and the
+   PreCompact hook (`pre-compact/main.js`).
 
-**Note:** Counters accumulate across resume/exit cycles until the threshold is reached (`userCount >= 10 OR toolCount >= 50`). This allows meaningful sessions to be captured even if split across multiple short sessions.
+## Counter-Ownership Contract
+
+`diary-capture.js` defines a single-writer-per-counter contract (ICL-8):
+
+| Counter | Written by | Read + reset by |
+|---------|-----------|-----------------|
+| `user-count` | **this hook** (UserPromptSubmit) | `diary-capture.js` |
+| `tool-count` | `compact-suggester` via `incrementSharedToolCount()` | `diary-capture.js` |
+
+This hook is the **sole writer** of `user-count`. It never reads or resets —
+those roles belong exclusively to `diary-capture.js`, which is also the sole
+reset path. There is no reset on session start.
+
+**Note:** Counters accumulate across resume/exit cycles until the threshold is
+reached (`userCount >= 10 OR toolCount >= 50`, per `scripts/lib/thresholds.js`).
+This lets meaningful sessions be captured even when split across several short
+sessions. The reset fires only when the threshold is met inside `runDiaryCapture`.
 
 ## Trigger
 
@@ -21,8 +40,10 @@ Tracks the number of user messages in a session to determine if the session is "
 
 ## Counter File
 
+Session-scoped, in the system temp dir:
+
 ```
-$TMPDIR/arcforge-user-count-arcforge-2025-01-24
+$TMPDIR/arcforge-user-count-<session-id>
 ```
 
 Contains a single integer representing the count.
@@ -30,18 +51,17 @@ Contains a single integer representing the count.
 ## Exported Functions
 
 ```javascript
-const { readCount, resetCounter } = require('../user-message-counter/main');
-
-// Read current count
-const count = readCount();  // e.g., 15
-
-// Reset counter (called from session-tracker/start.js)
-resetCounter();
+const { readCount, writeCount, resetCounter, getCounterFilePath } =
+  require('../user-message-counter/main');
 ```
+
+These thin wrappers over the shared `createSessionCounter('user-count')` exist
+for tests; production read/reset go through `diary-capture.js` per the
+counter-ownership contract above.
 
 ## Design Notes
 
-**Why temp file instead of reading transcript?**
+**Why a temp file instead of reading the transcript?**
 - Memory safe (transcripts can grow large)
-- Follows existing compact-suggester pattern
-- No dependency on CLAUDE_TRANSCRIPT_PATH availability
+- Follows the existing compact-suggester pattern
+- No dependency on `CLAUDE_TRANSCRIPT_PATH` availability

--- a/scripts/lib/learning-curator/dashboard-events.js
+++ b/scripts/lib/learning-curator/dashboard-events.js
@@ -174,4 +174,29 @@ function appendRelatedEvent(sourceCandidateId, patch, actor) {
   });
 }
 
-module.exports = { appendTransitionEvent, appendRelatedEvent };
+/**
+ * Append a candidate.updated event for an existing candidate.
+ *
+ * readCurrentCandidates() merges the patch onto the candidate record wholesale,
+ * so callers should pass a top-level field patch (e.g. { feedback: {...} }).
+ *
+ * @param {string} candidateId
+ * @param {object} patch — top-level field patch merged onto the candidate record
+ * @param {object} [actor]
+ */
+function appendUpdateEvent(candidateId, patch, actor) {
+  withStoreLock(() => {
+    const event = {
+      schema_version: 1,
+      event_id: generateEventId(),
+      ts: new Date().toISOString(),
+      candidate_id: candidateId,
+      event_type: 'candidate.updated',
+      actor: actor || { layer: 6, actor_type: 'dashboard' },
+      patch,
+    };
+    appendJsonlLine(getQueuePath(), event);
+  });
+}
+
+module.exports = { appendTransitionEvent, appendRelatedEvent, appendUpdateEvent };

--- a/scripts/lib/learning-dashboard.js
+++ b/scripts/lib/learning-dashboard.js
@@ -112,6 +112,20 @@ function evidenceQualityChip(quality) {
 }
 
 /**
+ * Build the integer-only feedback counts block for a card (ICL-6).
+ * confirm/contradict on a curator-activated instinct mirror running counts back
+ * to the candidate record as `record.feedback`. Only the integer counts are
+ * surfaced — never raw payloads — keeping the card allowlist intact. Returns
+ * undefined when the candidate carries no feedback (omits the field entirely).
+ */
+function buildCardFeedback(feedback) {
+  if (!feedback || typeof feedback !== 'object') return undefined;
+  const confirmations = Number.isFinite(feedback.confirmations) ? feedback.confirmations : 0;
+  const contradictions = Number.isFinite(feedback.contradictions) ? feedback.contradictions : 0;
+  return { confirmations, contradictions };
+}
+
+/**
  * Build a DashboardCandidateCard from a CandidateQueueRecord per Layer 6 spec.
  * Returns only allowlisted fields. project_id intentionally excluded.
  *
@@ -123,6 +137,7 @@ function sanitizeDashboardCard(record) {
   const llmAssessment = record.llm_assessment || {};
   const chip = evidenceQualityChip(record.evidence_quality);
   const hasRelationships = record.relationships !== undefined && record.relationships !== null;
+  const feedback = buildCardFeedback(record.feedback);
 
   return {
     schema_version: 1,
@@ -144,6 +159,7 @@ function sanitizeDashboardCard(record) {
     available_actions: legalActionsFor(status),
     ...(chip !== undefined && { evidence_quality_chip: chip }),
     ...(hasRelationships && { relationships: record.relationships }),
+    ...(feedback !== undefined && { feedback }),
   };
 }
 

--- a/scripts/lib/thresholds.js
+++ b/scripts/lib/thresholds.js
@@ -4,7 +4,7 @@
  * Shared module for determining when to trigger diary/evaluation actions.
  * Counters accumulate across resume/exit cycles until threshold is reached.
  *
- * NOTE: This is the canonical location. hooks/lib/thresholds.js should import from here.
+ * Canonical source — hooks import this directly (there is no hooks/lib/ layer).
  */
 
 const MIN_USER_MESSAGES = 10;

--- a/skills/arc-learning/SKILL.md
+++ b/skills/arc-learning/SKILL.md
@@ -43,7 +43,7 @@ Use `--json` on any command when another tool or test needs machine-readable out
 5. **Approve or dismiss.** Use the dashboard `[Approve]` or `[Dismiss]` action. Approval is required before any artifact is written.
 6. **Materialize as inactive drafts.** Use the dashboard `[Materialize]` action. Draft artifacts are written to `~/.arcforge/learning/drafts/<candidate-id>/<materialization-id>/instincts/<name>.md` — these are inactive review files; they are not loaded into Claude context.
 7. **Inspect before activation.** Open the candidate card on the dashboard; preview the draft body before activating.
-8. **Explicit activation.** Use the dashboard `[Activate]` action only after reviewing the draft. Activation copies the draft to `~/.arcforge/instincts/<project>/<candidate-id>.md` (project scope) or `~/.arcforge/instincts/global/<candidate-id>.md` (global scope), with `supersede_with_backup` if an active artifact already exists at that path. SessionStart never auto-loads activated instinct bodies — surfacing is via dashboard / `arc-recalling` only.
+8. **Explicit activation.** Use the dashboard `[Activate]` action only after reviewing the draft. Activation copies the draft to `~/.arcforge/instincts/<project>/<candidate-id>.md` (project scope) or `~/.arcforge/instincts/global/<candidate-id>.md` (global scope), with `supersede_with_backup` if an active artifact already exists at that path. Once activated, the instinct is injected at SessionStart through that activation gate only — the top 5 by confidence (sort/cap, not a threshold), with an `inject_activated_instincts` kill-switch (default ON). Non-activated candidates are never injected.
 
 ## Candidate Lifecycle Statuses
 

--- a/skills/arc-observing/SKILL.md
+++ b/skills/arc-observing/SKILL.md
@@ -45,7 +45,7 @@ The observer daemon is a four-layer orchestrator:
 3. **LLM curation** (Layer 4): Daemon invokes `claude --model haiku --max-turns 15 --print --output-format json --json-schema` with the batch. The LLM curator produces structured candidate proposals rather than direct instinct file writes
 4. **Ingestion** (Layer 5): Daemon calls `node $CURATOR_CLI ingest-proposal --batch-id --response-file` to parse the LLM response and append candidates to the review queue at `~/.arcforge/learning/candidates/queue.jsonl`
 
-The daemon never writes instinct `.md` files directly, and SessionStart never auto-loads instinct bodies into Claude context. All candidate proposals flow through the LLM curator into the review queue; human review via `arcforge learn dashboard` is the only path that produces active instinct files (Layer 8 activation), and activated instincts are surfaced through dashboard / history / evolve flows rather than runtime auto-injection.
+The daemon never writes instinct `.md` files directly, and SessionStart never auto-loads instinct bodies by confidence. All candidate proposals flow through the LLM curator into the review queue; human review via `arcforge learn dashboard` is the only path that produces active instinct files (Layer 8 activation). Dashboard-activated instincts are injected at SessionStart, but only through that explicit activation gate — the top 5 by confidence, with confidence used to sort and cap rather than as a threshold, and an `inject_activated_instincts` kill-switch (default ON).
 
 ## Instinct Format
 

--- a/skills/arc-observing/scripts/instinct.js
+++ b/skills/arc-observing/scripts/instinct.js
@@ -14,9 +14,7 @@ const {
   updateConfidenceFrontmatter,
   applyConfirmation,
   applyContradiction,
-  shouldAutoLoad,
   shouldArchive,
-  AUTO_LOAD_THRESHOLD,
   ARCHIVE_THRESHOLD
 } = require('../../../scripts/lib/confidence');
 
@@ -27,6 +25,17 @@ const {
 } = require('../../../scripts/lib/session-utils');
 
 const { sanitizeFilename } = require('../../../scripts/lib/utils');
+
+const { readCurrentCandidates } = require('../../../scripts/lib/learning-curator/queue-writer');
+const {
+  appendTransitionEvent,
+  appendUpdateEvent
+} = require('../../../scripts/lib/learning-curator/dashboard-events');
+const {
+  isLegalAction,
+  LIFECYCLE_STATUS,
+  LIFECYCLE_ACTION
+} = require('../../../scripts/lib/learning-curator/lifecycle');
 
 // ─────────────────────────────────────────────
 // Helpers
@@ -83,6 +92,67 @@ function pct(confidence) {
   return `${Math.round(confidence * 100)}%`;
 }
 
+/**
+ * Align confirm/contradict feedback on a curator-activated candidate (ICL-6).
+ *
+ * Curator-activated instincts carry `id == candidate_id` (set by activate.js).
+ * When such an instinct is confirmed or contradicted, mirror the running
+ * feedback counts back to the Layer 5 candidate store as a `candidate.updated`
+ * patch so the dashboard card stays consistent with the instinct frontmatter.
+ *
+ * When a contradiction archives the instinct AND the matched candidate is
+ * currently `activated`, also append a `deactivate` lifecycle transition —
+ * gated through `lifecycle.isLegalAction`. This stays inside the curator event
+ * log (the file remains in the instinct's own `archived/` dir); it does NOT run
+ * activate.js's physical move-to-`.disabled/` or its reviewer_ack consent model.
+ *
+ * Candidate lookup uses `readCurrentCandidates()` — the HOME-global event log
+ * replayed under the store lock — NOT the project-local legacy queue. A
+ * non-curator instinct simply has no matching candidate: no event, no crash.
+ *
+ * @param {string} instinctId
+ * @param {{confirmations: number, contradictions: number}} feedback
+ * @param {boolean} archived — true when the contradiction archived the instinct
+ */
+function syncCuratorCandidate(instinctId, feedback, archived) {
+  try {
+    const candidates = readCurrentCandidates();
+    const candidate = candidates[instinctId];
+    if (!candidate) return;
+
+    const actor = { layer: 6, actor_type: 'instinct_cli' };
+
+    appendUpdateEvent(
+      instinctId,
+      {
+        feedback: {
+          confirmations: feedback.confirmations,
+          contradictions: feedback.contradictions
+        }
+      },
+      actor
+    );
+
+    if (!archived) return;
+
+    const status = candidate.lifecycle ? candidate.lifecycle.status : undefined;
+    if (
+      status === LIFECYCLE_STATUS.ACTIVATED &&
+      isLegalAction(status, LIFECYCLE_ACTION.DEACTIVATE)
+    ) {
+      appendTransitionEvent(
+        instinctId,
+        LIFECYCLE_ACTION.DEACTIVATE,
+        LIFECYCLE_STATUS.DEACTIVATED,
+        actor
+      );
+    }
+  } catch {
+    // Curator store unavailable or locked — instinct file write already
+    // succeeded; do not crash the CLI over best-effort lifecycle alignment.
+  }
+}
+
 // ─────────────────────────────────────────────
 // Commands
 // ─────────────────────────────────────────────
@@ -123,10 +193,9 @@ function cmdStatus(project) {
       for (const inst of items) {
         const conf = inst.frontmatter.confidence || 0;
         const bar = confidenceBar(conf);
-        const autoLoad = shouldAutoLoad(conf) ? ' [auto-loaded]' : '';
         const trigger = inst.frontmatter.trigger || '';
 
-        console.log(`  ${bar}  ${pct(conf)}  ${inst.id}${autoLoad}`);
+        console.log(`  ${bar}  ${pct(conf)}  ${inst.id}`);
         if (trigger) {
           console.log(`            trigger: ${trigger}`);
         }
@@ -157,14 +226,16 @@ function cmdStatus(project) {
   }
 
   // Summary
-  const autoLoaded = instincts.filter(i => shouldAutoLoad(i.frontmatter.confidence || 0));
   const atRisk = instincts.filter(i => {
     const c = i.frontmatter.confidence || 0;
     return c < 0.3 && c >= ARCHIVE_THRESHOLD;
   });
 
   console.log('---');
-  console.log(`Auto-loaded (>= ${AUTO_LOAD_THRESHOLD}): ${autoLoaded.length}`);
+  console.log(
+    'Injection is activation-gated: activate instincts via `arcforge learn dashboard`. ' +
+      'Activated instincts are injected at SessionStart (top 5 by confidence; confidence sorts/caps, it is not a threshold).'
+  );
   if (atRisk.length > 0) {
     console.log(`At risk (< 0.3): ${atRisk.map(i => i.id).join(', ')}`);
   }
@@ -198,13 +269,15 @@ function cmdConfirm(instinctId, project) {
 
   fs.writeFileSync(filePath, updated, 'utf-8');
 
+  syncCuratorCandidate(
+    instinctId,
+    { confirmations, contradictions: frontmatter.contradictions || 0 },
+    false
+  );
+
   console.log(`Confirmed: ${instinctId}`);
   console.log(`  ${confidenceBar(oldConfidence)} ${pct(oldConfidence)} → ${confidenceBar(newConfidence)} ${pct(newConfidence)}`);
   console.log(`  Confirmations: ${confirmations}`);
-
-  if (shouldAutoLoad(newConfidence) && !shouldAutoLoad(oldConfidence)) {
-    console.log(`  Now auto-loaded into sessions (>= ${AUTO_LOAD_THRESHOLD})`);
-  }
 }
 
 /**
@@ -245,11 +318,23 @@ function cmdContradict(instinctId, project) {
     fs.writeFileSync(path.join(archivedDir, `${instinctId}.md`), archivedContent, 'utf-8');
     fs.unlinkSync(filePath);
 
+    syncCuratorCandidate(
+      instinctId,
+      { confirmations: frontmatter.confirmations || 0, contradictions },
+      true
+    );
+
     console.log(`Contradicted & archived: ${instinctId}`);
     console.log(`  ${confidenceBar(oldConfidence)} ${pct(oldConfidence)} → ${confidenceBar(newConfidence)} ${pct(newConfidence)}`);
     console.log(`  Confidence below ${ARCHIVE_THRESHOLD} — moved to archived/`);
   } else {
     fs.writeFileSync(filePath, updated, 'utf-8');
+
+    syncCuratorCandidate(
+      instinctId,
+      { confirmations: frontmatter.confirmations || 0, contradictions },
+      false
+    );
 
     console.log(`Contradicted: ${instinctId}`);
     console.log(`  ${confidenceBar(oldConfidence)} ${pct(oldConfidence)} → ${confidenceBar(newConfidence)} ${pct(newConfidence)}`);
@@ -373,6 +458,7 @@ module.exports = {
   loadInstincts,
   confidenceBar,
   pct,
+  syncCuratorCandidate,
   cmdStatus,
   cmdConfirm,
   cmdContradict,

--- a/tests/scripts/instinct-curator-lifecycle.test.js
+++ b/tests/scripts/instinct-curator-lifecycle.test.js
@@ -1,0 +1,309 @@
+// tests/scripts/instinct-curator-lifecycle.test.js
+//
+// ICL-6: confirm/contradict on a curator-activated instinct must align the
+// Layer 5 candidate lifecycle.
+//
+// - contradiction-archive on an activated candidate appends a `deactivate`
+//   lifecycle transition (gated through lifecycle.isLegalAction), so the
+//   dashboard shows it deactivated. The instinct file stays in its own
+//   archived/ dir — no activate.js .disabled/ move, no reviewer_ack.
+// - confirm/contradict mirror running feedback counts back to the candidate
+//   record so the dashboard card matches the instinct frontmatter.
+// - a non-curator instinct (no matching candidate) produces no event and no
+//   crash.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+let tmpDir;
+let homedirSpy;
+
+beforeEach(() => {
+  jest.resetModules();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instinct-curator-'));
+  homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tmpDir);
+});
+
+afterEach(() => {
+  homedirSpy.mockRestore();
+  jest.resetModules();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function getInstinct() {
+  return require('../../skills/arc-observing/scripts/instinct');
+}
+
+function getWriter() {
+  return require('../../scripts/lib/learning-curator/queue-writer');
+}
+
+function getDashboardEvents() {
+  return require('../../scripts/lib/learning-curator/dashboard-events');
+}
+
+function getDashboard() {
+  return require('../../scripts/lib/learning-dashboard');
+}
+
+const PROJECT = 'arcforge';
+const CANDIDATE_ID = 'cand_instinct_20260521T010000Z_a1b2c3d4e5f6';
+
+// Minimal valid CandidateQueueRecord (mirrors the queue-writer test fixture).
+function makeValidRecord(overrides = {}) {
+  return {
+    schema_version: 1,
+    candidate_id: CANDIDATE_ID,
+    created_at: '2026-05-21T01:00:00.000Z',
+    updated_at: '2026-05-21T01:00:00.000Z',
+    artifact_type: 'instinct',
+    scope: { kind: 'project', project: PROJECT, project_id: 'proj_abc' },
+    source: { source_type: 'layer4_llm_curator' },
+    name: 'grep before editing',
+    summary: 'Always grep for existing patterns before making edits',
+    rationale: 'Prevents duplicate code and missed context',
+    domain: 'workflow',
+    body: 'When editing files, first grep for existing patterns to avoid duplication',
+    body_source: 'llm_curator',
+    evidence: [
+      {
+        evidence_id: 'ev_abc123',
+        evidence_type: 'observation',
+        relevance: 'User repeatedly used grep before editing files',
+        summary: 'Observed grep-first pattern 5 times across 3 sessions',
+      },
+      {
+        evidence_id: 'ev_def456',
+        evidence_type: 'observation',
+        relevance: 'Second observation supporting the pattern',
+        summary: 'Confirmed grep-first pattern in another session',
+      },
+    ],
+    evidence_quality: 'medium',
+    evidence_quality_metadata: {
+      rule_version: 'v1',
+      basis: {
+        project_obs_count: 500,
+        cited_evidence_count: 1,
+        cited_evidence_by_type: {
+          observation: 1,
+          diary: 0,
+          reflect: 0,
+          recall: 0,
+          session_summary: 0,
+        },
+        has_user_correction: false,
+        has_manual_recall: false,
+        has_reflect_pattern: false,
+        has_error_repair_sequence: false,
+      },
+    },
+    lifecycle: {
+      status: 'pending_review',
+      status_changed_at: '2026-05-21T01:00:00.000Z',
+    },
+    safety: {
+      validator_version: 'v1',
+      sanitizer_policy_version: 'v1',
+      sanitizer_module: 'scripts/lib/sanitize-observation.js',
+      raw_prompt_included: false,
+      raw_response_included: false,
+      raw_hook_payloads_included: false,
+      raw_transcripts_included: false,
+      edit_bodies_included: false,
+      skill_args_included: false,
+      secret_scan: { status: 'passed', rule_version: 'v1' },
+      activation_claim_scan: { status: 'passed' },
+      file_write_claim_scan: { status: 'passed' },
+    },
+    dedupe: {
+      dedupe_key: 'project:proj_abc:instinct:grep-before-editing',
+      dedupe_basis: {
+        scope_kind: 'project',
+        project_id: 'proj_abc',
+        artifact_type: 'instinct',
+        normalized_name: 'grep-before-editing',
+        normalized_body_hash: 'abc123def456',
+      },
+    },
+    ...overrides,
+  };
+}
+
+// Seed an activated curator candidate in the HOME-global candidate store by
+// replaying lifecycle transitions through the event log.
+function seedActivatedCandidate() {
+  const { appendCandidate } = getWriter();
+  const { appendTransitionEvent } = getDashboardEvents();
+  appendCandidate(makeValidRecord());
+  appendTransitionEvent(CANDIDATE_ID, 'approve', 'approved');
+  appendTransitionEvent(CANDIDATE_ID, 'materialize', 'materialized');
+  appendTransitionEvent(CANDIDATE_ID, 'activate', 'activated');
+}
+
+function instinctsDir() {
+  return path.join(tmpDir, '.arcforge', 'instincts', PROJECT);
+}
+
+// Write a curator-sourced active instinct file (id == candidate_id).
+function writeCuratorInstinct(
+  id,
+  { confidence = 0.5, confirmations = 0, contradictions = 0 } = {},
+) {
+  const dir = instinctsDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const content = `---
+id: ${id}
+trigger: "when editing"
+domain: workflow
+source: curator
+confidence: ${confidence.toFixed(2)}
+extracted: 2026-05-21
+last_confirmed: 2026-05-21
+confirmations: ${confirmations}
+contradictions: ${contradictions}
+---
+
+# ${id}
+
+## Action
+Grep before editing.`;
+  fs.writeFileSync(path.join(dir, `${id}.md`), content, 'utf-8');
+}
+
+function readQueueEvents() {
+  const queuePath = path.join(tmpDir, '.arcforge', 'learning', 'candidates', 'queue.jsonl');
+  if (!fs.existsSync(queuePath)) return [];
+  return fs
+    .readFileSync(queuePath, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+describe('ICL-6: contradiction-archive deactivates a curator-activated candidate', () => {
+  it('repeated contradict to archive appends a deactivate transition event', () => {
+    seedActivatedCandidate();
+    writeCuratorInstinct(CANDIDATE_ID, { confidence: 0.5 });
+
+    const { cmdContradict } = getInstinct();
+    // 0.50 → 0.40 → 0.30 → 0.20 → 0.10 (< ARCHIVE_THRESHOLD 0.15)
+    for (let i = 0; i < 4; i++) {
+      cmdContradict(CANDIDATE_ID, PROJECT);
+    }
+
+    // Active file moved to the instinct's own archived/ dir (NOT .disabled/).
+    expect(fs.existsSync(path.join(instinctsDir(), `${CANDIDATE_ID}.md`))).toBe(false);
+    expect(fs.existsSync(path.join(instinctsDir(), 'archived', `${CANDIDATE_ID}.md`))).toBe(true);
+    expect(fs.existsSync(path.join(instinctsDir(), '.disabled'))).toBe(false);
+
+    const events = readQueueEvents();
+    const deactivateEvents = events.filter(
+      (e) =>
+        e.event_type === 'candidate.transitioned' &&
+        e.action === 'deactivate' &&
+        e.candidate_id === CANDIDATE_ID,
+    );
+    expect(deactivateEvents.length).toBe(1);
+    expect(deactivateEvents[0].next_status).toBe('deactivated');
+    // Honest actor — NOT the dashboard.
+    expect(deactivateEvents[0].actor.actor_type).toBe('instinct_cli');
+  });
+
+  it('dashboard shows the candidate deactivated after archive (lifecycle.status)', () => {
+    seedActivatedCandidate();
+    writeCuratorInstinct(CANDIDATE_ID, { confidence: 0.5 });
+
+    const { cmdContradict } = getInstinct();
+    for (let i = 0; i < 4; i++) {
+      cmdContradict(CANDIDATE_ID, PROJECT);
+    }
+
+    const { readCurrentCandidates } = getWriter();
+    const candidate = readCurrentCandidates()[CANDIDATE_ID];
+    // lifecycle.status assertion — proves the curator store (not legacy file) was read.
+    expect(candidate.lifecycle.status).toBe('deactivated');
+
+    const { createDashboardModel } = getDashboard();
+    const card = createDashboardModel().candidates.find((c) => c.candidate_id === CANDIDATE_ID);
+    expect(card.lifecycle_status).toBe('deactivated');
+  });
+
+  it('a single contradiction (no archive) does NOT deactivate', () => {
+    seedActivatedCandidate();
+    writeCuratorInstinct(CANDIDATE_ID, { confidence: 0.5 });
+
+    const { cmdContradict } = getInstinct();
+    cmdContradict(CANDIDATE_ID, PROJECT); // 0.50 → 0.40, no archive
+
+    const deactivateEvents = readQueueEvents().filter(
+      (e) => e.event_type === 'candidate.transitioned' && e.action === 'deactivate',
+    );
+    expect(deactivateEvents.length).toBe(0);
+
+    const { readCurrentCandidates } = getWriter();
+    expect(readCurrentCandidates()[CANDIDATE_ID].lifecycle.status).toBe('activated');
+  });
+});
+
+describe('ICL-6: non-curator instinct → no event, no crash', () => {
+  it('contradicting an instinct with no matching candidate writes no transition and does not throw', () => {
+    // No candidate seeded in the store — only a plain (non-curator) instinct file.
+    writeCuratorInstinct('orphan-pattern', { confidence: 0.5 });
+
+    const { cmdContradict } = getInstinct();
+    expect(() => {
+      for (let i = 0; i < 4; i++) {
+        cmdContradict('orphan-pattern', PROJECT);
+      }
+    }).not.toThrow();
+
+    expect(readQueueEvents()).toEqual([]);
+  });
+
+  it('confirming an instinct with no matching candidate does not throw', () => {
+    writeCuratorInstinct('orphan-pattern', { confidence: 0.5 });
+    const { cmdConfirm } = getInstinct();
+    expect(() => cmdConfirm('orphan-pattern', PROJECT)).not.toThrow();
+    expect(readQueueEvents()).toEqual([]);
+  });
+});
+
+describe('ICL-6: dashboard card feedback matches instinct frontmatter', () => {
+  it('confirm mirrors confirmations onto the candidate record and card', () => {
+    seedActivatedCandidate();
+    writeCuratorInstinct(CANDIDATE_ID, { confidence: 0.5, confirmations: 2, contradictions: 1 });
+
+    const { cmdConfirm } = getInstinct();
+    cmdConfirm(CANDIDATE_ID, PROJECT); // confirmations 2 → 3
+
+    // Read the running counts from the on-disk instinct frontmatter.
+    const { parseConfidenceFrontmatter } = require('../../scripts/lib/confidence');
+    const fileContent = fs.readFileSync(path.join(instinctsDir(), `${CANDIDATE_ID}.md`), 'utf-8');
+    const { frontmatter } = parseConfidenceFrontmatter(fileContent);
+
+    const { createDashboardModel } = getDashboard();
+    const card = createDashboardModel().candidates.find((c) => c.candidate_id === CANDIDATE_ID);
+
+    expect(card.feedback).toEqual({
+      confirmations: frontmatter.confirmations,
+      contradictions: frontmatter.contradictions,
+    });
+    expect(card.feedback.confirmations).toBe(3);
+    expect(card.feedback.contradictions).toBe(1);
+  });
+
+  it('contradict (no archive) mirrors contradictions onto the card', () => {
+    seedActivatedCandidate();
+    writeCuratorInstinct(CANDIDATE_ID, { confidence: 0.8, confirmations: 4, contradictions: 0 });
+
+    const { cmdContradict } = getInstinct();
+    cmdContradict(CANDIDATE_ID, PROJECT); // contradictions 0 → 1, confidence 0.8 → 0.7 (no archive)
+
+    const { createDashboardModel } = getDashboard();
+    const card = createDashboardModel().candidates.find((c) => c.candidate_id === CANDIDATE_ID);
+    expect(card.feedback).toEqual({ confirmations: 4, contradictions: 1 });
+  });
+});


### PR DESCRIPTION
## Wave 5 · ICL-6 + ICL-7 — lifecycle 對齊 + 學習面真相清掃

### ICL-6 — confirm/contradict ↔ candidate lifecycle
- contradiction-archive matching an activated candidate → append a **deactivate** transition event gated through `lifecycle.isLegalAction` (honest `instinct_cli` actor, not spoofed dashboard); file stays in `archived/`, no reviewer_ack bypass, no `.disabled/` move.
- **S5-3 fix**: candidate lookup uses `queue-writer.readCurrentCandidates()` (HOME-global event log) — NOT the legacy `getCandidateQueuePath` project-local file (the trap that scans empty). Asserted via `lifecycle.status` field on the matched candidate.
- dashboard card gains integer-only feedback counts.

### ICL-7 — doc/CLI truth-sweep (post-ICL-4 reality)
- aliases/global-promotions lifted from **stderr → userParts** (stderr versions deleted).
- `instinct.js` `status`/confirm output converged: removed false `[auto-loaded]`/`AUTO_LOAD_THRESHOLD` claims → activation-gated + top-5 + kill-switch truth (orphaned auto-load imports removed; confidence.js untouched).
- thresholds.js dead `hooks/lib` reference removed; session-tracker + user-message-counter READMEs rewritten.

### Acceptance (replayed + repaired by reviewer)
readCurrentCandidates not legacy ✅ · lifecycle.status assertion ✅ · isLegalAction gate, archived/ stays ✅ · stderr→userParts deleted not duplicated ✅ · instinct-curator-lifecycle.test.js 7/7 ✅ · `npm test` + check:docs green ✅

### ⚠️ 一個 sub-phrase 延後（owner 裁決，見下方 PR 討論 / 主訊息）
"batch-assembler 加有界 recent-feedback 摘要" was **not** implemented — it collides with the Layer-3 **one-way contract** (Layer 5/6/7/8 reads forbidden; lifecycle feedback lanes future-only). The sub-phrase has **no 驗收 assertion**. Reviewer confirmed the HALT is genuine. **Recommend: defer to a future Layer-3 schema revision** (don't amend a one-way contract for an unasserted feature).

Iron Law: arc-observing/arc-learning SKILL.md + instinct.js CLI-output → eval **ICL-13**. Noted in commit body; no eval run now.