### PR TITLE
feat(hooks): dual-channel compaction-prep + threshold data validation (ICL-10, ICL-12)

### DIFF
--- a/hooks/__tests__/compact-suggester.test.js
+++ b/hooks/__tests__/compact-suggester.test.js
@@ -140,7 +140,7 @@ describe('rolling-window phase detection', () => {
     assert.strictEqual(mod.phaseFromWindow(win), 'read-heavy');
     const msg = mod.buildMessage(50, win);
     assert.ok(msg.includes('mostly reads'));
-    assert.ok(msg.includes('exploration') || msg.includes('research'));
+    assert.ok(msg.includes('arc-compacting'));
   });
 
   it('detects write-heavy phase from window', () => {
@@ -148,19 +148,19 @@ describe('rolling-window phase detection', () => {
     assert.strictEqual(mod.phaseFromWindow(win), 'write-heavy');
     const msg = mod.buildMessage(50, win);
     assert.ok(msg.includes('active implementation'));
-    assert.ok(msg.includes('Mid-implementation'));
+    assert.ok(msg.includes('arc-compacting'));
   });
 
   it('neutral when no phase dominates', () => {
     const win = windowOf(6, 6);
     assert.strictEqual(mod.phaseFromWindow(win), 'neutral');
-    assert.ok(mod.buildMessage(50, win).includes('workflow phases'));
+    assert.ok(mod.buildMessage(50, win).includes('arc-compacting'));
   });
 
   it('neutral when too few samples', () => {
     const win = windowOf(5, 0);
     assert.strictEqual(mod.phaseFromWindow(win), 'neutral');
-    assert.ok(mod.buildMessage(50, win).includes('workflow phases'));
+    assert.ok(mod.buildMessage(50, win).includes('arc-compacting'));
   });
 
   it('window is bounded to 20 most-recent entries', () => {
@@ -298,6 +298,33 @@ describe('compact-suggester e2e (ICL-9 acceptance)', () => {
 
     // Shared diary tool-count incremented in lockstep (binding preserved).
     assert.strictEqual(fs.readFileSync(toolCountPath(), 'utf-8'), '50');
+  });
+
+  it('S6-3: threshold output is a SINGLE JSON object carrying BOTH channels', () => {
+    // Drive to the threshold; capture the one event that produces output.
+    let thresholdOut = null;
+    for (let i = 0; i < 50; i++) {
+      const res = runSuggester('Read');
+      assert.strictEqual(res.status, 0, res.stderr);
+      if (res.stdout.trim()) thresholdOut = res.stdout.trim();
+    }
+    assert.ok(thresholdOut, 'threshold produced stdout');
+
+    // Exactly one JSON object (single-output pattern), not two lines.
+    assert.strictEqual(thresholdOut.split('\n').length, 1, 'exactly one stdout line');
+    const parsed = JSON.parse(thresholdOut);
+
+    // Both channels present in the SAME object: user-visible systemMessage
+    // AND model-visible additionalContext (the arc-compacting indicator).
+    assert.ok(parsed.systemMessage, 'user-visible systemMessage present');
+    assert.ok(
+      parsed.systemMessage.includes('arc-compacting'),
+      'user line points at arc-compacting',
+    );
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PostToolUse');
+    const modelLine = parsed.hookSpecificOutput.additionalContext;
+    assert.ok(modelLine, 'model-visible additionalContext present');
+    assert.ok(modelLine.includes('arc-compacting'), 'model line is the arc-compacting indicator');
   });
 
   it('records suggestions[] into the live session JSON', () => {

--- a/hooks/compact-suggester/main.js
+++ b/hooks/compact-suggester/main.js
@@ -10,6 +10,13 @@
  *
  * Triggered on PostToolUse for ALL tools.
  *
+ * Dual-channel delivery (ICL-10): on a threshold hit the hook emits EXACTLY ONE
+ * JSON object carrying BOTH a user-visible systemMessage (the phase-aware
+ * suggestion) AND a model-visible additionalContext one-liner (the arc-compacting
+ * indicator) via the RV-1 merged helper outputPostToolUseFeedback. The user line
+ * is a notification; the model line is a routing indicator pointing at the
+ * arc-compacting skill — never a silent model directive.
+ *
  * State: a SINGLE session-scoped JSON file (getSuggesterStatePath) holds the
  * tool counter, the rolling phase window, and the suggestion snapshots — 1 read
  * + 1 write per event instead of three separate counter files. PreCompact resets
@@ -28,7 +35,7 @@ const {
   readStdinSync,
   parseStdinJson,
   setSessionIdFromInput,
-  output,
+  outputPostToolUseFeedback,
   readJsonFile,
   writeJsonFile,
   getTimestamp,
@@ -120,28 +127,34 @@ function shouldSuppressReminder(count, window) {
 }
 
 /**
- * Build phase-aware suggestion message from the rolling window.
+ * Build the user-visible suggestion message (systemMessage channel).
+ *
+ * Slimmed to a phase indicator (ICL-10): it names the current phase and the tool
+ * count, then defers the actual compact/no-compact timing call to the
+ * arc-compacting skill rather than inlining the decision guide. The model-visible
+ * companion line (buildModelIndicator) carries the same arc-compacting pointer.
  */
 function buildMessage(count, window) {
   const phase = phaseFromWindow(window);
-  const readHeavy = phase === 'read-heavy';
-  const writeHeavy = phase === 'write-heavy';
+  const label =
+    phase === 'read-heavy'
+      ? 'mostly reads'
+      : phase === 'write-heavy'
+        ? 'active implementation'
+        : 'mixed work';
+  return `\n📊 ${count} tool calls (${label}) — possible compaction boundary. See arc-compacting for whether to /compact now.\n`;
+}
 
-  if (count === THRESHOLD) {
-    if (readHeavy) {
-      return `\n📊 ${count} tool calls (mostly reads) — looks like a research/exploration phase. If you're transitioning to implementation, /compact now to free context for code.\n`;
-    }
-    if (writeHeavy) {
-      return `\n📊 ${count} tool calls (active implementation). If you're between tasks or about to switch features, /compact at the boundary. Mid-implementation compaction loses valuable context.\n`;
-    }
-    return `\n📊 ${count} tool calls this session. If you're between workflow phases, consider /compact to preserve context quality. Use arc-compacting for timing guidance.\n`;
-  }
-
-  if (count >= 75 && readHeavy) {
-    return `\n📊 ${count} tool calls — heavy read phase. Context is filling with research. If findings are saved to files, /compact now for a fresh start.\n`;
-  }
-
-  return `\n📊 ${count} tool calls. Between phases? /compact helps maintain context quality for longer sessions.\n`;
+/**
+ * Build the model-visible compaction-prep indicator (additionalContext channel).
+ *
+ * This is the ICL-10 capability: a one-line routing indicator that reaches the
+ * MODEL (not just the user), pointing at the arc-compacting skill so the model
+ * can make the phase-boundary timing call. It states the phase as evidence; it
+ * never issues a compaction directive — the decision stays with arc-compacting.
+ */
+function buildModelIndicator(count, window) {
+  return `arc-compacting indicator: ${count} tool calls (${phaseFromWindow(window)} phase) — at a possible compaction boundary. Consult arc-compacting to decide whether to /compact at this phase boundary.`;
 }
 
 /**
@@ -212,7 +225,12 @@ function main() {
       state.suggestions.push(snapshot);
       recordSessionSuggestion(snapshot);
       writeState(state);
-      output({ systemMessage: buildMessage(state.tools, state.window) });
+      // Dual channel (ICL-10): ONE merged JSON object carrying the model-visible
+      // additionalContext (arc-compacting indicator) AND the user-visible
+      // systemMessage suggestion. The model line is never a silent directive.
+      outputPostToolUseFeedback(buildModelIndicator(state.tools, state.window), {
+        systemMessage: buildMessage(state.tools, state.window),
+      });
       return;
     }
 
@@ -233,6 +251,7 @@ module.exports = {
   shouldSuggest,
   shouldSuppressReminder,
   buildMessage,
+  buildModelIndicator,
   trackToolType,
   windowRatio,
   phaseFromWindow,

--- a/scripts/lib/compaction-analysis.js
+++ b/scripts/lib/compaction-analysis.js
@@ -1,0 +1,226 @@
+/**
+ * compaction-analysis.js — correlate compact-suggester suggestions against
+ * actual compactions (ICL-12).
+ *
+ * Validates whether the compact-suggester threshold constants (THRESHOLD /
+ * INTERVAL in hooks/compact-suggester, MIN_TOOL_CALLS in thresholds.js) fire
+ * near where compactions actually happen. The session JSON records two arrays:
+ *   - suggestions[]: { count, phase, at }   (compact-suggester snapshots)
+ *   - compactions[]: [ ISO-timestamp, ... ] (pre-compact markers)
+ *
+ * Each compaction is paired with the most recent preceding suggestion (the one
+ * that "led to" it). From that single pairing we derive descriptive stats at any
+ * sample size. A tuning RECOMMENDATION is gated behind a minimum compaction
+ * sample so that synthetic or sparse data never licenses a constant change.
+ *
+ * Pure analysis (analyzeCompactions) is deterministic: no disk, no clock. A thin
+ * impure loader (loadSessions) reads the on-disk session corpus.
+ *
+ * Zero external dependencies — Node.js standard library only.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+/**
+ * Minimum number of paired compaction events required before this tool will
+ * surface a tuning recommendation. Below this, the corpus is too small to draw
+ * any conclusion and the recommendation is INSUFFICIENT_DATA. Matches the ICL-12
+ * spec floor (~20).
+ * @type {number}
+ */
+const MIN_COMPACTION_SAMPLES = 20;
+
+/**
+ * Recommendation value when fewer than MIN_COMPACTION_SAMPLES compactions are
+ * present. A distinct literal so downstream consumers can switch on it.
+ * @type {'insufficient data'}
+ */
+const INSUFFICIENT_DATA = 'insufficient data';
+
+/**
+ * Parse an ISO timestamp to epoch milliseconds. Returns null on any unparseable
+ * value rather than NaN so callers can skip cleanly.
+ * @param {string} ts
+ * @returns {number|null}
+ */
+function toEpoch(ts) {
+  if (typeof ts !== 'string') return null;
+  const ms = Date.parse(ts);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Pair each compaction with the latest suggestion whose timestamp is at or
+ * before the compaction. Suggestions and compactions are matched within a single
+ * session only.
+ *
+ * @param {Array<{count:number, phase:string, at:string}>} suggestions
+ * @param {string[]} compactions
+ * @returns {Array<{leadMs:number, count:number, phase:string}>} One entry per
+ *   compaction that had a preceding suggestion (compactions with no preceding
+ *   suggestion are omitted from pairs but counted by the caller).
+ */
+function pairSession(suggestions, compactions) {
+  const sugg = (Array.isArray(suggestions) ? suggestions : [])
+    .map((s) => ({
+      epoch: toEpoch(s?.at),
+      count: Number(s?.count) || 0,
+      phase: s?.phase || 'unknown',
+    }))
+    .filter((s) => s.epoch !== null)
+    .sort((a, b) => a.epoch - b.epoch);
+
+  const pairs = [];
+  for (const rawCompaction of Array.isArray(compactions) ? compactions : []) {
+    const cEpoch = toEpoch(rawCompaction);
+    if (cEpoch === null) continue;
+    // Latest suggestion at or before this compaction.
+    let match = null;
+    for (const s of sugg) {
+      if (s.epoch <= cEpoch) match = s;
+      else break;
+    }
+    if (match) {
+      pairs.push({ leadMs: cEpoch - match.epoch, count: match.count, phase: match.phase });
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Compute the median of a numeric array. Returns null for an empty array.
+ * @param {number[]} nums
+ * @returns {number|null}
+ */
+function median(nums) {
+  if (nums.length === 0) return null;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Analyze a corpus of session objects, correlating suggestions against
+ * compactions. Pure and deterministic — no disk, no clock.
+ *
+ * @param {Array<{suggestions?:Array, compactions?:Array}>} sessions
+ * @returns {{
+ *   sessionCount: number,
+ *   compactionCount: number,
+ *   suggestionCount: number,
+ *   compactionsWithPrecedingSuggestion: number,
+ *   pairs: Array<{leadMs:number, count:number, phase:string}>,
+ *   medianLeadMs: number|null,
+ *   countAtCompaction: { median:number|null, min:number|null, max:number|null },
+ *   phaseAtCompaction: Object<string, number>,
+ *   recommendation: string,
+ * }}
+ */
+function analyzeCompactions(sessions) {
+  if (!Array.isArray(sessions)) {
+    throw new Error('analyzeCompactions: sessions must be an array');
+  }
+
+  let compactionCount = 0;
+  let suggestionCount = 0;
+  const pairs = [];
+
+  for (const session of sessions) {
+    const suggestions = Array.isArray(session?.suggestions) ? session.suggestions : [];
+    const compactions = Array.isArray(session?.compactions) ? session.compactions : [];
+    suggestionCount += suggestions.length;
+    compactionCount += compactions.length;
+    pairs.push(...pairSession(suggestions, compactions));
+  }
+
+  const counts = pairs.map((p) => p.count);
+  const phaseAtCompaction = {};
+  for (const p of pairs) {
+    phaseAtCompaction[p.phase] = (phaseAtCompaction[p.phase] || 0) + 1;
+  }
+
+  // Recommendation is gated: synthetic or sparse corpora never license tuning.
+  const recommendation =
+    compactionCount < MIN_COMPACTION_SAMPLES
+      ? INSUFFICIENT_DATA
+      : `sufficient sample (${compactionCount} compactions): review count-at-compaction distribution (median ${median(counts)}) against THRESHOLD before tuning`;
+
+  return {
+    sessionCount: sessions.length,
+    compactionCount,
+    suggestionCount,
+    compactionsWithPrecedingSuggestion: pairs.length,
+    pairs,
+    medianLeadMs: median(pairs.map((p) => p.leadMs)),
+    countAtCompaction: {
+      median: median(counts),
+      min: counts.length ? Math.min(...counts) : null,
+      max: counts.length ? Math.max(...counts) : null,
+    },
+    phaseAtCompaction,
+    recommendation,
+  };
+}
+
+/**
+ * Load every session JSON under the arcforge sessions root. Thin impure loader;
+ * the pure analysis lives in analyzeCompactions.
+ *
+ * @param {string} [sessionsRoot] - Defaults to ~/.arcforge/sessions.
+ * @returns {Array<Object>} Parsed session objects (unreadable/invalid skipped).
+ */
+function loadSessions(sessionsRoot) {
+  const root = sessionsRoot || path.join(os.homedir(), '.arcforge', 'sessions');
+  const sessions = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return sessions; // No corpus yet.
+  }
+  // sessions/<project>/<date>/<session>.json — walk two levels deep.
+  for (const projectEntry of entries) {
+    if (!projectEntry.isDirectory()) continue;
+    const projectDir = path.join(root, projectEntry.name);
+    let dateEntries;
+    try {
+      dateEntries = fs.readdirSync(projectDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const dateEntry of dateEntries) {
+      if (!dateEntry.isDirectory()) continue;
+      const dateDir = path.join(projectDir, dateEntry.name);
+      let files;
+      try {
+        files = fs.readdirSync(dateDir);
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        try {
+          sessions.push(JSON.parse(fs.readFileSync(path.join(dateDir, file), 'utf-8')));
+        } catch {
+          // Skip unreadable/corrupt session files.
+        }
+      }
+    }
+  }
+  return sessions;
+}
+
+module.exports = {
+  MIN_COMPACTION_SAMPLES,
+  INSUFFICIENT_DATA,
+  analyzeCompactions,
+  loadSessions,
+  pairSession,
+};
+
+// Ad-hoc CLI: print the analysis of the on-disk corpus as JSON.
+if (require.main === module) {
+  console.log(JSON.stringify(analyzeCompactions(loadSessions()), null, 2));
+}

--- a/tests/scripts/compaction-analysis.test.js
+++ b/tests/scripts/compaction-analysis.test.js
@@ -1,0 +1,130 @@
+/**
+ * compaction-analysis.test.js (ICL-12)
+ *
+ * Deterministic correlation of suggestions[] × compactions[]. Synthetic fixtures
+ * exercise the pairing math at both sample sizes; they are NOT evidence for
+ * tuning any constant (the recommendation stays gated behind a real-data floor).
+ */
+
+const {
+  MIN_COMPACTION_SAMPLES,
+  INSUFFICIENT_DATA,
+  analyzeCompactions,
+  pairSession,
+} = require('../../scripts/lib/compaction-analysis');
+
+// Fixed base time so timestamps are deterministic.
+const T0 = Date.parse('2026-06-16T10:00:00.000Z');
+const at = (offsetMs) => new Date(T0 + offsetMs).toISOString();
+const MIN = 60_000;
+
+describe('pairSession', () => {
+  it('pairs a compaction with the latest preceding suggestion', () => {
+    const suggestions = [
+      { count: 50, phase: 'read-heavy', at: at(0) },
+      { count: 75, phase: 'write-heavy', at: at(10 * MIN) },
+    ];
+    const compactions = [at(12 * MIN)];
+    const pairs = pairSession(suggestions, compactions);
+    expect(pairs).toEqual([{ leadMs: 2 * MIN, count: 75, phase: 'write-heavy' }]);
+  });
+
+  it('omits a compaction that has no preceding suggestion', () => {
+    const suggestions = [{ count: 50, phase: 'read-heavy', at: at(20 * MIN) }];
+    const compactions = [at(5 * MIN)]; // before any suggestion
+    expect(pairSession(suggestions, compactions)).toEqual([]);
+  });
+
+  it('matches a suggestion exactly at the compaction timestamp', () => {
+    const suggestions = [{ count: 50, phase: 'neutral', at: at(0) }];
+    const pairs = pairSession(suggestions, [at(0)]);
+    expect(pairs).toEqual([{ leadMs: 0, count: 50, phase: 'neutral' }]);
+  });
+
+  it('skips unparseable timestamps without throwing', () => {
+    const suggestions = [{ count: 50, phase: 'read-heavy', at: 'not-a-date' }];
+    expect(pairSession(suggestions, ['also-bad'])).toEqual([]);
+  });
+});
+
+describe('analyzeCompactions: descriptive stats (any sample size)', () => {
+  it('aggregates pairing counts and lead-time across sessions', () => {
+    const sessions = [
+      {
+        suggestions: [
+          { count: 50, phase: 'read-heavy', at: at(0) },
+          { count: 75, phase: 'write-heavy', at: at(8 * MIN) },
+        ],
+        compactions: [at(2 * MIN), at(10 * MIN)],
+      },
+      {
+        suggestions: [{ count: 50, phase: 'neutral', at: at(0) }],
+        compactions: [at(4 * MIN)],
+      },
+    ];
+
+    const result = analyzeCompactions(sessions);
+    expect(result.sessionCount).toBe(2);
+    expect(result.compactionCount).toBe(3);
+    expect(result.suggestionCount).toBe(3);
+    expect(result.compactionsWithPrecedingSuggestion).toBe(3);
+    // lead times: 2min, 2min (75 at 8min → compaction at 10min), 4min → median 2min
+    expect(result.medianLeadMs).toBe(2 * MIN);
+    // counts at compaction: 50, 75, 50 → median 50
+    expect(result.countAtCompaction.median).toBe(50);
+    expect(result.countAtCompaction.min).toBe(50);
+    expect(result.countAtCompaction.max).toBe(75);
+    expect(result.phaseAtCompaction).toEqual({ 'read-heavy': 1, 'write-heavy': 1, neutral: 1 });
+  });
+
+  it('counts compactions with no preceding suggestion separately', () => {
+    const sessions = [
+      {
+        suggestions: [{ count: 50, phase: 'read-heavy', at: at(10 * MIN) }],
+        compactions: [at(5 * MIN), at(15 * MIN)], // first has no preceding suggestion
+      },
+    ];
+    const result = analyzeCompactions(sessions);
+    expect(result.compactionCount).toBe(2);
+    expect(result.compactionsWithPrecedingSuggestion).toBe(1);
+  });
+
+  it('handles sessions missing the arrays', () => {
+    const result = analyzeCompactions([{}, { suggestions: [] }, { compactions: [] }]);
+    expect(result.compactionCount).toBe(0);
+    expect(result.suggestionCount).toBe(0);
+    expect(result.compactionsWithPrecedingSuggestion).toBe(0);
+    expect(result.medianLeadMs).toBeNull();
+    expect(result.countAtCompaction.median).toBeNull();
+  });
+
+  it('throws with context on non-array input', () => {
+    expect(() => analyzeCompactions(null)).toThrow(/must be an array/);
+  });
+});
+
+describe('analyzeCompactions: gated recommendation', () => {
+  it('reports insufficient data below the sample floor', () => {
+    const sessions = [
+      {
+        suggestions: [{ count: 50, phase: 'read-heavy', at: at(0) }],
+        compactions: [at(MIN), at(2 * MIN), at(3 * MIN)], // 3 < 20
+      },
+    ];
+    const result = analyzeCompactions(sessions);
+    expect(result.compactionCount).toBe(3);
+    expect(result.recommendation).toBe(INSUFFICIENT_DATA);
+  });
+
+  it('produces a (non-insufficient) recommendation at or above the floor', () => {
+    const suggestions = [{ count: 60, phase: 'write-heavy', at: at(0) }];
+    const compactions = [];
+    for (let i = 0; i < MIN_COMPACTION_SAMPLES; i++) {
+      compactions.push(at((i + 1) * MIN));
+    }
+    const result = analyzeCompactions([{ suggestions, compactions }]);
+    expect(result.compactionCount).toBe(MIN_COMPACTION_SAMPLES);
+    expect(result.recommendation).not.toBe(INSUFFICIENT_DATA);
+    expect(result.recommendation).toMatch(/sufficient sample/);
+  });
+});


### PR DESCRIPTION
## Wave 5 · ICL-10 + ICL-12 — compaction-prep 通道 + 閾值資料驗證

### ICL-10 — model-visible compaction-prep channel
- On threshold hit: **dual channel** — existing systemMessage PLUS a model-visible one-liner via the **RV-1 merged helper** (`outputPostToolUseFeedback`), pinned as a **single JSON object with both fields** (S6-3).
- buildMessage phase-suggestions slimmed to an arc-compacting indicator.
- Fallback (UserPromptSubmit relay) **not** wired (the 0.2 spike did not fail). Live `claude --plugin-dir .` smoke confirmed the dual-channel JSON reaches the model (transcript evidence in report).

### ICL-12 — threshold data validation
- compaction-analysis correlates `suggestions[]` × `compactions[]`; constants tuned **only on evidence**, else records `insufficient data`; deterministic fixture test.

### Acceptance (replayed by reviewer)
single-JSON-both-fields pinned + live smoke ✅ · ICL-12 fixture deterministic ✅ · diary-threshold binding regression still passes ✅ · `npm test` (test:hooks) + check:docs green ✅

hooks.md untouched (stop condition honored). Iron Law: any arc-compacting indicator → eval **ICL-13**. Noted in commit body.