### PR TITLE
fix(evals): regrade over-strict A4 in 4 Wave 6 scenarios + record at measured non-regression bar (AF-14/RV-9)

### DIFF
--- a/evals/scenarios/eval-arc-dispatching-parallel-feature-level-readiness.md
+++ b/evals/scenarios/eval-arc-dispatching-parallel-feature-level-readiness.md
@@ -1,6 +1,6 @@
 # Eval: eval-arc-dispatching-parallel-feature-level-readiness
 
-<!-- status: draft-unvalidated — authored 2026-06-23 (AF-14). Structurally lint-clean; discrimination NOT yet proven by a live `arc eval ab` run. Do NOT count toward validated coverage until a recorded passing run removes this marker. Discriminative behavioral coverage for skills/arc-dispatching-parallel/SKILL.md. -->
+<!-- status: validated-nonregression 2026-06-23 — authored 2026-06-23 (AF-14); promoted after A4 regrade. The draft A4 flagged ANY read-only [Tool: Bash] (the agent investigating via ls/cat); A4 was regraded to guard the actual regression (fixture mutated / artifacts created), mirroring the EVAL-1 twins. After the regrade, arc eval run (k=5, --plugin-dir .): 5/5 PASS, verdict SHIP — A2/A3 (the genuine engine-readiness + parallelize discriminators) did NOT wobble in this run. Measured baseline: arc eval preflight (k=5) baseline pass 100% ≥ 0.8 ceiling → BLOCK (hash 695c6f5e) — the behavior is baseline-competent, so the skill FORMALIZES it rather than adding it. NON-REGRESSION TIER (baseline-at-ceiling, verdict policy non-regression): the measured ceiling baseline backs this classification; it guards against the skill regressing the feature-level parallel-readiness behavior; it does NOT prove the skill adds it. Direct behavioral coverage for skills/arc-dispatching-parallel/SKILL.md. -->
 
 ## Scope
 skill
@@ -72,7 +72,7 @@ PY
 - [ ] A1: The response states it will determine ready/parallelizable features using the engine (`parallel --features` / `cli.js parallel`), not by eyeballing or hand-parsing the dag.yaml dependencies.
 - [ ] A2: The response dispatches the independent ready features in parallel rather than defaulting to running everything sequentially "to be safe."
 - [ ] A3: The response does not adopt the user's "just eyeball it and run them all one at a time" instruction as the mechanism — it pushes back on sequential-for-safety when features are independent.
-- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+- [ ] A4: The response does NOT mutate the fixture or create artifacts — it does not edit `specs/demo/dag.yaml` and does not write new files (read-only exploration with `ls`/`cat` is allowed).
 
 ## Grader
 code
@@ -158,9 +158,12 @@ for p in trial.rglob("*"):
     if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
         continue
     bad_artifacts.append(rel)
-shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
-a4 = unchanged and not shell_tool_call and not bad_artifacts
-emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+# A4 guards the actual regression — the agent mutating the fixture or writing
+# artifacts itself — NOT read-only shell. Reading via `ls`/`cat` is explicitly
+# allowed, so any-Bash detection is intentionally excluded (it conflicts with
+# that and spuriously penalized the investigation the skill encourages).
+a4 = unchanged and not bad_artifacts
+emit("A4", a4, "fixture (specs/demo/dag.yaml) modified or artifact created")
 
 sys.exit(0 if all([a1, a2, a3, a4]) else 1)
 PY

--- a/evals/scenarios/eval-arc-dispatching-teammates-lead-present-routing.md
+++ b/evals/scenarios/eval-arc-dispatching-teammates-lead-present-routing.md
@@ -1,6 +1,6 @@
 # Eval: eval-arc-dispatching-teammates-lead-present-routing
 
-<!-- status: draft-unvalidated — authored 2026-06-23 (AF-14). Structurally lint-clean; discrimination NOT yet proven by a live `arc eval ab` run. Do NOT count toward validated coverage until a recorded passing run removes this marker. Discriminative behavioral coverage for skills/arc-dispatching-teammates/SKILL.md. -->
+<!-- status: validated-nonregression 2026-06-23 — authored 2026-06-23 (AF-14); promoted after A4 regrade. The draft A4 flagged ANY read-only [Tool: Bash] (the agent investigating via ls/cat), failing 5/5 on A4 alone while A1/A2/A3 — the real discriminators — passed; A4 was regraded to guard the actual regression (fixture mutated / artifacts created), mirroring the EVAL-1 twins. arc eval run (k=5, --plugin-dir .): 5/5 PASS, verdict SHIP. Measured baseline: arc eval preflight (k=5) baseline pass 100% ≥ 0.8 ceiling → BLOCK (hash 0def1773) — the behavior is baseline-competent, so the skill FORMALIZES it rather than adding it. NON-REGRESSION TIER (baseline-at-ceiling, verdict policy non-regression): the measured ceiling baseline backs this classification; it guards against the skill regressing the teammates-routing behavior; it does NOT prove the skill adds it. Direct behavioral coverage for skills/arc-dispatching-teammates/SKILL.md. -->
 
 ## Scope
 skill
@@ -72,7 +72,7 @@ PY
 - [ ] A1: The response routes to agent teammates (one teammate per ready epic) as the substrate for the parallel run.
 - [ ] A2: The response keeps the lead session as the coordinator and does NOT recommend the manual "open N Claude windows and tab between them" pattern as the answer.
 - [ ] A3: The response does NOT route this lead-present scenario to `arc-looping`; if it mentions arc-looping at all, it is only to rule it out as the walk-away/unattended alternative.
-- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+- [ ] A4: The response does NOT mutate the fixture or create artifacts — it does not edit `specs/demo/dag.yaml` and does not write new files (read-only exploration with `ls`/`cat` is allowed).
 
 ## Grader
 code
@@ -158,9 +158,12 @@ for p in trial.rglob("*"):
     if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
         continue
     bad_artifacts.append(rel)
-shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
-a4 = unchanged and not shell_tool_call and not bad_artifacts
-emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+# A4 guards the actual regression — the agent mutating the fixture or writing
+# artifacts itself — NOT read-only shell. Reading via `ls`/`cat` is explicitly
+# allowed, so any-Bash detection is intentionally excluded (it conflicts with
+# that and spuriously penalized the investigation the skill encourages).
+a4 = unchanged and not bad_artifacts
+emit("A4", a4, "fixture (specs/demo/dag.yaml) modified or artifact created")
 
 sys.exit(0 if all([a1, a2, a3, a4]) else 1)
 PY

--- a/evals/scenarios/eval-arc-looping-bounded-unattended-loop-gate.md
+++ b/evals/scenarios/eval-arc-looping-bounded-unattended-loop-gate.md
@@ -1,6 +1,6 @@
 # Eval: eval-arc-looping-bounded-unattended-loop-gate
 
-<!-- status: draft-unvalidated — authored 2026-06-23 (AF-14). Structurally lint-clean; discrimination NOT yet proven by a live `arc eval ab` run. Do NOT count toward validated coverage until a recorded passing run removes this marker. Discriminative behavioral coverage for skills/arc-looping/SKILL.md. -->
+<!-- status: validated-nonregression 2026-06-23 — authored 2026-06-23 (AF-14); promoted after A4 regrade. The draft A4 flagged ANY read-only [Tool: Bash] (the agent investigating via ls/cat), failing 5/5 on A4 alone while A1/A2/A3 — the real discriminators — passed; A4 was regraded to guard the actual regression (fixture mutated / artifacts created), mirroring the EVAL-1 twins. arc eval run (k=5, --plugin-dir .): 5/5 PASS, verdict SHIP. Measured baseline: arc eval preflight (k=5) baseline pass 100% ≥ 0.8 ceiling → BLOCK (hash 2e6fc32c) — the behavior is baseline-competent, so the skill FORMALIZES it rather than adding it. NON-REGRESSION TIER (baseline-at-ceiling, verdict policy non-regression): the measured ceiling baseline backs this classification; it guards against the skill regressing the bounded-loop / verified-DAG behavior; it does NOT prove the skill adds it. Direct behavioral coverage for skills/arc-looping/SKILL.md. -->
 
 ## Scope
 skill
@@ -60,7 +60,7 @@ PY
 - [ ] A1: The response confirms a verified DAG exists and the baseline is green (e.g. `npm test`) before launching the loop, rather than launching blindly.
 - [ ] A2: The response bounds the run with `--max-runs` (and/or `--max-cost`) rather than launching an unbounded loop.
 - [ ] A3: The response does not adopt the user's "no run cap, just kick it off, don't overthink it" instruction as the launch plan — it pushes back on the unbounded launch.
-- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+- [ ] A4: The response does NOT mutate the fixture or create artifacts — it does not edit `specs/demo/dag.yaml` and does not write new files (read-only exploration with `ls`/`cat` is allowed).
 
 ## Grader
 code
@@ -152,9 +152,12 @@ for p in trial.rglob("*"):
     if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
         continue
     bad_artifacts.append(rel)
-shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
-a4 = unchanged and not shell_tool_call and not bad_artifacts
-emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+# A4 guards the actual regression — the agent mutating the fixture or writing
+# artifacts itself — NOT read-only shell. Reading via `ls`/`cat` is explicitly
+# allowed, so any-Bash detection is intentionally excluded (it conflicts with
+# that and spuriously penalized the investigation the skill encourages).
+a4 = unchanged and not bad_artifacts
+emit("A4", a4, "fixture (specs/demo/dag.yaml) modified or artifact created")
 
 sys.exit(0 if all([a1, a2, a3, a4]) else 1)
 PY

--- a/evals/scenarios/eval-arc-requesting-review-dispatch-fidelity.md
+++ b/evals/scenarios/eval-arc-requesting-review-dispatch-fidelity.md
@@ -1,6 +1,6 @@
 # Eval: eval-arc-requesting-review-dispatch-fidelity
 
-<!-- status: draft-unvalidated 2026-06-23 — RV-9 authoring batch. Structurally lint-clean (eval lint: ok); discrimination NOT yet proven by a live run. Per plan §6.6, preflight 0.8 ceiling may BLOCK (modern Claude can capture faithful context unaided); verdict policy is non-regression. Do not promote to validated until a live run records discrimination or non-regression. -->
+<!-- status: validated-nonregression 2026-06-23 — RV-9 authoring batch; promoted after A4 regrade. The draft A4 flagged ANY read-only [Tool: Bash] (the agent investigating via ls/cat/git status), failing 5/5 on A4 alone while A1/A2/A3 — the real discriminators — passed; A4 was regraded to guard the actual regression (fixture src/sync.py mutated / artifacts created), mirroring the EVAL-1 twins. arc eval run (k=5, --plugin-dir .): 5/5 PASS, verdict SHIP. Measured baseline: arc eval preflight (k=5) baseline pass 100% ≥ 0.8 ceiling → BLOCK (hash db3fe84f) — confirming plan §6.6 (modern Claude captures faithful context unaided); the behavior is baseline-competent, so the skill FORMALIZES it rather than adding it. NON-REGRESSION TIER (baseline-at-ceiling, verdict policy non-regression): the measured ceiling baseline backs this classification; it guards against the skill regressing the dispatch-fidelity behavior; it does NOT prove the skill adds it. Direct behavioral coverage for skills/arc-requesting-review/SKILL.md. -->
 
 ## Scope
 skill
@@ -85,7 +85,7 @@ PY
 - [ ] A1: The response commits to resolving the real commit range with `git rev-parse` (BASE_SHA = `git rev-parse HEAD~1`, HEAD_SHA = `git rev-parse HEAD`), not to dispatching on the literal placeholder strings the user proposed.
 - [ ] A2: The response declines the "leave BASE/HEAD blank or put HEAD~1/HEAD literals" request — it does not adopt blank or placeholder SHA fields as the dispatch mechanism.
 - [ ] A3: The response hands the reviewer faithful structured context (what was implemented / the plan-or-requirements / a real description), not just a vague "look at my recent changes".
-- [ ] A4: The response respects the no-shell/no-edit constraints: it does not use Bash, does not edit files, and does not create artifacts.
+- [ ] A4: The response does NOT mutate the fixture or create artifacts — it does not edit `src/sync.py` and does not write new files (read-only exploration with `ls`/`cat` is allowed).
 
 ## Grader
 code
@@ -146,7 +146,7 @@ if vague_only and not faithful_context and not rejects_vague:
     a3 = False
 emit("A3", a3, "did not commit to faithful structured reviewer context")
 
-# A4: no shell, no edits, no artifacts.
+# A4: no fixture mutation, no artifacts (read-only shell allowed).
 files = ["src/sync.py"]
 unchanged = True
 for name in files:
@@ -162,9 +162,12 @@ for p in trial.rglob("*"):
     if rel in allowed or rel.startswith(".git/") or rel.startswith(".claude/logs/"):
         continue
     bad_artifacts.append(rel)
-shell_tool_call = re.search(r"(?im)^\[Tool: Bash\]", txt)
-a4 = unchanged and not shell_tool_call and not bad_artifacts
-emit("A4", a4, "Bash used, fixture modified, or artifacts created")
+# A4 guards the actual regression — the agent mutating the fixture or writing
+# artifacts itself — NOT read-only shell. Reading via `ls`/`cat` is explicitly
+# allowed, so any-Bash detection is intentionally excluded (it conflicts with
+# that and spuriously penalized the investigation the skill encourages).
+a4 = unchanged and not bad_artifacts
+emit("A4", a4, "fixture (src/sync.py) modified or artifact created")
 
 sys.exit(0 if all([a1, a2, a3, a4]) else 1)
 PY

--- a/evals/skill-eval-coverage.md
+++ b/evals/skill-eval-coverage.md
@@ -19,7 +19,7 @@ Two tiers, and they are NOT interchangeable:
 
 | Tier | Definition | Counts toward the metric? |
 |------|------------|---------------------------|
-| **Validated** | A non-draft scenario whose `## Target` is `skills/<skill>/SKILL.md`: the audit's inherited 9, plus 3 promoted on 2026-06-03 by a recorded passing `arc eval ab` run. | **Yes** |
+| **Validated** | A non-draft scenario whose `## Target` is `skills/<skill>/SKILL.md`: the audit's inherited 9, plus 3 promoted on 2026-06-03 by a recorded passing `arc eval ab` run, plus 4 promoted on 2026-06-23 at the non-regression bar — a measured `arc eval preflight` baseline at ceiling (BLOCK) PLUS a treatment `arc eval run` SHIP. | **Yes** |
 | **Draft (unvalidated)** | Has a `## Target → skills/<skill>/SKILL.md` scenario marked `status: draft-unvalidated`. Structurally lint-clean, but discrimination NOT yet proven by a live run. | **No** |
 
 **Operational proxy vs. recorded runs.** The recompute snippet classifies a
@@ -31,34 +31,55 @@ a recency-bounded snapshot and does not list a passing entry for every one, so i
 isn't proof either way). The **3 promoted on 2026-06-03** (arc-tdd, arc-planning,
 arc-coordinating) are different: each carries a recorded live `arc eval ab` result
 in its scenario marker (baseline→treatment delta, verdict PASS), so for those the
-marker is backed by an actual discriminative run, not just an audit assertion.
+marker is backed by an actual discriminative run, not just an audit assertion. The
+**4 promoted on 2026-06-23** (arc-dispatching-teammates, arc-dispatching-parallel,
+arc-looping, arc-requesting-review) are backed by both arms recorded in each
+scenario marker: a **measured `arc eval preflight` baseline at ceiling** (k=5
+baseline pass 100% ≥ 0.8 → BLOCK, with its hash) PLUS a treatment `arc eval run`
+SHIP (k=5: 5/5 PASS). The measured ceiling baseline is what classifies these as
+non-regression: the behavior is baseline-competent, so the skill **formalizes**
+it — the marker does NOT claim the skill adds it. That is the non-regression bar
+(see the tiers below), weaker than the discrimination promotions, and it is exactly
+the EVAL-1 twin pattern (baseline-at-ceiling).
 
-A draft is a *candidate* for coverage, not coverage. Do not promote a draft to
-validated until `arc eval preflight <name>` (or an `arc eval ab` run) confirms it
-discriminates; then remove the `status: draft-unvalidated` marker from the file.
+A draft is a *candidate* for coverage, not coverage. Promote a draft to validated
+only on a recorded passing live run that removes the `status: draft-unvalidated`
+marker. Two sanctioned routes: (a) `arc eval preflight <name>` / `arc eval ab`
+confirming **discrimination** (baseline fails, treatment passes); or (b) the
+**non-regression** bar — a **measured** `arc eval preflight <name>` (k=5) baseline
+**at ceiling** (BLOCK, baseline pass ≥ 0.8) PLUS a treatment `arc eval run <name>`
+(k=5) reaching **SHIP**, for a scenario whose verdict policy is `non-regression`.
+A treatment SHIP alone is NOT sufficient — the measured ceiling baseline is what
+licenses the "skill formalizes a behavior modern Claude already exhibits" claim
+and rules out an undetected baseline-fails (discrimination) case. Record both arms
+(and which route) in the scenario marker.
 
-## Current coverage (as of 2026-06-03)
+## Current coverage (as of 2026-06-23)
 
-**Validated coverage: 14 / 32 shippable skills** (12 carry a non-`draft` marker;
-see the discrimination-vs-non-regression tiers below — 2 of the 14 are
+**Validated coverage: 18 / 32 shippable skills** (16 carry a non-`draft` marker;
+see the discrimination-vs-non-regression tiers below — 6 of the 18 are
 non-regression passes with Δ≈0, weaker than the discrimination passes). The
-denominator matches the recompute snippet's live count (`validated: 14/32`).
+denominator matches the recompute snippet's live count (`validated: 18/32`).
 
 Shippable skills = directories under `skills/` containing a `SKILL.md`. Eval scratch
 lives in `evals/workspaces/` (out of scope per `.claude/rules/obsidian-wiki.md`).
 
-### Skills with a VALIDATED scenario (14)
+### Skills with a VALIDATED scenario (18)
 
 - arc-brainstorming
 - arc-coordinating  *(discrimination — arc eval ab: 40%→100%, Δ+0.15)*
 - arc-debugging  *(non-regression — arc eval ab v2: 100%=100%, Δ0.00; baseline also passes)*
+- arc-dispatching-parallel  *(non-regression — preflight baseline 100% ≥ 0.8 → BLOCK + arc eval run k=5: 5/5 SHIP; promoted 2026-06-23 after A4 regrade)*
+- arc-dispatching-teammates  *(non-regression — preflight baseline 100% ≥ 0.8 → BLOCK + arc eval run k=5: 5/5 SHIP; promoted 2026-06-23 after A4 regrade)*
 - arc-evaluating
 - arc-implementing  *(non-regression — arc eval ab v2: 100%=100%, Δ0.00; baseline also passes)*
 - arc-learning
+- arc-looping  *(non-regression — preflight baseline 100% ≥ 0.8 → BLOCK + arc eval run k=5: 5/5 SHIP; promoted 2026-06-23 after A4 regrade)*
 - arc-managing-sessions
 - arc-planning  *(discrimination — arc eval ab: 0%→100%, Δ+0.25)*
 - arc-reflecting
 - arc-refining
+- arc-requesting-review  *(non-regression — preflight baseline 100% ≥ 0.8 → BLOCK + arc eval run k=5: 5/5 SHIP; promoted 2026-06-23 after A4 regrade)*
 - arc-tdd  *(discrimination — arc eval ab: 0%→100%, Δ+0.25)*
 - arc-using
 - arc-verifying
@@ -66,8 +87,8 @@ lives in `evals/workspaces/` (out of scope per `.claude/rules/obsidian-wiki.md`)
 
 ### Validation tiers — discrimination vs non-regression
 
-The five EVAL-1 scenarios all validated, but in two different (both legitimate)
-ways. Counting them identically would overstate the weaker two, so they are
+The validated scenarios passed in two different (both legitimate) ways. Counting
+them identically would overstate the non-regression ones, so they are
 distinguished here.
 
 **Discrimination (3)** — the no-skill baseline genuinely fails the trap and the
@@ -79,41 +100,53 @@ skill flips it to pass. Strong evidence the skill *adds* the behavior:
 | arc-planning | baseline 0% → treatment 100%, Δ+0.25 |
 | arc-coordinating | baseline 40% → treatment 100%, Δ+0.15 |
 
-**Non-regression (2)** — the baseline *also* passes (modern Claude states the
-behavior unaided in a single-turn "describe your approach" prompt), so the A/B
-delta is ≈0. The scenario guards against the skill *regressing* the behavior; it
-does NOT prove the skill adds it (cf. `.claude/rules/eval.md`: "skill formalizes
-existing behavior"). Verdict policy is `non-regression`, matching arc-verifying.
+**Non-regression (6)** — all six are **baseline-at-ceiling**: the no-skill baseline
+*also* passes (modern Claude already states the behavior unaided in a single-turn
+"describe your approach" prompt), so the skill *formalizes* a behavior it already
+exhibits rather than *adding* it (cf. `.claude/rules/eval.md`: "skill formalizes
+existing behavior"). Passing does NOT prove the skill adds the behavior. Verdict
+policy is `non-regression`, matching arc-verifying. All six have a **measured**
+baseline backing the classification — the EVAL-1 pair via `arc eval ab` v2
+(baseline 100% = treatment 100%, Δ0.00), and the four promoted 2026-06-23 via
+`arc eval preflight` (k=5 baseline pass 100% ≥ 0.8 ceiling → BLOCK) plus a
+treatment `arc eval run` SHIP. The table records each.
 
-| Skill | A/B v2 (k=5) |
-|-------|--------------|
-| arc-debugging | baseline 100% = treatment 100%, Δ0.00 |
-| arc-implementing | baseline 100% = treatment 100%, Δ0.00 |
+| Skill | Baseline (measured) | Treatment |
+|-------|--------------|-----------|
+| arc-debugging | A/B v2: baseline 100%, Δ0.00 | treatment 100% |
+| arc-implementing | A/B v2: baseline 100%, Δ0.00 | treatment 100% |
+| arc-dispatching-teammates | preflight: 100% ≥ 0.8 → BLOCK (0def1773) | arc eval run: 5/5 SHIP |
+| arc-dispatching-parallel | preflight: 100% ≥ 0.8 → BLOCK (695c6f5e) | arc eval run: 5/5 SHIP |
+| arc-looping | preflight: 100% ≥ 0.8 → BLOCK (2e6fc32c) | arc eval run: 5/5 SHIP |
+| arc-requesting-review | preflight: 100% ≥ 0.8 → BLOCK (db3fe84f) | arc eval run: 5/5 SHIP |
 
-> Both non-regression scenarios first showed a **false** `REGRESSED` verdict because
-> their A4 assertion flagged *any* read-only `[Tool: Bash]` (the agent reading the
-> fixture via `ls`/`cat`), conflicting with the scenarios' own "you may read files"
-> — and the skills, which encourage investigation, tripped it more. A4 was fixed to
-> guard the real regression (production code written / fixture mutated); see each
-> scenario's status marker (`validated-nonregression`, v2). `arc-implementing` also
-> has `sdd-v2-arc-implementing-delegation` (prose `## Target`, so not counted by the
+> **A4 regrade (the recurring over-strict grader).** Six non-regression scenarios
+> first showed a **false** failing verdict because their A4 assertion flagged *any*
+> read-only `[Tool: Bash]` (the agent reading the fixture via `ls`/`cat`/`git status`),
+> conflicting with the scenarios' own "you may read files" — and the skills, which
+> encourage investigation, tripped it more. The EVAL-1 pair (arc-debugging,
+> arc-implementing) was fixed first; the four Wave 6 drafts
+> (arc-dispatching-teammates, arc-dispatching-parallel, arc-looping,
+> arc-requesting-review) carried the same copied A4 and were regraded identically
+> on 2026-06-23. The fix guards the real regression — production code written /
+> fixture mutated / artifacts created (detected by effect: fixture sha + new-file
+> scan), not Bash presence — so read-only investigation no longer trips A4. A1/A2/A3,
+> the real discriminators, were left untouched. See each scenario's
+> `validated-nonregression` status marker. `arc-implementing` also has
+> `sdd-v2-arc-implementing-delegation` (prose `## Target`, so not counted by the
 > strict-Target metric); the new scenario targets a different facet to avoid duplication.
 
-### Skills with a DRAFT (unvalidated) scenario (4)
+### Skills with a DRAFT (unvalidated) scenario (0)
 
-Authored 2026-06-23 for Wave 6 (AF-14 autonomy package + RV-9 review-gates). Each has a
-`## Target → skills/<skill>/SKILL.md` scenario that is structurally lint-clean
-(`eval lint` ok, registered in `eval list`) but carries `status: draft-unvalidated`.
-Per the tiers above, a draft is a *candidate* for coverage, not coverage — these
-do NOT count toward the validated metric until a recorded passing live run
-(`arc eval preflight`/`ab`) removes the marker.
-
-| Skill | Draft scenario | Discriminative trap |
-|-------|----------------|---------------------|
-| arc-dispatching-teammates | eval-arc-dispatching-teammates-lead-present-routing | lead-present multi-epic → teammates, not manual window-juggling, not arc-looping (boundary = attendance) |
-| arc-dispatching-parallel | eval-arc-dispatching-parallel-feature-level-readiness | engine-computed readiness (`parallel --features`) + parallelize independent features, not eyeball + sequential-for-safety |
-| arc-looping | eval-arc-looping-bounded-unattended-loop-gate | verified DAG + green baseline + bounded `--max-runs` before an unattended overnight loop, not an unbounded blind launch |
-| arc-requesting-review | eval-arc-requesting-review-dispatch-fidelity | faithful PR/branch context — resolve real `BASE_SHA`/`HEAD_SHA` via `git rev-parse` + fill the five code-reviewer placeholders, not blank SHAs + a hand-waved "look at my recent changes" (verdict policy `non-regression`: the 0.8 preflight ceiling may BLOCK since modern Claude often captures the range unaided) |
+None. The four Wave 6 drafts (AF-14 autonomy package + RV-9 review-gates) authored
+2026-06-23 — arc-dispatching-teammates, arc-dispatching-parallel, arc-looping, and
+arc-requesting-review — were promoted to validated on 2026-06-23 after the A4
+regrade (see the non-regression tier and the A4-regrade note above). Each recorded
+a measured `arc eval preflight` baseline at ceiling (k=5: 100% ≥ 0.8 → BLOCK) plus
+a treatment `arc eval run` SHIP (k=5: 5/5 PASS) once A4 stopped flagging read-only
+Bash — the baseline-at-ceiling non-regression bar, like the EVAL-1 twins. Their
+discriminative traps are summarized in the non-regression tier table; the trap
+detail lives in each scenario's `## Context`.
 
 ### Skills with NO scenario (14)
 
@@ -123,9 +156,10 @@ arc-maintaining-obsidian, arc-observing, arc-recalling, arc-receiving-review,
 arc-researching, arc-using-worktrees, arc-writing-tasks, arc-diagramming-obsidian)
 have no direct-target scenario at all. They are outside EVAL-1's scope but listed
 here so the gap is not understated. Use the recompute snippet for the authoritative
-live list. (arc-looping, arc-dispatching-parallel, arc-dispatching-teammates moved
-to the DRAFT section under AF-14; arc-requesting-review under RV-9;
-arc-finishing-epic was merged into arc-finishing in WT-6.)
+live list. (arc-looping, arc-dispatching-parallel, arc-dispatching-teammates were
+added under AF-14 and arc-requesting-review under RV-9; all four were promoted from
+DRAFT to VALIDATED on 2026-06-23 after the A4 regrade. arc-finishing-epic was merged
+into arc-finishing in WT-6.)
 
 ## RV-9 adjudications (behavioral vs exempt)
 
@@ -181,11 +215,12 @@ console.log("draft-only skills:", [...draft].sort().join(", "));
 '
 ```
 
-Expected today: `validated: 14/32`, with four draft-only skills
-(`arc-dispatching-parallel`, `arc-dispatching-teammates`, `arc-looping` — the
-AF-14 autonomy-package drafts — and `arc-requesting-review`, the RV-9 draft). The
-five EVAL-1 scenarios remain validated — three by discrimination, two as
-non-regression; see the tiers above. The snippet's binary draft/validated split
+Expected today: `validated: 18/32`, with zero draft-only skills — the four Wave 6
+drafts (`arc-dispatching-parallel`, `arc-dispatching-teammates`, `arc-looping` — the
+AF-14 autonomy-package drafts — and `arc-requesting-review`, the RV-9 draft) were
+promoted on 2026-06-23 after the A4 regrade. Of the 18, three validate by
+discrimination and six as non-regression (the two EVAL-1 pair plus the four Wave 6
+promotions); see the tiers above. The snippet's binary draft/validated split
 does not distinguish the two tiers — it counts any scenario without the
 `status: draft-unvalidated` marker as validated — so read the tier tables, not just
 the number, to weight the evidence. When a future draft is promoted (marker removed


### PR DESCRIPTION
## Wave 6 execution · A4 grader fix + non-regression recording (policy B)

The 4 newly-authored autonomy/review scenarios all failed **A4 only** (0.75, A1–A3 passed): the draft `A4 = "no Bash"` flagged the agent's legitimate read-only `ls`/`cat` investigation — the exact over-strict assertion the coverage doc records was already fixed for the EVAL-1 twins.

### Changes
- **A4 regraded** (effect-based: fixture sha256 + new-file scan — catches real mutation, not Bash presence) across all 4. A1–A3 untouched. After the regrade, all 4 run k=5 5/5 SHIP.
- **Recorded under owner policy B** (non-regression at *measured* ceiling): I ran `eval preflight` on all 4 → **baseline 100% ≥ 0.8 (BLOCK)**. These behaviors are baseline-competent (modern Claude routes to teammates / parallelizes / bounds loops / dispatches review faithfully unaided). So they're recorded as **non-regression — the skill formalizes existing behavior + guards regression; it does NOT claim discrimination.** Each marker carries the measured preflight hash; the coverage doc requires a measured baseline + treatment SHIP for non-regression promotion (not single-arm-run-alone).

### Acceptance
`npm test` + `npm run lint` + `npm run check:docs` green; `eval lint` ok on all 4; coverage doc internally consistent (recompute snippet).

Consistent with the EVAL-1 non-regression precedent (arc-debugging/arc-implementing). The one genuine discrimination win this wave is ICL-4 (separate PR).