### PR TITLE
docs: fix install-surface sibling drift (v4.0.0 release audit)

### DIFF
--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -42,7 +42,7 @@ Codex scans `~/.agents/skills/` for skill directories at startup. Each directory
 
 The symlink `~/.agents/skills/arcforge` points into the cloned repo's `skills/` directory, making all arcforge skills visible to Codex without copying files. The `description` field in each skill's SKILL.md frontmatter tells Codex when to auto-activate the skill (e.g., `"Use when exploring ideas before implementation"`).
 
-> **Note:** The `~/.agents/arcforge` clone is shared with Gemini CLI. If you already installed arcforge for Gemini, skip step 1 and reuse the existing clone.
+> **Note:** The `~/.agents/arcforge` clone is shared with Gemini CLI and OpenCode. If you already installed arcforge for either, skip step 1 and reuse the existing clone.
 
 ## Usage
 
@@ -103,7 +103,7 @@ unlink ~/.agents/skills/arcforge
 rm -rf ~/.agents/arcforge   # optional: remove the repo
 ```
 
-> **Note:** If Gemini CLI also uses this clone, removing `~/.agents/arcforge` will affect Gemini too.
+> **Note:** If Gemini CLI or OpenCode also use this clone, removing `~/.agents/arcforge` will affect them too.
 
 ## Windows
 

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -51,7 +51,7 @@ OpenCode uses two mechanisms to integrate arcforge:
 
 2. **Plugin** — The `arcforge.js` plugin uses OpenCode's `experimental.chat.system.transform` hook to inject agentic context (routing tables, skill metadata) into the system prompt at runtime. This enables features like automatic skill routing that go beyond basic skill discovery.
 
-> **Note:** Unlike Codex and Gemini (which share `~/.agents/skills/`), OpenCode requires its own skills symlink at `~/.config/opencode/skills/` plus the plugin symlink.
+> **Note:** OpenCode requires its own skills symlink at `~/.config/opencode/skills/` plus the plugin symlink. Each platform points its own distinct skills location at the shared `~/.agents/arcforge` clone (Codex: `~/.agents/skills/`, Gemini: `~/.gemini/skills/`).
 
 ## Tool Mapping
 


### PR DESCRIPTION
## What

The `arc-release-audit` run for v4.0.0 surfaced two factual errors in the platform install docs (arc-releasing step 2 — install-surface audit). Kept out of the release PR (#120) to preserve a pure squashed release commit; fixing here as the promised follow-up.

### Fixes
- **`docs/README.codex.md`** (lines 45, 106): the shared-clone notes mentioned only Gemini, omitting OpenCode — which also clones to `~/.agents/arcforge`. `docs/README.gemini.md` already used the correct "Codex or OpenCode" wording, so the Codex doc was the stale sibling never backfilled when OpenCode was added.
- **`docs/README.opencode.md`** (line 54): claimed "Codex and Gemini share `~/.agents/skills/`" — factually wrong. No two platforms share a skills directory (Codex: `~/.agents/skills/`, Gemini: `~/.gemini/skills/`, OpenCode: `~/.config/opencode/skills/`). The shared resource is the **clone** `~/.agents/arcforge`; each platform points its own distinct skills location at it.

Doc prose only — no install command changed.

### Test plan
- [x] `npm run check:docs` — no gating doc-reference violations
- [x] Two files changed; both verified against the sibling `README.gemini.md` wording

### Not included
The 1 remaining [nit] (OpenCode Quick Install format divergence) is deferred — it needs a judgment call on whether the inline-prompt form is intentional vs. the uniform "fetch and follow" pattern.

https://claude.ai/code/session_01VbAii9JHZrk7qhHj2868Hn