### PR TITLE
feat(skills): migrate arc-refining/arc-planning SDD recipes to sdd-gate CLI (SDD-6)

### DIFF
--- a/skills/arc-planning/SKILL.md
+++ b/skills/arc-planning/SKILL.md
@@ -42,34 +42,33 @@ Once you have the spec-id, all inputs come from `specs/<spec-id>/spec.xml` and t
 
 ## Phase 1 — Input Validation and Scope Extraction
 
-Validate the spec programmatically using sdd-utils, and extract the current sprint's scope from the latest `<delta>`:
+Validate the spec and read the current sprint's scope from the `header` gate's
+stable JSON. The gate parses `specs/<spec-id>/spec.xml` and emits both the
+validation result and the parsed header — the planner reads scope from that
+JSON, not from a separate inline parse:
 
 ```bash
-node -e "
-  const fs = require('fs');
-  const { parseSpecHeader, validateSpecHeader } = require('${ARCFORGE_ROOT}/scripts/lib/sdd-utils');
-  const xml = fs.readFileSync('specs/<spec-id>/spec.xml', 'utf-8');
-  const parsed = parseSpecHeader(xml);
-  const result = validateSpecHeader(parsed);
-  console.log(JSON.stringify(result, null, 2));
-  if (parsed && parsed.latest_delta) {
-    const d = parsed.latest_delta;
-    console.log('Sprint version:', d.version, 'iteration:', d.iteration);
-    console.log('Added (implement epics):', d.added.map(x => x.ref));
-    console.log('Modified (update epics):', d.modified.map(x => x.ref));
-    console.log('Removed (teardown epics):', d.removed.map(x => x.ref));
-    console.log('Renamed (mechanical refactor epics):', d.renamed.map(x => x.ref_old + '→' + x.ref_new));
-  } else if (parsed) {
-    console.log('No delta — v1 spec. Plan all requirements in detail files.');
-  }
-"
+node "${ARCFORGE_ROOT}/scripts/cli.js" sdd-gate header --spec-id <spec-id> \
+  --draft specs/<spec-id>/spec.xml
 ```
 
-- If `valid` is `false` and any issue has `level: 'ERROR'` — **BLOCK**. Remediation: "Run refiner to produce a spec first." Do not proceed.
-- If `valid` is `false` with only WARNINGs (e.g., broken `design_path`) — proceed but surface the warnings.
-- If `valid` is `true` — proceed.
+- If `status` is `"block"` (exit 1) — any issue has `level: "ERROR"` — **BLOCK**. Remediation: "Run refiner to produce a spec first." Do not proceed.
+- If `status` is `"pass"` (exit 0) with WARNING issues (e.g., broken `design_path`) — proceed but surface the warnings.
+- If `status` is `"pass"` (exit 0) with no issues — proceed.
 
-The scope-extraction snippet uses `parsed.latest_delta` (the highest-version delta — equivalent to the last child of `<overview>`). Earlier `<delta>` elements are historical record of prior sprints; the planner ignores them.
+Read sprint scope from `header.latest_delta`:
+
+| JSON field | Planner reads it as |
+|---|---|
+| `header.latest_delta.version` / `.iteration` | Current sprint identity |
+| `header.latest_delta.added[].ref` | Implement epics |
+| `header.latest_delta.modified[].ref` | Update epics |
+| `header.latest_delta.removed[].ref` | Teardown epics |
+| `header.latest_delta.renamed[]` (`ref_old` → `ref_new`) | Mechanical refactor epics |
+
+`header.latest_delta` is the highest-version delta (the last child of `<overview>`).
+When it is `null`, the spec is v1 — plan all requirements in the detail files.
+Earlier `<delta>` elements are historical record of prior sprints; the planner ignores them.
 
 ## Phase 2 — Determine Planning Scope
 

--- a/skills/arc-refining/SKILL.md
+++ b/skills/arc-refining/SKILL.md
@@ -54,21 +54,13 @@ Before producing a new spec version, verify that the prior sprint is complete. T
 **Prior spec exists → run the gate check:**
 
 ```bash
-node -e "
-  const { checkDagStatus } = require('${ARCFORGE_ROOT}/scripts/lib/sdd-utils');
-  const status = checkDagStatus('specs/<spec-id>/dag.yaml');
-  if (status === null) {
-    console.log('No dag.yaml — proceed (legal: refined but not yet planned).');
-  } else if (status.incomplete === 0) {
-    console.log('All', status.total, 'epics complete — proceed with new iteration.');
-  } else {
-    console.log('BLOCKED:', status.incomplete, 'of', status.total, 'epics still incomplete:');
-    for (const e of status.incompleteEpics) console.log('  -', e.id, '(' + e.status + ')');
-    console.log('Complete current sprint before iterating.');
-    process.exit(1);
-  }
-"
+node "${ARCFORGE_ROOT}/scripts/cli.js" sdd-gate dag --spec-id <spec-id>
 ```
+
+Reads the stable JSON: `status: "pass"` (exit 0) → proceed; `status: "block"`
+(exit 1) → the JSON's `dag.incompleteEpics` lists the unfinished epics and
+`message` is the user-facing block reason. `dag: null` means no `dag.yaml` (legal:
+refined but not yet planned).
 
 Three outcomes:
 
@@ -90,12 +82,7 @@ There is no `--force` flag, no `abandoned` epic status, no environment-variable 
 Validate the design doc programmatically:
 
 ```bash
-node -e "
-  const { parseDesignDoc, validateDesignDoc } = require('${ARCFORGE_ROOT}/scripts/lib/sdd-utils');
-  const parsed = parseDesignDoc('docs/plans/<spec-id>/<date>/design.md');
-  const result = validateDesignDoc(parsed);
-  console.log(JSON.stringify(result, null, 2));
-"
+node "${ARCFORGE_ROOT}/scripts/cli.js" sdd-gate design --design docs/plans/<spec-id>/<date>/design.md
 ```
 
 - If `valid` is `false` and any issue has `level: 'ERROR'` — **BLOCK**. Print the issues to terminal, exit non-zero, write no files. Do not write any report file.
@@ -112,58 +99,16 @@ If `specs/<spec-id>/vision.md` exists, read it as context — it describes the p
 
 Both files are read-only inputs to the refiner. Do NOT write to `vision.md`. Do NOT edit existing ledger entries; the B2 immutability hook will deny any such write.
 
-### 2.5b — Validate Vision and Ledger (node -e gate)
+### 2.5b — Validate Vision and Ledger (sdd-gate context)
 
 ```bash
-node -e "
-  const { parseVision, validateVision, parseDecisionLedger, validateDecisionLedger,
-          getHeadLedgerContent, parseDecisionLedgerContent,
-          checkSpecDecisionGraph } = require('${ARCFORGE_ROOT}/scripts/lib/sdd-utils');
-  const fs = require('fs');
-
-  // Vision gate — no-op when spec vision absent.
-  const productVisionPath = 'product/vision.md';
-  const specVisionPath = 'specs/<spec-id>/vision.md';
-  const productParsed = fs.existsSync(productVisionPath) ? parseVision(productVisionPath) : null;
-  const specParsed = fs.existsSync(specVisionPath) ? parseVision(specVisionPath) : null;
-  const visionResult = validateVision(productParsed, specParsed);
-  if (!visionResult.valid) {
-    console.log(JSON.stringify(visionResult, null, 2));
-    process.exit(1);
-  }
-
-  // Ledger gate — no-op when absent.
-  const ledgerPath = 'specs/<spec-id>/decisions.yml';
-  const current = parseDecisionLedger(ledgerPath);
-  if (current !== null) {
-    const headContent = getHeadLedgerContent(ledgerPath, process.cwd());
-    const previous = parseDecisionLedgerContent(headContent);
-    const result = validateDecisionLedger(current, previous);
-    if (!result.valid) {
-      console.log(JSON.stringify(result, null, 2));
-      process.exit(1);
-    }
-  }
-
-  // Graph gate — spec↔decision↔anchor consistency (D6 P2, S10). No-op when absent.
-  const specXmlPath = 'specs/<spec-id>/spec.xml';
-  const specXmlContent = fs.existsSync(specXmlPath) ? fs.readFileSync(specXmlPath, 'utf8') : null;
-  const graphResult = checkSpecDecisionGraph({
-    specXmlContent,
-    ledger: current,
-    productVision: productParsed,
-    specVision: specParsed,
-  });
-  if (!graphResult.valid) {
-    console.log(JSON.stringify(graphResult, null, 2));
-    process.exit(1);
-  }
-
-  console.log('vision+ledger+graph gate: OK');
-"
+node "${ARCFORGE_ROOT}/scripts/cli.js" sdd-gate context --spec-id <spec-id>
 ```
 
-No-op rule: when `specs/<spec-id>/decisions.yml`, `specs/<spec-id>/vision.md`, and `specs/<spec-id>/spec.xml` are absent, the gate MUST PASS. Only present files are validated. This gate does not write any files. On ERROR: **BLOCK** — print issues to terminal, exit non-zero, write no files (per fr-rf-015-ac2: non-R3 block, terminal output only).
+The gate chains three sub-checks in order — vision, ledger (append-only against
+HEAD), then spec↔decision↔anchor graph. `status: "pass"` (exit 0) → proceed;
+`status: "block"` (exit 1) names the failing sub-gate in `gate` and lists the
+errors. No-op rule: when `specs/<spec-id>/decisions.yml`, `specs/<spec-id>/vision.md`, and `specs/<spec-id>/spec.xml` are absent, the gate MUST PASS. Only present files are validated. This gate does not write any files. On ERROR: **BLOCK** — print issues to terminal, exit non-zero, write no files (per fr-rf-015-ac2: non-R3 block, terminal output only).
 
 ## Phase 3 — Detect Behavior Context
 
@@ -211,24 +156,29 @@ The refiner has no authorization to pick. Authoring `windowMs: 60000` (or any re
    - Axis 2: `(a) keep design wording, edit Q&A row; (b) accept Q&A answer, edit design; (c) make the axis configurable so both stances coexist`.
    - Axis 3: `(a) downgrade the criterion to SHOULD/MAY citing design's qualitative phrase; (b) leave the axis unbound; (c) ask user to specify a concrete value in a new design iteration`.
 
-**Before exiting non-zero, MUST write the conflict handoff file (fr-rf-015-ac1):**
+**Before exiting non-zero, MUST write the conflict handoff file (fr-rf-015-ac1)** by piping the conflict payload as JSON to the `conflict` gate stage. The heredoc keeps the payload off disk until the CLI writes the canonical file:
 
 ```bash
-node -e "
-  const { writeConflictMarker } = require('${ARCFORGE_ROOT}/scripts/lib/sdd-utils');
-  writeConflictMarker('<spec-id>', {
-    axis_fired: '<1|2|3>',
-    conflict_description: '<specific design line ranges and Q&A row q_ids involved>',
-    candidate_resolutions: [
-      '(a) <first candidate>',
-      '(b) <second candidate>'
-    ],
-    user_action_prompt: 'Run /arc-brainstorming iterate <spec-id> to resolve this conflict.'
-  });
-"
+node "${ARCFORGE_ROOT}/scripts/cli.js" sdd-gate conflict --spec-id <spec-id> <<'JSON'
+{
+  "axis_fired": "<1|2|3>",
+  "conflict_description": "<specific design line ranges and Q&A row q_ids involved>",
+  "candidate_resolutions": [
+    "(a) <first candidate>",
+    "(b) <second candidate>"
+  ],
+  "user_action_prompt": "Run /arc-brainstorming iterate <spec-id> to resolve this conflict."
+}
+JSON
 ```
 
-The schema source of truth is `PENDING_CONFLICT_RULES` (from `${ARCFORGE_ROOT}/scripts/lib/sdd-utils`). The file is written at `specs/<spec-id>/_pending-conflict.md`. It is **ephemeral** — brainstorming Phase 0 reads it as Change Intent seed (fr-bs-008), then deletes it on successful new-design write. Refiner does NOT clean it up.
+**Required payload fields (per `PENDING_CONFLICT_RULES`) — all four are mandatory; a missing or empty field exits non-zero. Reproduce these keys exactly (no synonyms):**
+- `axis_fired` — the string `"1"`, `"2"`, or `"3"` (the axis that fired). Axis-3 blocks (invention, Phase 5.5a self-contradiction, Phase 5.5b unauthorized criterion) use `"3"`.
+- `conflict_description` — the specific design line ranges and Q&A `q_id`s in conflict.
+- `candidate_resolutions` — a list of **1–3** concrete, user-pickable resolutions (never zero, never more than three).
+- `user_action_prompt` — the recovery route, always `Run /arc-brainstorming iterate <spec-id> to resolve this conflict.`
+
+The schema source of truth is `PENDING_CONFLICT_RULES` (from `${ARCFORGE_ROOT}/scripts/lib/sdd-utils`). The file is written at `specs/<spec-id>/_pending-conflict.md` (the path is echoed back as `conflict_marker` in the gate JSON). It is **ephemeral** — brainstorming Phase 0 reads it as Change Intent seed (fr-bs-008), then deletes it on successful new-design write. Refiner does NOT clean it up. A malformed payload (missing required field, zero resolutions) exits non-zero with a descriptive error and writes nothing.
 
 **MUST NOT write `_pending-conflict.md` for non-R3-axis blocks (fr-rf-015-ac2):**
 - DAG completion gate failure (fr-rf-012) → terminal output only, exit non-zero, no file written.
@@ -346,7 +296,7 @@ Before Phase 6 output validation, re-read each requirement's `<description>` aga
 
 If any requirement fails this sub-pass — **BLOCK (R3 enforcement severity).** Print to terminal: requirement ID, the specific scope or verb mismatch, and the relevant remediation hint above. Exit non-zero. Write no authoritative files — no `spec.xml`, no `details/`. **Phase 5.5 findings MUST NOT be downgraded to WARNING** — a WARN would let the spec ship with internal contradictions.
 
-**Before exiting non-zero, MUST write the conflict handoff file (fr-rf-014-ac5):** call `writeConflictMarker` (recipe above in Phase 4) with these values:
+**Before exiting non-zero, MUST write the conflict handoff file (fr-rf-014-ac5):** run the `sdd-gate conflict` recipe from Phase 4 (the `<<'JSON'` heredoc), supplying these payload values:
 - `axis_fired: '3'`
 - `conflict_description`: `'<requirement ID>: <specific scope or verb mismatch> — <remediation hint from ac1/ac2>'` (ac1: widen/narrow scope; ac2: align verbs)
 - `candidate_resolutions`: 1–3 concrete user-pickable resolutions
@@ -360,7 +310,7 @@ Re-read each criterion in the in-memory draft and verify it traces to a (design 
 
 If any criterion has no traceable source — **BLOCK (write conflict file, per fr-rf-015-ac1, R3 enforcement severity).** Phase 5.5 findings MUST NOT be downgraded to WARNING. Before exiting non-zero:
 
-1. Call `writeConflictMarker` (same pattern as Phase 4 block shown above), setting `axis_fired: '3'`.
+1. Run the `sdd-gate conflict` recipe from Phase 4 (same `<<'JSON'` heredoc shown above), setting `axis_fired: '3'` in the payload.
 2. Print to terminal: which criterion has no source, and the 1–3 candidate resolutions.
 3. Exit non-zero. Write no authoritative files — no `spec.xml`, no `details/`.
 
@@ -368,18 +318,20 @@ This sub-pass is independent of Phase 4's three axes. Phase 4 catches conflicts 
 
 ## Phase 6 — Output Validation (Two-Pass Write, continued)
 
-Before writing any file to disk, validate the in-memory spec:
+Before writing any file to disk, validate the in-memory spec. Pipe the in-memory
+draft `spec.xml` to the `header` gate stage over stdin (heredoc) — the draft never
+touches disk, preserving zero-filesystem-state-on-block:
 
 ```bash
-node -e "
-  const fs = require('fs');
-  const { parseSpecHeader, validateSpecHeader } = require('${ARCFORGE_ROOT}/scripts/lib/sdd-utils');
-  const xml = fs.readFileSync('_draft_spec.xml', 'utf-8');
-  const parsed = parseSpecHeader(xml);
-  const result = validateSpecHeader(parsed);
-  console.log(JSON.stringify(result, null, 2));
-"
+node "${ARCFORGE_ROOT}/scripts/cli.js" sdd-gate header --spec-id <spec-id> <<'SPECXML'
+<the in-memory spec.xml content>
+SPECXML
 ```
+
+The `header` stage reads only the `<overview>` block, so the single `spec.xml`
+suffices — the in-memory `details/*.xml` are not inputs to this gate. `status:
+"pass"` (exit 0) → continue to 6b; `status: "block"` (exit 1) → the `issues`
+array carries the ERROR findings.
 
 Phase 6 runs two checks:
 
@@ -392,35 +344,30 @@ Phase 6 runs two checks:
 
 **6b — Axis-3 mechanical authorization check (R3-axis block, writes conflict file):**
 
+Pipe the **combined in-memory draft** to the `authorize` gate stage. The
+mechanical check reads `<requirement>/<criterion>/<trace>` elements — and those
+live in the `details/*.xml` content, NOT in the `<overview>` of `spec.xml`. So
+the input here is the full in-memory draft you built in Phase 5 (the overview
+plus every requirement and every `<trace>`), as a single concatenated XML stream
+— before the two-pass write splits it into `spec.xml` + `details/`. On a failed
+check the CLI deterministically writes `specs/<spec-id>/_pending-conflict.md`
+with `axis_fired: '3'` and the unauthorized-trace summary — the agent does NOT
+hand-build the marker for this stage:
+
 ```bash
-node -e "
-  const fs = require('fs');
-  const { mechanicalAuthorizationCheck, writeConflictMarker, parseDecisionLedger } = require('${ARCFORGE_ROOT}/scripts/lib/sdd-utils');
-  const result = mechanicalAuthorizationCheck(
-    fs.readFileSync('_draft_spec.xml', 'utf-8'),
-    'docs/plans/<spec-id>/<date>/design.md',
-    'docs/plans/<spec-id>/<date>/decision-log.yml',
-    parseDecisionLedger('specs/<spec-id>/decisions.yml')
-  );
-  if (!result.valid) {
-    console.log(JSON.stringify(result.unauthorized_traces, null, 2));
-    writeConflictMarker('<spec-id>', {
-      axis_fired: '3',
-      conflict_description: 'Mechanical authorization check failed: ' +
-        result.unauthorized_traces.map(t => t.trace_value + ' (' + t.reason + ')').join('; '),
-      candidate_resolutions: [
-        '(a) Add authorizing source to design.md for the flagged criterion.',
-        '(b) Downgrade the criterion to SHOULD/MAY citing design qualitative phrase.',
-        '(c) Remove the criterion — the axis is unbound without an authorizing source.'
-      ],
-      user_action_prompt: 'Run /arc-brainstorming iterate <spec-id> to resolve this conflict.'
-    });
-    process.exit(1);
-  }
-"
+node "${ARCFORGE_ROOT}/scripts/cli.js" sdd-gate authorize --spec-id <spec-id> \
+  --design docs/plans/<spec-id>/<date>/design.md \
+  --decision-log docs/plans/<spec-id>/<date>/decision-log.yml <<'DRAFT'
+<the combined in-memory draft: overview + all requirements + all traces>
+DRAFT
 ```
 
-If `mechanicalAuthorizationCheck` returns `valid: false` — **BLOCK (write conflict file, per fr-rf-015-ac1)**. Call `writeConflictMarker` with `axis_fired: '3'`, then exit non-zero. Write no authoritative files.
+The stage loads the ledger from `specs/<spec-id>/decisions.yml` automatically.
+`status: "pass"` (exit 0) → both checks passed. `status: "block"` (exit 1) →
+`unauthorized_traces` lists the flagged criteria and `conflict_marker` echoes the
+path of the written file.
+
+If the `authorize` stage returns `status: "block"` — **BLOCK (conflict file written by the CLI, per fr-rf-015-ac1)**, exit non-zero. Write no authoritative files (no `spec.xml`, no `details/`) — only the `_pending-conflict.md` the CLI produced.
 
 **If both checks pass:** write all files atomically: `spec.xml` and all `details/*.xml` in a single operation. Partial writes (spec.xml written but details/ incomplete) MUST NOT occur.
 

--- a/tests/skills/test_skill_arc_planning.py
+++ b/tests/skills/test_skill_arc_planning.py
@@ -68,17 +68,19 @@ def test_arc_planning_contains_required_sections():
 
 
 def test_arc_planning_input_validation_sdd_utils():
-    """Skill must invoke sdd-utils validateSpecHeader before decomposition (fr-pl-005, fr-cc-if-005-ac4)."""
+    """Skill must invoke the sdd-gate header stage to validate the spec header and
+    extract delta scope before decomposition (fr-pl-005, fr-cc-if-005-ac4).
+    SDD-6: migrated from direct sdd-utils validateSpecHeader/parseSpecHeader calls."""
     text = _read_skill()
 
-    # Must mention validateSpecHeader for input validation
-    assert "validateSpecHeader" in text
+    # Must invoke the header gate stage for input validation (runs validateSpecHeader behind it)
+    assert "sdd-gate header" in text
 
-    # Must mention parseSpecHeader to extract delta scope
-    assert "parseSpecHeader" in text
+    # Must read the delta scope from the header stage's latest_delta output
+    assert "latest_delta" in text or "parsed.deltas" in text
 
-    # Must mention sdd-utils or scripts/lib/sdd-utils
-    assert "sdd-utils" in text
+    # Must delegate validation to the sdd-gate CLI (replaces direct sdd-utils calls)
+    assert "sdd-gate" in text
 
 
 def test_arc_planning_sprint_model():

--- a/tests/skills/test_skill_arc_refining.py
+++ b/tests/skills/test_skill_arc_refining.py
@@ -72,8 +72,8 @@ def test_arc_refining_sdd_utils_input_validation():
     # Must mention parseDesignDoc and/or sdd-utils for input validation
     assert "parseDesignDoc" in text or "sdd-utils" in text
 
-    # Must mention validateDesignDoc for input validation
-    assert "validateDesignDoc" in text
+    # Must invoke the design-validation gate stage for input validation (SDD-6: was validateDesignDoc)
+    assert "sdd-gate design" in text
 
 
 def test_arc_refining_sdd_utils_output_validation():
@@ -396,9 +396,9 @@ def test_fr_rf_015_ac1_r3_block_paths_invoke_write_conflict_marker():
     """
     text = _read_skill()
 
-    # Must mention writeConflictMarker (the writer function name)
-    assert "writeConflictMarker" in text, (
-        "fr-rf-015-ac1: SKILL.md must direct refiner to call writeConflictMarker on R3 axis block"
+    # Must invoke the conflict gate stage (the conflict-marker writer; SDD-6: was writeConflictMarker)
+    assert "sdd-gate conflict" in text, (
+        "fr-rf-015-ac1: SKILL.md must direct refiner to run sdd-gate conflict on R3 axis block"
     )
 
     # Phase 4 (axis 1/2 block) must invoke the writer
@@ -407,8 +407,8 @@ def test_fr_rf_015_ac1_r3_block_paths_invoke_write_conflict_marker():
     assert phase4_start != -1, "Phase 4 heading must exist"
     assert phase5_start != -1, "Phase 5 heading must exist"
     phase4_section = text[phase4_start:phase5_start]
-    assert "writeConflictMarker" in phase4_section, (
-        "fr-rf-015-ac1: Phase 4 BLOCK path must invoke writeConflictMarker (axis 1/2)"
+    assert "sdd-gate conflict" in phase4_section, (
+        "fr-rf-015-ac1: Phase 4 BLOCK path must invoke sdd-gate conflict (axis 1/2)"
     )
 
     # Phase 5.5 or Phase 6 must invoke the writer for axis-3 blocks
@@ -417,8 +417,8 @@ def test_fr_rf_015_ac1_r3_block_paths_invoke_write_conflict_marker():
     assert phase55_start != -1, "Phase 5.5 heading must exist"
     assert phase6_start != -1, "Phase 6 heading must exist"
     post_draft_section = text[phase55_start:]
-    assert "writeConflictMarker" in post_draft_section, (
-        "fr-rf-015-ac1: Phase 5.5 or Phase 6 axis-3 BLOCK path must invoke writeConflictMarker"
+    assert "sdd-gate conflict" in post_draft_section, (
+        "fr-rf-015-ac1: Phase 5.5 or Phase 6 axis-3 BLOCK path must invoke sdd-gate conflict"
     )
 
 
@@ -732,8 +732,8 @@ def test_fr_rf_010_ac5_mechanical_auth_check_trace_types():
     if next_section != -1:
         phase6_section = phase6_section[:next_section]
 
-    assert "mechanicalAuthorizationCheck" in phase6_section, (
-        "fr-rf-010-ac5: Phase 6 must invoke mechanicalAuthorizationCheck"
+    assert "sdd-gate authorize" in phase6_section, (
+        "fr-rf-010-ac5: Phase 6 must invoke sdd-gate authorize (mechanical auth check runs behind the gate)"
     )
 
     # Must distinguish design line-range traces
@@ -962,9 +962,9 @@ def test_fr_rf_014_ac5_phase55a_writes_conflict_marker():
     text = _read_skill()
     section_a = _get_phase55a_section(text)
 
-    # Phase 5.5a MUST invoke writeConflictMarker
-    assert "writeConflictMarker" in section_a, (
-        "fr-rf-014-ac5: Phase 5.5a must invoke writeConflictMarker "
+    # Phase 5.5a MUST route to the conflict gate stage
+    assert "sdd-gate conflict" in section_a, (
+        "fr-rf-014-ac5: Phase 5.5a must invoke sdd-gate conflict "
         "(audit-patched: self-contradiction is NOT exempt from the handoff)"
     )
 
@@ -1001,9 +1001,9 @@ def test_fr_rf_014_ac5_phase55b_writes_conflict_marker():
     text = _read_skill()
     section_b = _get_phase55b_section(text)
 
-    # Phase 5.5b MUST invoke writeConflictMarker
-    assert "writeConflictMarker" in section_b, (
-        "fr-rf-014-ac5: Phase 5.5b must invoke writeConflictMarker for axis-3 LLM findings"
+    # Phase 5.5b MUST route to the conflict gate stage
+    assert "sdd-gate conflict" in section_b, (
+        "fr-rf-014-ac5: Phase 5.5b must invoke sdd-gate conflict for axis-3 LLM findings"
     )
 
     # axis_fired must be '3' for 5.5b


### PR DESCRIPTION
## Summary

Completes the SDD-6 skill migration that v4.0.0 shipped only half of: the `sdd-gate <stage>` engine landed (#87) but **zero skill consumers** were wired. `arc-refining` (7 inline `node -e` recipes) and `arc-planning` (1) now invoke the deterministic `sdd-gate` CLI stages.

Salvages the stranded WIP commit `3b6931f` (== branch `feat/sdd-6-skill`) via cherry-pick — 2 skill files only; its engine-only parent `7aa7dd5` was superseded by #87 — then reconciles the Phase 5.5a/5.5b cross-references, documents the exact pending-conflict field contract inline, and retargets the pytest skill contracts to the `sdd-gate` surface.

**Load-bearing, not cosmetic:** the old 2-arg `writeConflictMarker` recipe throws (`sdd-validators.js` requires a 3rd `projectRoot` arg); `sdd-gate conflict` supplies it. Verified end-to-end: `sdd-gate conflict` (cwd=temp, no `CLAUDE_PROJECT_DIR`) → exit 0, writes a valid 4-field `_pending-conflict.md`.

## Iron Law (TDD-for-docs)

- **RED:** inline `node -e` recipes throw at runtime; pytest pinned retired function names (`writeConflictMarker`, `validateSpecHeader`, `validateDesignDoc`, `mechanicalAuthorizationCheck`) — 6 skill tests fail by design between the migration and the retarget.
- **GREEN:** skills consume `sdd-gate` stages (design / header / conflict / authorize); pytest retargeted to the gate surface (each assertion still names its `fr-*` AC and asserts a string genuinely present in the migrated skill); the R3 contract is documented inline. 65/65 skill tests pass; full suite (5 runners) green; lint clean.
- **REFACTOR:** single conflict-write surface — every R3 block phase (4, 5.5a, 5.5b, 6b) routes through one `sdd-gate` stage; no phase calls `writeConflictMarker` directly.

## Verification

Adversarially verified by an independent fan-out (6 refuters, all `refuted: false`): `node -e` == 0 in both skills; assert counts equal main↔HEAD (138/138, 45/45) — no assertion weakened or deleted; the 4 context-stage validators received zero test edits; diff confined to exactly 4 files (2 SKILL.md + 2 pytest).

## Reviewer sign-off needed

**M3 spec-contract judgment:** please confirm that asserting on the `sdd-gate` surface faithfully guards each `fr-rf-*` / `fr-pl-*` AC (the retarget was made by the implementer; the same validators run behind the gate).

## Follow-ups

- Behavioral R3 eval (separate PR) — the firm ship-gate; must run GREEN against this PR once merged.
- v4.0.1 release preconditions tracked in #122 (held).

https://claude.ai/code/session_01VbAii9JHZrk7qhHj2868Hn
