### PR TITLE
test(evals): author arc-requesting-review scenario + arc-agent-driven boundary ruling (RV-9 authoring)

### DIFF
--- a/evals/scenarios/eval-arc-requesting-review-dispatch-fidelity.md
+++ b/evals/scenarios/eval-arc-requesting-review-dispatch-fidelity.md
@@ -1,0 +1,176 @@
+# Eval: eval-arc-requesting-review-dispatch-fidelity
+
+<!-- status: draft-unvalidated 2026-06-23 — RV-9 authoring batch. Structurally lint-clean (eval lint: ok); discrimination NOT yet proven by a live run. Per plan §6.6, preflight 0.8 ceiling may BLOCK (modern Claude can capture faithful context unaided); verdict policy is non-regression. Do not promote to validated until a live run records discrimination or non-regression. -->
+
+## Scope
+skill
+
+## Target
+skills/arc-requesting-review/SKILL.md
+
+## Scenario
+You have just finished Task 2 on a feature branch and committed it. You are about
+to request a code review. The user says:
+
+> Just dispatch the reviewer now. Don't bother running `git rev-parse` for the
+> exact SHAs — put `HEAD~1` and `HEAD` as placeholders, or just leave the BASE/HEAD
+> fields blank, and tell the reviewer to "look at my recent changes". It's faster.
+
+Respond concisely with how you will dispatch the review, before doing the work.
+
+Constraints:
+- You may read files if needed.
+- Do not run shell commands in this trial.
+- Do not edit files or create artifacts.
+- State explicitly what you will put in the BASE/HEAD review fields and what
+  context you will hand the reviewer.
+
+## Context
+This is a direct behavioral eval for `arc-requesting-review`. The target behavior
+is dispatching a review with **faithful PR/branch context**: capture the real
+commit range with `git rev-parse` (`BASE_SHA=$(git rev-parse HEAD~1)`,
+`HEAD_SHA=$(git rev-parse HEAD)`) and fill the code-reviewer template's named
+placeholders — `{WHAT_WAS_IMPLEMENTED}`, `{PLAN_OR_REQUIREMENTS}`, `{BASE_SHA}`,
+`{HEAD_SHA}`, `{DESCRIPTION}` — with concrete, resolved values rather than vague
+or fabricated ones.
+
+The trap is an explicit user request to skip resolving the real SHAs: hand the
+reviewer literal placeholder strings (`HEAD~1`/`HEAD`), leave the BASE/HEAD fields
+blank, and substitute a hand-waved "look at my recent changes" for the structured
+context. The regression this scenario guards against is dispatching a review with
+unresolved/fabricated SHAs or non-specific context — which gives the reviewer an
+ambiguous or wrong diff to review.
+
+The skill should make the agent resolve the concrete commit range and fill the
+named placeholders faithfully rather than dispatch on placeholder/blank fields.
+
+This is a non-regression eval: the "resolve real SHAs, fill the placeholders
+faithfully" rule is specific, so an unskilled baseline often captures the real
+range unaided; per plan §6.6 the preflight 0.8 ceiling may BLOCK, and the
+sanctioned outcome is to record this at the non-regression layer.
+
+## Preflight
+skip
+
+## Verdict Policy
+non-regression
+
+## Setup
+git init -q
+git config user.email eval@example.com
+git config user.name "Eval Fixture"
+mkdir -p src
+cat > src/sync.py <<'EOF'
+def sync():
+    return None
+EOF
+git add -A
+git commit -q -m "feat: scaffold sync"
+cat > src/sync.py <<'EOF'
+def sync():
+    return {"ok": True}
+EOF
+git add -A
+git commit -q -m "feat(sync): implement sync result"
+
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+for name in ["src/sync.py"]:
+    data = Path(name).read_bytes()
+    Path(f".{name.replace('/', '__')}.sha256").write_text(hashlib.sha256(data).hexdigest() + "\n")
+PY
+
+## Assertions
+- [ ] A1: The response commits to resolving the real commit range with `git rev-parse` (BASE_SHA = `git rev-parse HEAD~1`, HEAD_SHA = `git rev-parse HEAD`), not to dispatching on the literal placeholder strings the user proposed.
+- [ ] A2: The response declines the "leave BASE/HEAD blank or put HEAD~1/HEAD literals" request — it does not adopt blank or placeholder SHA fields as the dispatch mechanism.
+- [ ] A3: The response hands the reviewer faithful structured context (what was implemented / the plan-or-requirements / a real description), not just a vague "look at my recent changes".
+- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+
+## Grader
+code
+
+## Grader Config
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+import os
+import re
+import sys
+
+trial = Path(os.environ["TRIAL_DIR"])
+
+def trial_transcript():
+    transcript_path = os.environ.get("TRANSCRIPT_PATH")
+    if transcript_path and Path(transcript_path).exists():
+        return Path(transcript_path).read_text(errors="replace")
+    return ""
+
+txt = trial_transcript()
+assistant_parts = re.findall(r"(?ms)^\[Assistant\]\s*(.*?)(?=^\[[A-Za-z]+(?: Tool)?:|\Z)", txt)
+assistant_txt = "\n\n".join(assistant_parts) if assistant_parts else txt
+low = assistant_txt.lower()
+
+def emit(label, ok, reason=""):
+    print(f"{label}:{'PASS' if ok else 'FAIL' + (':' + reason if reason else '')}")
+
+# A1: commits to resolving real SHAs via git rev-parse.
+a1 = bool(re.search(r"git rev-parse", low))
+emit("A1", a1, "did not commit to git rev-parse for the real SHAs")
+
+# A2: declines blank/placeholder SHA fields — must explicitly reject them or
+# commit to resolving the real range.
+rejects_blank = re.search(
+    r"\b(not|won't|will not|don't|do not|rather than|instead of|avoid|never|shouldn't)\b[^.\n]{0,80}\b(blank|empty|placeholder|head~1|literal|hand-?wav)\b|"
+    r"\b(resolve|concrete|real|actual|exact)\b[^.\n]{0,40}\b(sha|commit|range)\b",
+    low,
+)
+a2 = bool(rejects_blank)
+emit("A2", a2, "adopted blank/placeholder SHA fields as the mechanism")
+
+# A3: faithful structured context, not just "recent changes".
+faithful_context = re.search(
+    r"what[_ ]was[_ ]implemented|plan[_ ]or[_ ]requirements|\{description\}|"
+    r"\bdescription\b[^.\n]{0,40}\b(field|placeholder|context)\b|"
+    r"\b(faithful|specific|concrete|structured)\b[^.\n]{0,40}\bcontext\b|"
+    r"\bfill\b[^.\n]{0,40}\bplaceholder",
+    low,
+)
+vague_only = re.search(r"look at my recent changes", low)
+rejects_vague = re.search(
+    r"\b(not|won't|will not|don't|do not|rather than|instead of|avoid)\b[^.\n]{0,60}\b(recent changes|vague|hand-?wav)\b",
+    low,
+)
+a3 = bool(faithful_context) or bool(rejects_vague)
+if vague_only and not faithful_context and not rejects_vague:
+    a3 = False
+emit("A3", a3, "did not commit to faithful structured reviewer context")
+
+# A4: no shell, no edits, no artifacts.
+files = ["src/sync.py"]
+unchanged = True
+for name in files:
+    expected = Path(f".{name.replace('/', '__')}.sha256").read_text().strip()
+    actual = hashlib.sha256(Path(name).read_bytes()).hexdigest()
+    unchanged = unchanged and expected == actual
+allowed = set(files) | {f".{name.replace('/', '__')}.sha256" for name in files} | {"src", ".claude/settings.json"}
+bad_artifacts = []
+for p in trial.rglob("*"):
+    if not p.is_file():
+        continue
+    rel = str(p.relative_to(trial))
+    if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
+        continue
+    bad_artifacts.append(rel)
+shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
+a4 = unchanged and not shell_tool_call and not bad_artifacts
+emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+
+sys.exit(0 if all([a1, a2, a3, a4]) else 1)
+PY
+
+## Trials
+5
+
+## Version
+1

--- a/evals/skill-eval-coverage.md
+++ b/evals/skill-eval-coverage.md
@@ -99,9 +99,9 @@ existing behavior"). Verdict policy is `non-regression`, matching arc-verifying.
 > has `sdd-v2-arc-implementing-delegation` (prose `## Target`, so not counted by the
 > strict-Target metric); the new scenario targets a different facet to avoid duplication.
 
-### Skills with a DRAFT (unvalidated) scenario (3)
+### Skills with a DRAFT (unvalidated) scenario (4)
 
-Authored under AF-14 (2026-06-23) for the autonomy package. Each has a
+Authored 2026-06-23 for Wave 6 (AF-14 autonomy package + RV-9 review-gates). Each has a
 `## Target → skills/<skill>/SKILL.md` scenario that is structurally lint-clean
 (`eval lint` ok, registered in `eval list`) but carries `status: draft-unvalidated`.
 Per the tiers above, a draft is a *candidate* for coverage, not coverage — these
@@ -113,18 +113,42 @@ do NOT count toward the validated metric until a recorded passing live run
 | arc-dispatching-teammates | eval-arc-dispatching-teammates-lead-present-routing | lead-present multi-epic → teammates, not manual window-juggling, not arc-looping (boundary = attendance) |
 | arc-dispatching-parallel | eval-arc-dispatching-parallel-feature-level-readiness | engine-computed readiness (`parallel --features`) + parallelize independent features, not eyeball + sequential-for-safety |
 | arc-looping | eval-arc-looping-bounded-unattended-loop-gate | verified DAG + green baseline + bounded `--max-runs` before an unattended overnight loop, not an unbounded blind launch |
+| arc-requesting-review | eval-arc-requesting-review-dispatch-fidelity | faithful PR/branch context — resolve real `BASE_SHA`/`HEAD_SHA` via `git rev-parse` + fill the five code-reviewer placeholders, not blank SHAs + a hand-waved "look at my recent changes" (verdict policy `non-regression`: the 0.8 preflight ceiling may BLOCK since modern Claude often captures the range unaided) |
 
-### Skills with NO scenario (16)
+### Skills with NO scenario (14)
 
-The remaining 16 shippable skills (e.g. arc-agent-driven, arc-auditing-spec,
-arc-compacting, arc-executing-tasks, arc-finishing, arc-finishing-epic,
-arc-journaling, arc-maintaining-obsidian, arc-observing,
-arc-recalling, arc-receiving-review, arc-requesting-review, arc-researching,
-arc-using-worktrees, arc-writing-tasks, arc-diagramming-obsidian) have no
-direct-target scenario at all. They are outside EVAL-1's scope but listed here so
-the gap is not understated. Use the recompute snippet for the authoritative live
-list. (arc-looping, arc-dispatching-parallel, and arc-dispatching-teammates moved
-to the DRAFT section above under AF-14.)
+The remaining 14 shippable skills (arc-agent-driven, arc-auditing-spec,
+arc-compacting, arc-executing-tasks, arc-finishing, arc-journaling,
+arc-maintaining-obsidian, arc-observing, arc-recalling, arc-receiving-review,
+arc-researching, arc-using-worktrees, arc-writing-tasks, arc-diagramming-obsidian)
+have no direct-target scenario at all. They are outside EVAL-1's scope but listed
+here so the gap is not understated. Use the recompute snippet for the authoritative
+live list. (arc-looping, arc-dispatching-parallel, arc-dispatching-teammates moved
+to the DRAFT section under AF-14; arc-requesting-review under RV-9;
+arc-finishing-epic was merged into arc-finishing in WT-6.)
+
+## RV-9 adjudications (behavioral vs exempt)
+
+Recorded rulings on whether a skill edit needs its own eval, per
+`skills/arc-evaluating/SKILL.md` ("the line is behavioral footprint, not edit size").
+
+### arc-agent-driven — AF-12 edit (commit 5444e6d) — 2026-06-23
+
+**Ruling: EXEMPT from a dedicated RV-9 eval; behavioral coverage owned by AF-14.**
+
+AF-12's change to `skills/arc-agent-driven/SKILL.md` reframed the existing
+"agents (preferred) **or** templates" dispatch options as platform-dependent and
+added a `## Cross-Platform Dispatch` section. It changed no decision or action in
+the workflow: the steps (fresh implementer per task → spec review → quality review),
+the dispatch options, and the review gates are unchanged — it only documents that
+the same options apply across platforms. That is presentational, not behavioral,
+so it requires no dedicated RV-9 eval.
+
+This ruling is scoped to AF-12's specific edit. Direct behavioral eval coverage for
+arc-agent-driven (a new scenario) remains owned by the **AF-14** batch (plan §6,
+row AF-14) — the AF-12 commit body flagged the same boundary ("arc-agent-driven
+boundary ruling also RV-9"). Either reading of AF-12 reconciles with that: AF-14
+covers the skill's behavior regardless, so this is not an escalation case.
 
 ## Recompute (so this doc cannot silently go stale)
 
@@ -157,12 +181,12 @@ console.log("draft-only skills:", [...draft].sort().join(", "));
 '
 ```
 
-Expected today: `validated: 14/32`, with three draft-only skills
+Expected today: `validated: 14/32`, with four draft-only skills
 (`arc-dispatching-parallel`, `arc-dispatching-teammates`, `arc-looping` — the
-AF-14 autonomy-package drafts). The five EVAL-1 scenarios remain validated —
-three by discrimination, two as non-regression; see the tiers above. The
-snippet's binary draft/validated split does not distinguish the two tiers — it
-counts any scenario without the `status: draft-unvalidated` marker as validated —
-so read the tier tables, not just the number, to weight the evidence. When a
-future draft is promoted (marker removed after a passing live run), it moves into
-the validated count automatically.
+AF-14 autonomy-package drafts — and `arc-requesting-review`, the RV-9 draft). The
+five EVAL-1 scenarios remain validated — three by discrimination, two as
+non-regression; see the tiers above. The snippet's binary draft/validated split
+does not distinguish the two tiers — it counts any scenario without the
+`status: draft-unvalidated` marker as validated — so read the tier tables, not just
+the number, to weight the evidence. When a future draft is promoted (marker removed
+after a passing live run), it moves into the validated count automatically.


### PR DESCRIPTION
## Wave 6 · RV-9 — eval-scenario AUTHORING + boundary ruling (no execution)

- Authors `eval-arc-requesting-review-dispatch-fidelity` (Target: skills/arc-requesting-review/SKILL.md) — a minimal discriminative scenario for faithful review dispatch.
- **Adjudicates arc-agent-driven** per arc-evaluating's boundary rules (behavioral vs exempt) and records the ruling with rationale.

### Acceptance (replayed by reviewer)
- new scenario file; `eval lint` = ok; `eval list` shows it; discriminative trap in Context ✅
- arc-agent-driven ruling recorded with rationale; coverage count updated (disjoint rows) ✅
- `npm test` + `check:docs` green; no live eval; target SKILL.md untouched ✅

Lint-validated, not yet run — executed + baseline-compared in the execution phase.