### PR TITLE
chore(cli): cli-consumers linter (warn) + unmerged-branch sweep guard

### DIFF
--- a/.claude/skills/arc-releasing/SKILL.md
+++ b/.claude/skills/arc-releasing/SKILL.md
@@ -17,6 +17,7 @@ Never start the release workflow on a broken branch.
 2. `npm test` — all 4 runners green
 3. `git status` clean of unrelated work-in-progress. Untracked lock files or editor droppings that belong in `.gitignore` must be addressed separately, never folded into the release commit
 4. `git log main..HEAD --oneline` — verify the commits listed match the intended release scope
+5. `node scripts/check-unmerged-branches.js` — every local branch with commits off `main` must be dispositioned: a MERGED PR, an OPEN PR, or already landed on `origin/main`. A branch reported `NO-PR` is unmerged work about to miss this release — land it (open + merge a PR) or delete it, then re-run. The script catches squash-merged branches that `git branch --no-merged main` cannot see. Releaser-only; it cannot be a CI gate (a fresh runner has no local branches), and it degrades to list-only if `gh` is absent.
 
 If any pre-flight fails, stop and tell the user. A broken release is worse than a delayed one, because it ships to users through the marketplace cache and is painful to recall.
 

--- a/.claude/workflows/arc-release-audit.js
+++ b/.claude/workflows/arc-release-audit.js
@@ -127,7 +127,8 @@ Run these READ-ONLY checks from the repo root and report structured results. Do 
 2. Eval surface: \`git diff --name-only ${prevTag} HEAD | grep -E '^(skills/|evals/scenarios/|evals/fixtures/)'\` — evalSurfaceChanged = true if any output.
 3. Benchmark freshness: \`node scripts/check-benchmark-freshness.js\` — benchmarkFresh = (exit code 0). Include its stdout in the matching check detail.
 4. Version sync: \`npm run check:versions\` — versionSynced = (exit code 0). Capture the location→version table into the check detail.
-5. currentVersion: the top-level "version" in package.json.
+5. CLI consumers: \`npm run check:cli-consumers\` — read-only. Capture its stdout into the check detail. The linter is warn-mode today (always exits 0): record status 'warn' if it lists any zero-consumer command, else 'pass'. Do NOT treat a nonzero list as a hard fail while warn-mode is in effect.
+6. currentVersion: the top-level "version" in package.json.
 
 Return JSON per schema. 'checks' must contain one row per check above (name, status pass/fail/warn, detail).`,
   { schema: SETUP_SCHEMA, label: 'preflight-gates', phase: 'Preflight' },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - run: pip install pytest pyyaml
       - run: npm run check:versions
       - run: npm run check:docs
+      - run: npm run check:cli-consumers
       - run: npm run test:scripts
       - run: npm run test:hooks
       - run: npm run test:node

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:reflect": "node skills/arc-reflecting/scripts/reflect.js",
     "check:versions": "node scripts/check-version-sync.js",
     "check:docs": "node scripts/check-doc-refs.js",
+    "check:cli-consumers": "node scripts/check-cli-consumers.js",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/scripts/check-cli-consumers.js
+++ b/scripts/check-cli-consumers.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+/**
+ * check-cli-consumers.js — flag shipped CLI commands that no shipped doc,
+ * skill, template, or agent references (the "stranded CLI" defect class).
+ *
+ * v4.0.0 shipped the `sdd-gate` command with ZERO consumers: the engine
+ * landed (#87) but the skills that were meant to call it kept running their
+ * old inline recipes. A CLI surface nobody invokes is dead weight at best and,
+ * as with sdd-gate, a sign that a planned migration never completed. This guard
+ * enumerates every command in the frozen CLI manifest and confirms each is
+ * named somewhere in the shipped prose surface.
+ *
+ * Source of truth: scripts/lib/cli-manifest.js `CLI_MANIFEST`. That file is
+ * bidirectionally contract-tested against the live `cli.js` switch, so it can
+ * never silently drift from the real command set — unlike scraping help.js.
+ *
+ * WARN MODE (current). `GATING` is false: the linter prints any zero-consumer
+ * command but ALWAYS exits 0. This is deliberate — at v4.0.0 `sdd-gate` has no
+ * consumers, so gating now would redden unrelated PRs. The SDD-6 migration
+ * (release v4.0.1) wires sdd-gate's consumers; once it lands, flip `GATING` to
+ * true so the check fails on any future stranded command. This mirrors the
+ * repo's doc-reference linter, which shipped warn-first then flipped to gating.
+ *
+ * LIMITATION — common-English-word command names. The match is a lenient
+ * word-boundary presence test (zero vs nonzero), so a command whose name is an
+ * ordinary word (`status`, `next`, `block`, `merge`, `sync`, `parallel`,
+ * `complete`, `reboot`) will almost always match incidental prose and read as
+ * "consumed" even if its CLI form is never referenced. This guard therefore
+ * reliably catches only DISTINCTIVE names (sdd-gate, worktree, obsidian,
+ * ratify, schema, expand, cleanup). False negatives on common-word commands
+ * are accepted; the alternative (context-aware parsing) is out of scope for a
+ * presence linter. The allowlist below absorbs any documented intentional gap.
+ *
+ * CLI tier: prints a human-readable report and exits 0 (warn) / 1 (gating).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { CLI_MANIFEST } = require('./lib/cli-manifest');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// Shipped prose surfaces a CLI command should be referenced from. Markdown
+// only — code files invoke commands via the engine, not by name in prose.
+const SCAN_DIRS = ['skills', 'docs/guide', 'templates', 'agents'];
+
+// Commands intentionally exempt from the zero-consumer check. Mirrors the
+// `doc-ref-lint: ignore` precedent. Shipped EMPTY — add an entry only with a
+// documented reason (a command that legitimately has no prose consumer).
+const ALLOWLIST = new Set([]);
+
+// Flip to true once v4.0.1 wires sdd-gate's consumers (see header). Until then,
+// the linter reports but never fails.
+const GATING = false;
+
+/** Recursively collect *.md files under a directory (skips node_modules + dotdirs). */
+function collectMarkdown(dir, acc) {
+  if (!fs.existsSync(dir)) return acc;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectMarkdown(full, acc);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Enumerate every invocable command label: each top-level command, plus each
+ * `parent sub` join for commands that declare subcommands (e.g. `worktree add`).
+ */
+function enumerateCommands() {
+  const labels = [];
+  for (const [name, def] of Object.entries(CLI_MANIFEST)) {
+    labels.push(name);
+    if (def?.subcommands) {
+      for (const sub of Object.keys(def.subcommands)) {
+        labels.push(`${name} ${sub}`);
+      }
+    }
+  }
+  return labels;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function main() {
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    collectMarkdown(path.join(repoRoot, dir), files);
+  }
+  const corpus = files.map((f) => fs.readFileSync(f, 'utf8')).join('\n');
+
+  const commands = enumerateCommands();
+  const stranded = [];
+  for (const cmd of commands) {
+    if (ALLOWLIST.has(cmd)) continue;
+    const re = new RegExp(`\\b${escapeRegExp(cmd)}\\b`);
+    if (!re.test(corpus)) stranded.push(cmd);
+  }
+
+  console.log(
+    `cli-consumer linter — ${commands.length} CLI commands vs ${files.length} shipped docs\n`,
+  );
+
+  if (stranded.length === 0) {
+    console.log('Every CLI command has at least one documented consumer.');
+    process.exit(0);
+  }
+
+  const log = GATING ? console.error : console.warn;
+  const prefix = GATING ? '' : '[warn] ';
+  log(`${prefix}Shipped CLI commands with ZERO consumers (${stranded.length}):`);
+  for (const cmd of stranded) {
+    log(`  - ${cmd}  (no word-boundary match in ${SCAN_DIRS.join(', ')})`);
+  }
+  if (!GATING) {
+    log('\nWarn-only until v4.0.1 wires sdd-gate; flip GATING to true after it lands.');
+  }
+  process.exit(GATING ? 1 : 0);
+}
+
+main();

--- a/scripts/check-unmerged-branches.js
+++ b/scripts/check-unmerged-branches.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+/**
+ * check-unmerged-branches.js — fail fast on undisposed local branches.
+ *
+ * Before cutting a release, every local branch that still carries commits not
+ * on `main` should be accounted for: either its work already landed (the PR is
+ * MERGED, or the commits are reachable from `origin/main`), or it has an OPEN PR
+ * tracking that work. A branch with commits and no disposition is a loose end —
+ * unmerged work the releaser has forgotten about, or a stale branch that should
+ * be deleted. This guard surfaces those before they silently miss the release.
+ *
+ * Classification per branch:
+ *   MERGED-PR — a PR for this branch has state MERGED (catches squash merges,
+ *               where the branch commits are NOT ancestors of main and so are
+ *               invisible to `git branch --no-merged`).
+ *   OPEN-PR   — no merged PR, but an OPEN PR tracks the branch (dispositioned).
+ *   LANDED    — no merged/open PR, but the branch tip is reachable from
+ *               origin/main (a real or fast-forward merge landed it remotely).
+ *   NO-PR     — commits exist, nothing above applies. Release blocker: the
+ *               branch must be landed or deleted before release.
+ *
+ * Exits 0 when every branch is dispositioned (MERGED-PR / OPEN-PR / LANDED).
+ * Exits 1 when any NO-PR branch with commits exists.
+ *
+ * Degraded mode: if `gh` is absent, the script cannot read PR state, so it
+ * cannot distinguish a squash-merged branch from an abandoned one. It prints
+ * the unmerged branch list as a warning and exits 0 (list-only) rather than
+ * blocking the release on information it cannot obtain.
+ *
+ * NOT A CI GATE. A fresh CI runner checks out a single ref, so
+ * `git branch --no-merged main` sees no local branches and this check is
+ * vacuously green — it would never catch anything. This guard is meaningful
+ * ONLY in a releaser's working clone, which carries the accumulated local
+ * branches. Invoke it manually as a release pre-flight step; do not wire it
+ * into `npm test` or any CI workflow.
+ */
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+/**
+ * Run a command with array args (never shell string interpolation, per
+ * .claude/rules/security.md). Returns trimmed stdout, or null on nonzero exit.
+ */
+function run(cmd, args) {
+  try {
+    return execFileSync(cmd, args, { cwd: repoRoot, encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** True if `gh` is installed and runnable. */
+function hasGh() {
+  return run('gh', ['--version']) !== null;
+}
+
+/**
+ * Local branch names that still carry commits not on main, excluding the
+ * current branch (the `* ` line — it is the release branch by construction and
+ * legitimately has no PR yet) and any detached-HEAD line.
+ */
+function unmergedBranches() {
+  const out = run('git', ['branch', '--no-merged', 'main']);
+  if (!out) {
+    return [];
+  }
+  const names = [];
+  for (const line of out.split('\n')) {
+    if (line.startsWith('*')) {
+      continue;
+    }
+    const name = line.replace(/^[+\s]+/, '').trim();
+    if (!name || name.startsWith('(')) {
+      continue;
+    }
+    names.push(name);
+  }
+  return names;
+}
+
+/**
+ * True if the branch tip is reachable from origin/main — a real or
+ * fast-forward merge landed it remotely. Skips silently if origin/main is
+ * absent (offline clone with no fetched remote).
+ */
+function landedOnOrigin(branch) {
+  const refExists = run('git', ['rev-parse', '--verify', '--quiet', 'origin/main']);
+  if (refExists === null) {
+    return false;
+  }
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', branch, 'origin/main'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify one branch into MERGED-PR / OPEN-PR / LANDED / NO-PR using PR state
+ * first (the only signal that survives a squash merge), then origin/main
+ * reachability as a fallback.
+ */
+function classify(branch) {
+  const args = ['pr', 'list', '--head', branch, '--state', 'all', '--json', 'number,state'];
+  const json = run('gh', args);
+  let prs = [];
+  if (json) {
+    try {
+      prs = JSON.parse(json);
+    } catch {
+      prs = [];
+    }
+  }
+  if (prs.some((p) => p.state === 'MERGED')) {
+    return 'MERGED-PR';
+  }
+  if (prs.some((p) => p.state === 'OPEN')) {
+    return 'OPEN-PR';
+  }
+  if (landedOnOrigin(branch)) {
+    return 'LANDED';
+  }
+  return 'NO-PR';
+}
+
+function main() {
+  const branches = unmergedBranches();
+  if (branches.length === 0) {
+    console.log('No local branches carry unmerged commits. Nothing to disposition.');
+    process.exit(0);
+  }
+
+  if (!hasGh()) {
+    console.warn('Warning: `gh` not found — cannot read PR state to disposition branches.');
+    console.warn('Listing unmerged local branches for manual review (list-only, not blocking):');
+    for (const b of branches) {
+      console.warn(`  - ${b}`);
+    }
+    console.warn('Install `gh` (GitHub CLI) for an authoritative MERGED/OPEN/NO-PR ruling.');
+    process.exit(0);
+  }
+
+  // Refresh origin/main so the LANDED fallback does not false-flag a branch
+  // merged on the remote. A failed fetch (offline) is non-fatal — warn and
+  // fall back to whatever origin/main the clone already has.
+  if (run('git', ['fetch', 'origin', 'main']) === null) {
+    console.warn('Warning: `git fetch origin main` failed — origin/main may be stale.');
+  }
+
+  const rows = branches.map((branch) => ({ branch, status: classify(branch) }));
+  const width = Math.max(...rows.map((r) => r.branch.length));
+  const blockers = [];
+
+  console.log('Unmerged local branch disposition\n');
+  for (const { branch, status } of rows) {
+    const ok = status !== 'NO-PR';
+    const mark = ok ? 'OK ' : 'XX ';
+    console.log(`  ${mark} ${branch.padEnd(width)}  ${status}`);
+    if (!ok) {
+      blockers.push(branch);
+    }
+  }
+  console.log('');
+
+  if (blockers.length > 0) {
+    console.error(`Undisposed branches with commits (${blockers.length}):`);
+    for (const b of blockers) {
+      console.error(`  - ${b} — land it (open + merge a PR) or delete it before releasing`);
+    }
+    process.exit(1);
+  }
+
+  console.log('All unmerged branches are dispositioned (merged, open PR, or landed on origin).');
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

Two release-time guards so the v4.0.0 failure class — a shipped CLI command with zero consumers, plus a stranded local branch that silently missed the release — cannot recur.

### G-C — `scripts/check-cli-consumers.js` (warn mode)
Enumerates every command in the contract-tested `CLI_MANIFEST` (top-level + `parent sub` joins) and flags any with zero word-boundary matches across `skills/ docs/guide/ templates/ agents/`. **WARN MODE (exits 0):** on the v4.0.0 tree it reports exactly one stranded command — `sdd-gate`. Wired into `package.json` (`check:cli-consumers`), `ci.yml` (after `check:docs`), and a read-only row in the `arc-release-audit` preflight. Flip `GATING=true` after v4.0.1 wires sdd-gate's consumers (#122) — mirrors the doc-ref linter warn→gate path. Documented limitation: common-English-word command names can't be reliably checked.

### G-B — `scripts/check-unmerged-branches.js` (+ arc-releasing Pre-Flight step 5)
`git branch --no-merged main`, then per branch `gh pr list` to classify MERGED-PR / OPEN-PR / LANDED / NO-PR (catches squash merges git can't see); origin/main reachability fallback; degrades to list-only if `gh` is absent. **Releaser-invoked, NOT a CI gate** (a fresh runner has no local branches). On a real clone it surfaces the stranded `feat/sdd-6-skill` (NO-PR).

## Verification

Biome clean, `npm test` green (5 runners), `check:cli-consumers` reports exactly `sdd-gate`, sweep classifies and exits nonzero on undisposed branches. No deps — lands any time; the G-C gating flip is tracked in #122.

https://claude.ai/code/session_01VbAii9JHZrk7qhHj2868Hn
