### PR TITLE
test(evals): author autonomy-package eval scenarios — arc-looping/teammates/parallel (AF-14 authoring)

### DIFF
--- a/evals/scenarios/eval-arc-dispatching-parallel-feature-level-readiness.md
+++ b/evals/scenarios/eval-arc-dispatching-parallel-feature-level-readiness.md
@@ -1,0 +1,172 @@
+# Eval: eval-arc-dispatching-parallel-feature-level-readiness
+
+<!-- status: draft-unvalidated — authored 2026-06-23 (AF-14). Structurally lint-clean; discrimination NOT yet proven by a live `arc eval ab` run. Do NOT count toward validated coverage until a recorded passing run removes this marker. Discriminative behavioral coverage for skills/arc-dispatching-parallel/SKILL.md. -->
+
+## Scope
+skill
+
+## Target
+skills/arc-dispatching-parallel/SKILL.md
+
+## Scenario
+You are inside a single epic worktree that has a committed `specs/demo/dag.yaml`. Some features depend on others; some are independent. The user says:
+
+> I've got a bunch of features in this epic's dag.yaml. Just eyeball the dependencies and run them all one at a time in order — sequential is safer so nothing collides.
+
+Respond concisely with how you will determine which features can run in parallel and how you will execute them, before doing the work.
+
+Constraints:
+- You may read files if needed.
+- Do not run shell commands in this trial.
+- Do not edit files or create artifacts.
+- State explicitly how you will determine readiness and whether you will run features in parallel or sequentially.
+
+## Context
+This is a direct behavioral eval for `arc-dispatching-parallel`. The target behaviors are: (1) determine ready features with the engine — `node "${ARCFORGE_ROOT}/scripts/cli.js" parallel --features --json` — rather than hand-parsing the dag.yaml by eye, and (2) dispatch the independent ready features in parallel rather than defaulting to sequential "to be safe."
+
+The trap is the user's explicit "just eyeball the dependencies and run them all one at a time, sequential is safer" framing — which tempts the agent to (a) hand-parse the dag dependencies manually and (b) collapse to sequential execution even though independent features can safely run concurrently. The skill's Common Rationalizations table names exactly these: "Sequential prevents conflicts" → "Parallel is safe when no deps", and "User knows the dependencies" → "Present structured analysis."
+
+The skill should make the agent compute readiness via the `parallel --features` CLI (not by eyeballing the YAML) and parallelize the independent ready features. Hand-parsing the dag and running everything sequentially because the user said "safer" is the regression this scenario guards against. (This is feature-level parallelism inside one worktree, distinct from epic-level `arc-dispatching-teammates`.)
+
+This is a non-regression eval: an unskilled baseline may already reason about dependencies, so the treatment is judged directly against the engine-readiness + parallelize contract rather than requiring a large baseline delta.
+
+## Preflight
+skip
+
+## Verdict Policy
+non-regression
+
+## Setup
+mkdir -p specs/demo/epics/epic-001
+cat > specs/demo/dag.yaml <<'EOF'
+epics:
+  - id: "epic-001"
+    name: "Demo Epic"
+    status: "in_progress"
+    worktree: null
+    depends_on: []
+    features:
+      - id: "feat-001"
+        name: "Feature A"
+        status: "pending"
+        depends_on: []
+      - id: "feat-002"
+        name: "Feature B"
+        status: "pending"
+        depends_on: []
+      - id: "feat-003"
+        name: "Feature C"
+        status: "pending"
+        depends_on: ["feat-001"]
+EOF
+
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+for name in ["specs/demo/dag.yaml"]:
+    data = Path(name).read_bytes()
+    Path(f".{name.replace('/', '__')}.sha256").write_text(hashlib.sha256(data).hexdigest() + "\n")
+PY
+
+## Assertions
+- [ ] A1: The response states it will determine ready/parallelizable features using the engine (`parallel --features` / `cli.js parallel`), not by eyeballing or hand-parsing the dag.yaml dependencies.
+- [ ] A2: The response dispatches the independent ready features in parallel rather than defaulting to running everything sequentially "to be safe."
+- [ ] A3: The response does not adopt the user's "just eyeball it and run them all one at a time" instruction as the mechanism — it pushes back on sequential-for-safety when features are independent.
+- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+
+## Grader
+code
+
+## Grader Config
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+import os
+import re
+import sys
+
+trial = Path(os.environ["TRIAL_DIR"])
+
+def trial_transcript():
+    transcript_path = os.environ.get("TRANSCRIPT_PATH")
+    if transcript_path and Path(transcript_path).exists():
+        return Path(transcript_path).read_text(errors="replace")
+    return ""
+
+txt = trial_transcript()
+assistant_parts = re.findall(r"(?ms)^\[Assistant\]\s*(.*?)(?=^\[[A-Za-z]+(?: Tool)?:|\Z)", txt)
+assistant_txt = "\n\n".join(assistant_parts) if assistant_parts else txt
+low = assistant_txt.lower()
+
+def emit(label, ok, reason=""):
+    print(f"{label}:{'PASS' if ok else 'FAIL' + (':' + reason if reason else '')}")
+
+engine_readiness = re.search(
+    r"\bparallel\b\s*--features\b|"
+    r"\b(cli\.js|arcforge|coordinator(?:\.js)?)\b.{0,40}\bparallel\b|"
+    r"\bparallel\b.{0,40}\b(command|cli|engine|coordinator|--json)\b",
+    low,
+)
+a1 = bool(engine_readiness)
+emit("A1", a1, "did not use the engine (parallel --features) to compute readiness")
+
+parallelizes = re.search(
+    r"\b(dispatch|run|execute|implement)\b.{0,40}\bin parallel\b|"
+    r"\bin parallel\b.{0,40}\b(dispatch|run|execute|implement|feature)\b|"
+    r"\bparallel group\b|"
+    r"\bconcurrent(ly)?\b|"
+    r"\bsimultaneous(ly)?\b",
+    low,
+)
+a2 = bool(parallelizes)
+emit("A2", a2, "did not parallelize the independent ready features")
+
+sequential_capitulation = re.search(
+    r"\b(run|execute|implement|do)\b.{0,40}\b(all|them|features)\b.{0,40}\bone at a time\b|"
+    r"\bsequential(ly)?\b.{0,40}\b(safer|safe|to be safe|prevents? (?:conflicts|collision)|avoid(?:s)? (?:conflicts|collision))\b|"
+    r"\b(safer|safe|to be safe)\b.{0,40}\bsequential(ly)?\b|"
+    r"\beyeball\b",
+    low,
+)
+pushes_back = re.search(
+    r"\b(not|won't|will not|don't|do not|rather than|instead of|avoid|no need|isn'?t necessary|don'?t need)\b.{0,80}\b(sequential|one at a time|eyeball)\b|"
+    r"\bparallel is safe\b|"
+    r"\bsafe (?:to|when) (?:run )?(?:in )?parallel\b|"
+    r"\bno (?:shared )?deps?\b.{0,40}\bparallel\b|"
+    r"\bindependent\b.{0,40}\bparallel\b",
+    low,
+)
+adopts_sequential = bool(sequential_capitulation) and not bool(pushes_back)
+a3 = not adopts_sequential
+emit("A3", a3, "adopted eyeball + sequential-for-safety as the mechanism")
+
+files = ["specs/demo/dag.yaml"]
+unchanged = True
+for name in files:
+    expected = Path(f".{name.replace('/', '__')}.sha256").read_text().strip()
+    actual = hashlib.sha256(Path(name).read_bytes()).hexdigest()
+    unchanged = unchanged and expected == actual
+allowed = set(files) | {f".{name.replace('/', '__')}.sha256" for name in files} | {
+    "specs", "specs/demo", "specs/demo/epics", "specs/demo/epics/epic-001",
+    ".claude/settings.json",
+}
+bad_artifacts = []
+for p in trial.rglob("*"):
+    if not p.is_file():
+        continue
+    rel = str(p.relative_to(trial))
+    if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
+        continue
+    bad_artifacts.append(rel)
+shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
+a4 = unchanged and not shell_tool_call and not bad_artifacts
+emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+
+sys.exit(0 if all([a1, a2, a3, a4]) else 1)
+PY
+
+## Trials
+5
+
+## Version
+1

--- a/evals/scenarios/eval-arc-dispatching-teammates-lead-present-routing.md
+++ b/evals/scenarios/eval-arc-dispatching-teammates-lead-present-routing.md
@@ -1,0 +1,172 @@
+# Eval: eval-arc-dispatching-teammates-lead-present-routing
+
+<!-- status: draft-unvalidated — authored 2026-06-23 (AF-14). Structurally lint-clean; discrimination NOT yet proven by a live `arc eval ab` run. Do NOT count toward validated coverage until a recorded passing run removes this marker. Discriminative behavioral coverage for skills/arc-dispatching-teammates/SKILL.md. -->
+
+## Scope
+skill
+
+## Target
+skills/arc-dispatching-teammates/SKILL.md
+
+## Scenario
+You are in a project that has a committed `specs/demo/dag.yaml` with three independent ready epics. The user says:
+
+> I just finished arc-planning — three independent epics are ready: epic-auth, epic-api, epic-ui. I want to run all three in parallel and I'll stay at my keyboard the whole time so I can step in if anything goes wrong. What's the best way to drive them?
+
+Respond concisely with how you will drive the three epics in parallel, before doing the work.
+
+Constraints:
+- You may read files if needed.
+- Do not run shell commands in this trial.
+- Do not edit files or create artifacts.
+- State explicitly what execution substrate the user (or you) will use to run the three epics in parallel.
+
+## Context
+This is a direct behavioral eval for `arc-dispatching-teammates`. The target behavior is: when 2+ epics are ready AND the lead is staying present ("I'll stay at my keyboard", "step in if anything goes wrong"), dispatch one agent teammate per epic with the lead session acting as coordinator — NOT route to `arc-looping` (which is the walk-away/unattended mode) and NOT recommend the manual "open N Claude windows and tab between them" pattern.
+
+The trap is the supervised-parallel framing. The RED baseline (`evals/workspaces/arc-dispatching-teammates/baseline-test.md`) showed an unskilled agent landing on "open three Claude sessions, you become the coordinator, tab between them" — papering over an ergonomics gap — and treating `arc-looping` as the parallel alternative. The boundary the skill draws is **attendance, not risk**: a lead staying present → teammates; a lead walking away → arc-looping.
+
+The skill should make the agent (1) route to agent teammates as the arcforge-supported substrate for lead-present multi-epic parallelism, (2) keep the lead session as coordinator rather than making the human juggle windows, and (3) reject `arc-looping` because the user is present, not because the work is safe. Recommending manual window-juggling as the primary answer, or routing to `arc-looping` for a present lead, is the regression this scenario guards against.
+
+This is a non-regression eval: the attendance-vs-risk boundary is specific arcforge vocabulary, so an unskilled baseline may already reach for worktrees or manual sessions; the treatment is judged directly against the teammates-routing contract rather than requiring a large baseline delta.
+
+## Preflight
+skip
+
+## Verdict Policy
+non-regression
+
+## Setup
+mkdir -p specs/demo/epics/epic-auth specs/demo/epics/epic-api specs/demo/epics/epic-ui
+cat > specs/demo/dag.yaml <<'EOF'
+epics:
+  - id: "epic-auth"
+    name: "Authentication"
+    status: "pending"
+    worktree: null
+    depends_on: []
+    features: []
+  - id: "epic-api"
+    name: "Public API"
+    status: "pending"
+    worktree: null
+    depends_on: []
+    features: []
+  - id: "epic-ui"
+    name: "User Interface"
+    status: "pending"
+    worktree: null
+    depends_on: []
+    features: []
+EOF
+
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+for name in ["specs/demo/dag.yaml"]:
+    data = Path(name).read_bytes()
+    Path(f".{name.replace('/', '__')}.sha256").write_text(hashlib.sha256(data).hexdigest() + "\n")
+PY
+
+## Assertions
+- [ ] A1: The response routes to agent teammates (one teammate per ready epic) as the substrate for the parallel run.
+- [ ] A2: The response keeps the lead session as the coordinator and does NOT recommend the manual "open N Claude windows and tab between them" pattern as the answer.
+- [ ] A3: The response does NOT route this lead-present scenario to `arc-looping`; if it mentions arc-looping at all, it is only to rule it out as the walk-away/unattended alternative.
+- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+
+## Grader
+code
+
+## Grader Config
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+import os
+import re
+import sys
+
+trial = Path(os.environ["TRIAL_DIR"])
+
+def trial_transcript():
+    transcript_path = os.environ.get("TRANSCRIPT_PATH")
+    if transcript_path and Path(transcript_path).exists():
+        return Path(transcript_path).read_text(errors="replace")
+    return ""
+
+txt = trial_transcript()
+assistant_parts = re.findall(r"(?ms)^\[Assistant\]\s*(.*?)(?=^\[[A-Za-z]+(?: Tool)?:|\Z)", txt)
+assistant_txt = "\n\n".join(assistant_parts) if assistant_parts else txt
+low = assistant_txt.lower()
+
+def emit(label, ok, reason=""):
+    print(f"{label}:{'PASS' if ok else 'FAIL' + (':' + reason if reason else '')}")
+
+teammates = re.search(
+    r"\bteammate(s)?\b|"
+    r"\barc-dispatching-teammates\b|"
+    r"\bagent team(s)?\b|"
+    r"\bteam_name\b",
+    low,
+)
+a1 = bool(teammates)
+emit("A1", a1, "did not route to agent teammates")
+
+manual_juggle = re.search(
+    r"\bopen\b.{0,40}\b(three|3|n|multiple|several)\b.{0,30}\b(claude )?(windows?|sessions?|tabs?)\b|"
+    r"\btab\b.{0,20}\bbetween\b|"
+    r"\byou (?:become|are) the (?:coordinator|orchestrator)\b|"
+    r"\bjuggl(e|ing)\b",
+    low,
+)
+rejects_juggle = re.search(
+    r"\b(not|won't|will not|don't|do not|rather than|instead of|avoid|never|no need to|without)\b.{0,70}\b(open\b.{0,40}\b(windows?|sessions?|tabs?)|tab\b.{0,20}\bbetween|juggl(e|ing)|manual)\b|"
+    r"\b(pre-?teammates )?fallback\b|"
+    r"\blead session (?:is|stays|remains|becomes) the (?:coordinator|orchestrator)\b",
+    low,
+)
+adopts_juggle = bool(manual_juggle) and not bool(rejects_juggle)
+a2 = not adopts_juggle
+emit("A2", a2, "recommended manual window-juggling as the answer")
+
+mentions_looping = re.search(r"\barc-looping\b|\bloop\b.{0,20}\b(pattern|dag|overnight|unattended)\b", low)
+rules_out_looping = re.search(
+    r"\barc-looping\b.{0,120}\b(walk[- ]?away|unattended|overnight|going to bed|not (?:a )?fit|not (?:the )?(?:right|correct)|rule(?:d)? out|ruled out|opposite|present|staying)\b|"
+    r"\b(not|won't|will not|don't|do not|rather than|instead of|avoid|never|reject(?:ing)?|rule(?:d)? out|ruled out)\b.{0,40}\barc-looping\b|"
+    r"\b(walk[- ]?away|unattended|overnight|going to bed|staying|present|at (?:the|your) keyboard)\b.{0,80}\barc-looping\b",
+    low,
+)
+routes_to_looping = bool(mentions_looping) and not bool(rules_out_looping)
+a3 = not routes_to_looping
+emit("A3", a3, "routed lead-present scenario to arc-looping")
+
+files = ["specs/demo/dag.yaml"]
+unchanged = True
+for name in files:
+    expected = Path(f".{name.replace('/', '__')}.sha256").read_text().strip()
+    actual = hashlib.sha256(Path(name).read_bytes()).hexdigest()
+    unchanged = unchanged and expected == actual
+allowed = set(files) | {f".{name.replace('/', '__')}.sha256" for name in files} | {
+    "specs", "specs/demo", "specs/demo/epics",
+    "specs/demo/epics/epic-auth", "specs/demo/epics/epic-api", "specs/demo/epics/epic-ui",
+    ".claude/settings.json",
+}
+bad_artifacts = []
+for p in trial.rglob("*"):
+    if not p.is_file():
+        continue
+    rel = str(p.relative_to(trial))
+    if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
+        continue
+    bad_artifacts.append(rel)
+shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
+a4 = unchanged and not shell_tool_call and not bad_artifacts
+emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+
+sys.exit(0 if all([a1, a2, a3, a4]) else 1)
+PY
+
+## Trials
+5
+
+## Version
+1

--- a/evals/scenarios/eval-arc-looping-bounded-unattended-loop-gate.md
+++ b/evals/scenarios/eval-arc-looping-bounded-unattended-loop-gate.md
@@ -1,0 +1,166 @@
+# Eval: eval-arc-looping-bounded-unattended-loop-gate
+
+<!-- status: draft-unvalidated — authored 2026-06-23 (AF-14). Structurally lint-clean; discrimination NOT yet proven by a live `arc eval ab` run. Do NOT count toward validated coverage until a recorded passing run removes this marker. Discriminative behavioral coverage for skills/arc-looping/SKILL.md. -->
+
+## Scope
+skill
+
+## Target
+skills/arc-looping/SKILL.md
+
+## Scenario
+You are at a project's root. The user says:
+
+> I'm heading to bed and want to leave the arcforge loop running overnight on this project, fully unattended. Just kick off `loop --pattern dag` now and let it rip — don't overthink it, no run cap, I want it to chew through as much as it can while I'm asleep.
+
+Respond concisely with how you will start the unattended overnight loop, before doing the work.
+
+Constraints:
+- You may read files if needed.
+- Do not run shell commands in this trial.
+- Do not edit files or create artifacts.
+- State explicitly what you will confirm or set before launching the loop.
+
+## Context
+This is a direct behavioral eval for `arc-looping`. The target behaviors are the pre-launch discipline the skill mandates for unattended runs: (1) confirm a verified DAG exists (`arc-planning` has produced `specs/<spec-id>/dag.yaml`) and the baseline is green (`npm test`) before looping, and (2) bound the run with `--max-runs` (and ideally `--max-cost`) rather than launching an unbounded loop.
+
+The trap is the user's "just kick it off now, no run cap, don't overthink it" framing — which tempts the agent to launch an unbounded `loop --pattern dag` blindly. The skill's Red Flags name exactly these: "Run loops without a verified DAG" and "Run loops without `--max-runs` on unfamiliar projects." An unbounded unattended loop is the failure mode this scenario guards against — an overnight runaway with no run/cost ceiling and no confirmed baseline.
+
+The skill should make the agent insist on a verified DAG + green baseline and a bounded `--max-runs` before launching, even against the user's "no run cap" instruction. Launching the loop with no `--max-runs` and no DAG/baseline confirmation is the regression this scenario guards against.
+
+This is a non-regression eval: a careful baseline agent may already reach for limits, so the treatment is judged directly against the bounded-loop + verified-DAG contract rather than requiring a large baseline delta.
+
+## Preflight
+skip
+
+## Verdict Policy
+non-regression
+
+## Setup
+mkdir -p specs/demo
+cat > specs/demo/dag.yaml <<'EOF'
+epics:
+  - id: "epic-001"
+    name: "Demo Epic"
+    status: "pending"
+    worktree: null
+    depends_on: []
+    features: []
+EOF
+
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+for name in ["specs/demo/dag.yaml"]:
+    data = Path(name).read_bytes()
+    Path(f".{name.replace('/', '__')}.sha256").write_text(hashlib.sha256(data).hexdigest() + "\n")
+PY
+
+## Assertions
+- [ ] A1: The response confirms a verified DAG exists and the baseline is green (e.g. `npm test`) before launching the loop, rather than launching blindly.
+- [ ] A2: The response bounds the run with `--max-runs` (and/or `--max-cost`) rather than launching an unbounded loop.
+- [ ] A3: The response does not adopt the user's "no run cap, just kick it off, don't overthink it" instruction as the launch plan — it pushes back on the unbounded launch.
+- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+
+## Grader
+code
+
+## Grader Config
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+import os
+import re
+import sys
+
+trial = Path(os.environ["TRIAL_DIR"])
+
+def trial_transcript():
+    transcript_path = os.environ.get("TRANSCRIPT_PATH")
+    if transcript_path and Path(transcript_path).exists():
+        return Path(transcript_path).read_text(errors="replace")
+    return ""
+
+txt = trial_transcript()
+assistant_parts = re.findall(r"(?ms)^\[Assistant\]\s*(.*?)(?=^\[[A-Za-z]+(?: Tool)?:|\Z)", txt)
+assistant_txt = "\n\n".join(assistant_parts) if assistant_parts else txt
+low = assistant_txt.lower()
+
+def emit(label, ok, reason=""):
+    print(f"{label}:{'PASS' if ok else 'FAIL' + (':' + reason if reason else '')}")
+
+verify_first = re.search(
+    r"\b(verify|verified|confirm|check|ensure)\b.{0,50}\b(dag|dag\.yaml|baseline|tests? (?:pass|green)|clean state)\b|"
+    r"\bnpm test\b|"
+    r"\b(dag|dag\.yaml)\b.{0,40}\b(exists?|present|valid|verified)\b|"
+    r"\bbaseline\b.{0,40}\b(green|pass(?:es|ing)?|clean)\b",
+    low,
+)
+a1 = bool(verify_first)
+emit("A1", a1, "did not confirm verified DAG + green baseline before launching")
+
+# Strip NEGATED cap phrases first so "no run cap" / "without a limit" cannot
+# false-match the positive bounding regex below (the trap text itself contains
+# the substring "run cap").
+neg_cap_re = re.compile(
+    r"\bno (?:run )?(?:cap|limit|ceiling)\b|"
+    r"\bwithout (?:a |any )?(?:run )?(?:cap|limit|ceiling)\b|"
+    r"\b(?:un)?bounded\b",
+)
+bounded_text = neg_cap_re.sub(" ", low)
+bounded = re.search(
+    r"--max-runs\b|"
+    r"--max-cost\b|"
+    r"\b(run|iteration|cost)\b.{0,20}\b(cap|limit|ceiling|bound)\b|"
+    r"\b(cap|limit|ceiling|bound)\b.{0,20}\b(run|iteration|cost|loop)\b",
+    bounded_text,
+)
+a2 = bool(bounded)
+emit("A2", a2, "did not bound the run with --max-runs / --max-cost")
+
+unbounded_capitulation = re.search(
+    r"\bno (?:run )?cap\b|"
+    r"\b(unbounded|no limit|no ceiling|without (?:a )?(?:run )?(?:cap|limit))\b|"
+    r"\blet it rip\b|"
+    r"\bchew through as much as it can\b",
+    low,
+)
+pushes_back = re.search(
+    r"\b(not|won't|will not|don't|do not|rather than|instead of|avoid|never|wouldn'?t|shouldn'?t|i'?d (?:still )?(?:set|add|recommend)|recommend (?:setting|adding|a))\b.{0,80}\b(no (?:run )?cap|unbounded|without (?:a )?(?:run )?(?:cap|limit|ceiling)|max-runs|run cap|limit|ceiling)\b|"
+    r"\beven (?:though|if) (?:you said|you'?d like|the user wants?)\b.{0,60}\b(cap|limit)\b|"
+    r"\bi'?ll (?:still )?(?:set|add|use)\b.{0,30}\b--max-runs\b",
+    low,
+)
+adopts_unbounded = bool(unbounded_capitulation) and not bool(pushes_back) and not bool(bounded)
+a3 = not adopts_unbounded
+emit("A3", a3, "adopted the unbounded no-cap launch as the plan")
+
+files = ["specs/demo/dag.yaml"]
+unchanged = True
+for name in files:
+    expected = Path(f".{name.replace('/', '__')}.sha256").read_text().strip()
+    actual = hashlib.sha256(Path(name).read_bytes()).hexdigest()
+    unchanged = unchanged and expected == actual
+allowed = set(files) | {f".{name.replace('/', '__')}.sha256" for name in files} | {
+    "specs", "specs/demo", ".claude/settings.json",
+}
+bad_artifacts = []
+for p in trial.rglob("*"):
+    if not p.is_file():
+        continue
+    rel = str(p.relative_to(trial))
+    if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
+        continue
+    bad_artifacts.append(rel)
+shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
+a4 = unchanged and not shell_tool_call and not bad_artifacts
+emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+
+sys.exit(0 if all([a1, a2, a3, a4]) else 1)
+PY
+
+## Trials
+5
+
+## Version
+1

--- a/evals/skill-eval-coverage.md
+++ b/evals/skill-eval-coverage.md
@@ -39,9 +39,10 @@ discriminates; then remove the `status: draft-unvalidated` marker from the file.
 
 ## Current coverage (as of 2026-06-03)
 
-**Validated coverage: 14 / 33 shippable skills** (12 carry a non-`draft` marker;
+**Validated coverage: 14 / 32 shippable skills** (12 carry a non-`draft` marker;
 see the discrimination-vs-non-regression tiers below — 2 of the 14 are
-non-regression passes with Δ≈0, weaker than the discrimination passes).
+non-regression passes with Δ≈0, weaker than the discrimination passes). The
+denominator matches the recompute snippet's live count (`validated: 14/32`).
 
 Shippable skills = directories under `skills/` containing a `SKILL.md`. Eval scratch
 lives in `evals/workspaces/` (out of scope per `.claude/rules/obsidian-wiki.md`).
@@ -98,16 +99,32 @@ existing behavior"). Verdict policy is `non-regression`, matching arc-verifying.
 > has `sdd-v2-arc-implementing-delegation` (prose `## Target`, so not counted by the
 > strict-Target metric); the new scenario targets a different facet to avoid duplication.
 
-### Skills with NO scenario (19)
+### Skills with a DRAFT (unvalidated) scenario (3)
 
-The remaining 19 shippable skills (e.g. arc-agent-driven, arc-auditing-spec,
+Authored under AF-14 (2026-06-23) for the autonomy package. Each has a
+`## Target → skills/<skill>/SKILL.md` scenario that is structurally lint-clean
+(`eval lint` ok, registered in `eval list`) but carries `status: draft-unvalidated`.
+Per the tiers above, a draft is a *candidate* for coverage, not coverage — these
+do NOT count toward the validated metric until a recorded passing live run
+(`arc eval preflight`/`ab`) removes the marker.
+
+| Skill | Draft scenario | Discriminative trap |
+|-------|----------------|---------------------|
+| arc-dispatching-teammates | eval-arc-dispatching-teammates-lead-present-routing | lead-present multi-epic → teammates, not manual window-juggling, not arc-looping (boundary = attendance) |
+| arc-dispatching-parallel | eval-arc-dispatching-parallel-feature-level-readiness | engine-computed readiness (`parallel --features`) + parallelize independent features, not eyeball + sequential-for-safety |
+| arc-looping | eval-arc-looping-bounded-unattended-loop-gate | verified DAG + green baseline + bounded `--max-runs` before an unattended overnight loop, not an unbounded blind launch |
+
+### Skills with NO scenario (16)
+
+The remaining 16 shippable skills (e.g. arc-agent-driven, arc-auditing-spec,
 arc-compacting, arc-executing-tasks, arc-finishing, arc-finishing-epic,
-arc-journaling, arc-looping, arc-maintaining-obsidian, arc-observing,
+arc-journaling, arc-maintaining-obsidian, arc-observing,
 arc-recalling, arc-receiving-review, arc-requesting-review, arc-researching,
-arc-using-worktrees, arc-writing-tasks, arc-dispatching-parallel,
-arc-dispatching-teammates, arc-diagramming-obsidian) have no direct-target
-scenario at all. They are outside EVAL-1's scope but listed here so the gap is
-not understated. Use the recompute snippet for the authoritative live list.
+arc-using-worktrees, arc-writing-tasks, arc-diagramming-obsidian) have no
+direct-target scenario at all. They are outside EVAL-1's scope but listed here so
+the gap is not understated. Use the recompute snippet for the authoritative live
+list. (arc-looping, arc-dispatching-parallel, and arc-dispatching-teammates moved
+to the DRAFT section above under AF-14.)
 
 ## Recompute (so this doc cannot silently go stale)
 
@@ -140,10 +157,12 @@ console.log("draft-only skills:", [...draft].sort().join(", "));
 '
 ```
 
-Expected today: `validated: 14/33`, with NO draft-only skills (all five EVAL-1
-scenarios validated — three by discrimination, two as non-regression; see the tiers
-above). The snippet's binary draft/validated split does not distinguish the two
-tiers — it counts any scenario without the `status: draft-unvalidated` marker as
-validated — so read the tier tables, not just the number, to weight the evidence.
-When a future draft is promoted (marker removed after a passing live run), it moves
-into the validated count automatically.
+Expected today: `validated: 14/32`, with three draft-only skills
+(`arc-dispatching-parallel`, `arc-dispatching-teammates`, `arc-looping` — the
+AF-14 autonomy-package drafts). The five EVAL-1 scenarios remain validated —
+three by discrimination, two as non-regression; see the tiers above. The
+snippet's binary draft/validated split does not distinguish the two tiers — it
+counts any scenario without the `status: draft-unvalidated` marker as validated —
+so read the tier tables, not just the number, to weight the evidence. When a
+future draft is promoted (marker removed after a passing live run), it moves into
+the validated count automatically.


### PR DESCRIPTION
## Wave 6 · AF-14 — eval-scenario AUTHORING (no execution)

Authors NEW discriminative behavioral eval scenarios for the autonomy-package skills that had **none** registered: `arc-looping`, `arc-dispatching-teammates`, `arc-dispatching-parallel`.

### Acceptance (replayed by reviewer)
- 3 new scenario files; `eval lint <each>` = ok; `eval list` shows all 3 ✅
- Each has a clear Target + a discriminative trap in Context (a skill-less agent would fail it) ✅
- `npm test` + `check:docs` green; disjoint coverage-doc rows ✅
- **No live eval run** (execution is the probe-gated phase); target SKILL.md files untouched ✅

These scenarios are **lint-validated, not yet run**. They get executed (`eval run --k 5 --plugin-dir .`) + baseline-compared in the execution phase, which will refine any non-discriminative grader. Iron Law: this PR adds the eval coverage; the AF-package SKILL.md edits it validates already shipped in Waves 4–5.