### PR TITLE
fix(evals): HOME-isolation for eval trials (ARCFORGE_HOME) + ICL-4 discrimination record (Wave 6 exec)

### DIFF
--- a/evals/scenarios/eval-icl4-activated-instinct-injection.md
+++ b/evals/scenarios/eval-icl4-activated-instinct-injection.md
@@ -1,6 +1,6 @@
 # Eval: eval-icl4-activated-instinct-injection
 
-**Status**: Active — Layer 8 activated-instinct SessionStart injection gate (ICL-4 positive boundary).
+**Status**: validated-DISCRIMINATION 2026-06-23 — Layer 8 activated-instinct SessionStart injection gate (ICL-4 positive boundary). Preflight PASS (baseline pass 0% < 0.8 — genuinely discriminative); `arc eval run` k=5 → 5/5 SHIP (baseline 0% → treatment 100%, Δ+1.0). Proves ICL-4's activation-gated injection actually surfaces an activated instinct at SessionStart. REQUIRES `ARCFORGE_HOME` trial isolation at runtime (the eval-home-isolation fix); without it the trial reads the real `~/.arcforge` and the fixture never reaches the hook.
 
 ## Scope
 learning

--- a/evals/scenarios/instinct-adherence.md
+++ b/evals/scenarios/instinct-adherence.md
@@ -1,6 +1,6 @@
 # Eval: instinct-adherence
 
-**Status**: Active — Layer 8 non-activated-instinct SessionStart boundary gate (post-ICL-4).
+**Status**: Active (non-regression, now NON-VACUOUS under `ARCFORGE_HOME` isolation) — Layer 8 non-activated-instinct SessionStart boundary gate (post-ICL-4). Preflight BLOCK (baseline pass 100% ≥ 0.8 ceiling → non-regression guard, not discriminative — expected for a negative boundary); `arc eval run` k=5 → 5/5 SHIP. With the eval-home-isolation fix the trial's own (empty) activation store is read, so the activation gate is actually exercised — the fixture is reachable and correctly NOT surfaced (previously the trial read the real `~/.arcforge`, so this guard passed vacuously).
 
 ## Scope
 learning

--- a/scripts/lib/eval-trial-env.js
+++ b/scripts/lib/eval-trial-env.js
@@ -84,6 +84,13 @@ function cleanupTrialDir(trialDir) {
 function runSetup(setupCommand, trialDir, projectRoot) {
   const env = { ...process.env };
   if (projectRoot) env.PROJECT_ROOT = projectRoot;
+  // Redirect the arcforge data home to the trial dir so a setup that writes
+  // arcforge fixtures (instincts, activations, observations) via
+  // getArcforgeHome() lands under TRIAL_DIR/.arcforge — the same home the
+  // trial's SessionStart hook reads (it honors ARCFORGE_HOME). Also expose
+  // TRIAL_DIR so setups can reference it explicitly.
+  env.ARCFORGE_HOME = path.join(trialDir, '.arcforge');
+  env.TRIAL_DIR = trialDir;
   const { exitCode, stderr } = execCommand('sh', ['-c', setupCommand], {
     cwd: trialDir,
     timeout: 30000,

--- a/scripts/lib/eval.js
+++ b/scripts/lib/eval.js
@@ -198,6 +198,12 @@ function runTrial(scenario, trialNumber, totalTrials, options = {}) {
     cwd: trialDir,
     timeout: 300000,
     maxBuffer: CLAUDE_MAX_BUFFER,
+    // Redirect ONLY the arcforge data home (not HOME) to the trial's isolated
+    // fixture. getArcforgeHome() honors ARCFORGE_HOME before falling back to
+    // ~/.arcforge, so the trial's SessionStart hook reads the Setup-written
+    // fixture under TRIAL_DIR/.arcforge instead of the real ~/.arcforge. Real
+    // HOME is preserved so the claude trial still resolves ~/.claude auth.
+    env: { ...process.env, ARCFORGE_HOME: path.join(trialDir, '.arcforge') },
   });
   const wallDuration = Date.now() - t0;
   if (process.env.EVAL_DEBUG) {

--- a/scripts/lib/learning.js
+++ b/scripts/lib/learning.js
@@ -2,7 +2,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
-const { readJsonFile, writeJsonFile } = require('./utils');
+const { readJsonFile, writeJsonFile, getArcforgeHome } = require('./utils');
 const { renderDraft } = require('./learning-drafts');
 
 const VALID_SCOPES = new Set(['project', 'global']);
@@ -50,7 +50,12 @@ function assertScope(scope) {
 function getLearningConfigPath({ scope, projectRoot = process.cwd(), homeDir } = {}) {
   assertScope(scope);
   if (scope === 'global')
-    return path.join(homePath(homeDir), '.arcforge', 'learning', 'config.json');
+    // No explicit homeDir → honor ARCFORGE_HOME (eval-trial isolation) via the
+    // shared resolver; byte-identical to ~/.arcforge when ARCFORGE_HOME is unset.
+    // An explicit homeDir (tests) keeps the original path exactly.
+    return homeDir
+      ? path.join(homePath(homeDir), '.arcforge', 'learning', 'config.json')
+      : path.join(getArcforgeHome(), 'learning', 'config.json');
   return path.join(projectRoot, '.arcforge', 'learning', 'config.json');
 }
 

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -535,8 +535,16 @@ function generateRunId() {
  * Root for all arcforge user state (worktrees, sessions, diaries).
  * Lives outside ~/.claude/ because Claude Code v2.1.78+ protects ~/.claude/
  * from nested-subprocess Write calls, which breaks the background enricher.
+ *
+ * `ARCFORGE_HOME` overrides the default location when set to a non-empty path.
+ * The eval harness uses this to redirect a trial's arcforge data home to an
+ * isolated fixture dir without touching HOME (which would break the trial's
+ * ~/.claude auth resolution). When the env var is unset, the resolved path is
+ * byte-identical to the original `~/.arcforge`.
  */
 function getArcforgeHome() {
+  const override = process.env.ARCFORGE_HOME;
+  if (override?.trim()) return override;
   return path.join(os.homedir(), '.arcforge');
 }
 

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -119,6 +119,44 @@ describe('learning subsystem MVP-1', () => {
       writeGlobalConfig({ scope: 'global', inject_activated_instincts: false });
       expect(isInjectActivatedInstinctsEnabled({ homeDir })).toBe(false);
     });
+
+    it('global config path honors ARCFORGE_HOME when no homeDir is passed (eval-trial isolation)', () => {
+      const prev = process.env.ARCFORGE_HOME;
+      try {
+        process.env.ARCFORGE_HOME = path.join(homeDir, 'isolated-arcforge');
+        expect(getLearningConfigPath({ scope: 'global' })).toBe(
+          path.join(homeDir, 'isolated-arcforge', 'learning', 'config.json'),
+        );
+      } finally {
+        if (prev === undefined) delete process.env.ARCFORGE_HOME;
+        else process.env.ARCFORGE_HOME = prev;
+      }
+    });
+
+    it('global config path is byte-identical to ~/.arcforge when ARCFORGE_HOME is unset', () => {
+      const prev = process.env.ARCFORGE_HOME;
+      try {
+        delete process.env.ARCFORGE_HOME;
+        expect(getLearningConfigPath({ scope: 'global' })).toBe(
+          path.join(os.homedir(), '.arcforge', 'learning', 'config.json'),
+        );
+      } finally {
+        if (prev !== undefined) process.env.ARCFORGE_HOME = prev;
+      }
+    });
+
+    it('explicit homeDir takes precedence over ARCFORGE_HOME (tests stay byte-identical)', () => {
+      const prev = process.env.ARCFORGE_HOME;
+      try {
+        process.env.ARCFORGE_HOME = path.join(homeDir, 'should-be-ignored');
+        expect(getLearningConfigPath({ scope: 'global', homeDir })).toBe(
+          path.join(homeDir, '.arcforge', 'learning', 'config.json'),
+        );
+      } finally {
+        if (prev === undefined) delete process.env.ARCFORGE_HOME;
+        else process.env.ARCFORGE_HOME = prev;
+      }
+    });
   });
 
   it('validates required candidate queue schema fields', () => {

--- a/tests/scripts/utils.test.js
+++ b/tests/scripts/utils.test.js
@@ -10,6 +10,7 @@ const {
   loadSession,
   saveSession,
   getProjectName,
+  getArcforgeHome,
   getSessionsDir,
   getProjectSessionsDir,
   getDiaryedDir,
@@ -179,5 +180,20 @@ describe('path helpers', () => {
     const base = path.join(os.homedir(), '.arcforge', 'diaryed');
     expect(getDiaryedDir('proj')).toBe(path.join(base, 'proj'));
     expect(getDiaryedDir()).toBe(path.join(base, 'global'));
+  });
+
+  it('getArcforgeHome should be byte-identical to ~/.arcforge when ARCFORGE_HOME is unset', () => {
+    delete process.env.ARCFORGE_HOME;
+    expect(getArcforgeHome()).toBe(path.join(os.homedir(), '.arcforge'));
+  });
+
+  it('getArcforgeHome should honor a non-empty ARCFORGE_HOME override', () => {
+    process.env.ARCFORGE_HOME = '/tmp/trial-xyz/.arcforge';
+    expect(getArcforgeHome()).toBe('/tmp/trial-xyz/.arcforge');
+  });
+
+  it('getArcforgeHome should ignore a blank ARCFORGE_HOME and fall back to ~/.arcforge', () => {
+    process.env.ARCFORGE_HOME = '   ';
+    expect(getArcforgeHome()).toBe(path.join(os.homedir(), '.arcforge'));
   });
 });


### PR DESCRIPTION
## Wave 6 execution · eval HOME-isolation + ICL-13 results

The keystone that made the ICL-13 instinct batch measurable, plus the records it produced.

### Harness fix (3bb1b32)
Eval trials spawned `claude` inheriting the **real** `HOME`, but the SessionStart hook resolves `~/.arcforge` via `os.homedir()` — so a trial read the developer's real arcforge home, not the trial fixture (the positive ICL-4 scenario couldn't discriminate; `instinct-adherence` passed vacuously). Attempt A (`HOME=trialDir`) broke `claude`'s own auth ("Not logged in"), so this uses **Approach B**: a new `getArcforgeHome()` resolver in `utils.js` honors `ARCFORGE_HOME` (byte-identical to `~/.arcforge` when unset); `eval.js` + `eval-trial-env.js` set it per trial. +3 tests.

### ICL-13 result record (ced6449)
- `eval-icl4-activated-instinct-injection` → **validated-DISCRIMINATION**: preflight PASS (baseline 0%), run k=5 5/5 SHIP — **Δ+1.0**. Proves ICL-4's activation-gated injection actually surfaces an activated instinct at SessionStart.
- `instinct-adherence` → now **non-vacuous** (the gate is actually exercised), non-regression guard, k=5 5/5 SHIP.

### Kill-switch isolation (448e32f)
`getLearningConfigPath`'s global-scope branch honors `ARCFORGE_HOME` **only when no explicit `homeDir` is passed** — byte-identical for tests (which pass `homeDir`) and for production when `ARCFORGE_HOME` is unset; the shared `homePath()` and its ~40 callers are untouched. Closes the gap where `eval-icl4`'s kill-switch read leaked to the real `~/.arcforge`. +3 path-level tests.

### Acceptance
`npm test` (5 runners) + `npm run lint` + `npm run check:docs` all green; `eval lint` ok on both scenarios.