### PR TITLE
fix(cli): ratify-pending morning queue reads canonical D-id field

### DIFF
--- a/scripts/lib/loop-state.js
+++ b/scripts/lib/loop-state.js
@@ -178,7 +178,7 @@ function scanProposedDecisions(projectRoot) {
     if (!Array.isArray(parsed)) continue;
     const decisionIds = parsed
       .filter((d) => d && d.status === 'proposed')
-      .map((d) => d.id)
+      .map((d) => d['D-id'])
       .filter(Boolean);
     if (decisionIds.length > 0) {
       result.count += decisionIds.length;

--- a/tests/scripts/loop-state.test.js
+++ b/tests/scripts/loop-state.test.js
@@ -186,9 +186,9 @@ describe('loop-state', () => {
       };
       mkLedger(
         'spec-a',
-        '- id: D-001\n  status: proposed\n  decision: x\n- id: D-002\n  status: proposed\n  decision: y\n',
+        '- D-id: D-001\n  status: proposed\n  decision: x\n- D-id: D-002\n  status: proposed\n  decision: y\n',
       );
-      mkLedger('spec-b', '- id: D-003\n  status: accepted\n  decision: z\n');
+      mkLedger('spec-b', '- D-id: D-003\n  status: accepted\n  decision: z\n');
 
       const state = loadLoopState(tmpDir);
       state.status = 'complete';
@@ -205,7 +205,7 @@ describe('loop-state', () => {
     it('does not double-queue ratify-pending across two finalize calls', () => {
       const dir = path.join(tmpDir, 'specs', 'spec-a');
       fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, 'decisions.yml'), '- id: D-001\n  status: proposed\n');
+      fs.writeFileSync(path.join(dir, 'decisions.yml'), '- D-id: D-001\n  status: proposed\n');
 
       finalizeLoop(loadLoopState(tmpDir), 50, tmpDir);
       finalizeLoop(loadLoopState(tmpDir), 50, tmpDir);
@@ -216,7 +216,7 @@ describe('loop-state', () => {
     it('does not queue ratify-pending when no decisions are proposed', () => {
       const dir = path.join(tmpDir, 'specs', 'spec-a');
       fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, 'decisions.yml'), '- id: D-001\n  status: accepted\n');
+      fs.writeFileSync(path.join(dir, 'decisions.yml'), '- D-id: D-001\n  status: accepted\n');
 
       finalizeLoop(loadLoopState(tmpDir), 50, tmpDir);
       expect(getActions(tmpDir, 'ratify-pending')).toHaveLength(0);


### PR DESCRIPTION
## North-star finding #1 (caught during the Wave 6 manual confirmation, pre-flight)

The SessionStart **morning review queue** has two halves: `loop-finished` (outcome summary) and `ratify-pending` (N decisions awaiting human ratification). The second half was **dead against real data**.

### Root cause
`scanProposedDecisions` (loop-state.js) mapped `d.id`, but the canonical decision-ledger field is **`D-id`** — used by the decision-ledger schema, `REQUIRED_LEDGER_FIELDS`, `validateDecisionLedger`, and `ratify-command.js` alike. Against a schema-valid `decisions.yml`, `d.id` is `undefined` for every entry → `count` stays 0 → `addPendingAction(..., 'ratify-pending', ...)` never fires.

Empirically: same canonical `decisions.yml`, old `d.id` → count 0; `d['D-id']` → count 1.

### Impact (the seam)
After an overnight `loop --pattern dag`, proposed decisions drafted during the run would **not** surface in the morning queue. The human would have to hand-scan every `specs/*/decisions.yml` to find them — "produce, not review", the exact north-star failure condition (plan line 485).

### Why tests didn't catch it
`tests/scripts/loop-state.test.js` fixtures used the same wrong `id:` field, so the test guarded the bug instead of real behavior (false-green).

### Fix (TDD)
- **RED**: corrected the four fixtures to canonical `D-id:` → the two `ratify-pending` assertions fail against the old `d.id` read.
- **GREEN**: `d.id` → `d['D-id']` → pass. `decision_ids` is now populated too, so the morning notification names the correct `ratify <spec-id> <D-id>` commands.
- Full suite **2260 passed**, lint clean. Sibling sweep found no other `.id` reads on decision entries.

https://claude.ai/code/session_01VbAii9JHZrk7qhHj2868Hn