### PR TITLE
fix(hooks): honor ARCFORGE_OBSERVE_NO_SPAWN in start.js + fix session-tracker teardown race (F3)

### DIFF
--- a/hooks/__tests__/e2e-hooks.test.js
+++ b/hooks/__tests__/e2e-hooks.test.js
@@ -203,6 +203,14 @@ describe('E2E: session-tracker/start.js', () => {
   const scriptPath = path.join(HOOKS_DIR, 'session-tracker', 'start.js');
   let testDir;
 
+  // start.js spawns a disowned observer daemon on SessionStart. Pointed at the
+  // temp HOME, that backgrounded daemon writes into .arcforge/instincts AFTER
+  // the hook exits and races the recursive teardown rm (ENOTEMPTY). Suppress
+  // the real spawn — the same CI-safety guard observe.test.js uses.
+  function startEnv() {
+    return { CLAUDE_PROJECT_DIR: testDir, HOME: testDir, ARCFORGE_OBSERVE_NO_SPAWN: '1' };
+  }
+
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-start-'));
   });
@@ -214,7 +222,7 @@ describe('E2E: session-tracker/start.js', () => {
   it('should create session JSON file on startup', () => {
     const sessionId = 'test-session-create';
     const input = makeSessionStartInput('startup', { session_id: sessionId });
-    const result = runNodeHook(scriptPath, input, { CLAUDE_PROJECT_DIR: testDir, HOME: testDir });
+    const result = runNodeHook(scriptPath, input, startEnv());
 
     assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
 
@@ -235,7 +243,7 @@ describe('E2E: session-tracker/start.js', () => {
   });
 
   it('should exit 0 with empty stdin', () => {
-    const result = runNodeHook(scriptPath, '', { CLAUDE_PROJECT_DIR: testDir, HOME: testDir });
+    const result = runNodeHook(scriptPath, '', startEnv());
     assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
   });
 });

--- a/hooks/session-tracker/start.js
+++ b/hooks/session-tracker/start.js
@@ -74,6 +74,10 @@ function initializeSession() {
  */
 function checkDaemon() {
   try {
+    // Parity with observe/main.js: both spawn the same observer daemon, so
+    // both must honor ARCFORGE_OBSERVE_NO_SPAWN. Without this, setting the
+    // env still spawned a daemon here on every SessionStart.
+    if (process.env.ARCFORGE_OBSERVE_NO_SPAWN === '1') return;
     const daemonPath = path.join(
       __dirname,
       '../../skills/arc-observing/scripts/observer-daemon.sh',


### PR DESCRIPTION
## Follow-up F3 — session-tracker teardown race (root-caused) + production parity gap

**Scope: F3 only. F2 (loop-rundag flake) is deferred — see below.**

### Root cause (real, not a flake mask)
The `E2E: session-tracker/start.js` test runs the real hook against a temp HOME and tears it down recursively. `checkDaemon()` spawns a **disowned** observer daemon that writes into `<tempHOME>/.arcforge/instincts` *after* the hook exits — racing the teardown `rm` → `ENOTEMPTY`.

### Production parity gap (the real fix, not a test accommodation)
`hooks/observe/main.js` honors `ARCFORGE_OBSERVE_NO_SPAWN=1` (main.js:45) before spawning the observer daemon, but `hooks/session-tracker/start.js checkDaemon()` did **not** — even though both spawn the **same** daemon. A user who set that env to suppress the daemon still got one spawned on every SessionStart. A 3-line guard closes the gap; the e2e test sets the env (mirroring observe.test.js).

Note: `ARCFORGE_OBSERVE_NO_SPAWN` is a pre-existing **internal/undocumented** env var (observe/main.js). This PR brings start.js to parity. Promoting it to a *documented* user-facing kill-switch is a separate follow-up if desired.

### Acceptance (replayed by reviewer)
- F3 root cause = test-infra/parity (NOT the instinct migration — explicitly ruled out: migration writes nothing on empty stdin) ✅
- Affected test deterministic 20× green; zero daemon spawn, no leaked dirs ✅
- Full `npm test` + `check:docs` green ✅

### F2 deferred (loop-rundag flake — genuine block)
The `loop-rundag.test.js 'failed session is blocked before verify even runs'` CI flake could **not be reproduced** (20× isolated, full suite, CPU contention, `--detectOpenHandles` clean). The test **mocks** session spawning (`jest.spyOn _runSubprocess`) and its assertions are provably deterministic — so there's no defensible test-side fix without masking (forbidden). Blocked on the missing CI assertion signature. **Known-flaky, deferred**: if it recurs, capture the full `--verbose` assertion diff from the failing CI run to diagnose.