### PR TITLE
docs(product): flip 6.0.0 to shipped

### DIFF
--- a/product/ROADMAP.md
+++ b/product/ROADMAP.md
@@ -8,7 +8,7 @@ decision *and* every reversal. How to maintain this file: [`product/AGENTS.md`](
 
 | Version | Tag | Milestone | Status | What & why | Spec |
 |---|---|---|---|---|---|
-| 6.0.0 | `rc-v6.0.0` | v6 toolkit | **building ← we are here** | Ground-up rebuild: 15 self-contained skills behind a prose router, a 5-group CLI reached as bare `arcforge`, 6 hooks, and the retained learning / eval / obsidian systems — Claude Code single-harness, zero runtime deps. Release candidate is tagged; flips to `shipped` with the `v6.0.0` tag on the main branch. | [skill-system](specs/skill-system.md) · [cli](specs/cli.md) · [hooks](specs/hooks.md) · [learning](specs/learning.md) · [eval](specs/eval.md) · [obsidian](specs/obsidian.md) · [worktrees-loop](specs/worktrees-loop.md) |
+| 6.0.0 | `v6.0.0` | v6 toolkit | **shipped ← we are here** | Ground-up rebuild: 15 self-contained skills behind a prose router, a 5-group CLI reached as bare `arcforge`, 6 hooks, and the retained learning / eval / obsidian systems — Claude Code single-harness, zero runtime deps. | [skill-system](specs/skill-system.md) · [cli](specs/cli.md) · [hooks](specs/hooks.md) · [learning](specs/learning.md) · [eval](specs/eval.md) · [obsidian](specs/obsidian.md) · [worktrees-loop](specs/worktrees-loop.md) |
 
 > Un-scheduled ideas live in the [Backlog](BACKLOG.md); a wish graduates into a
 > version (row + spec + Decision Log entry) when picked.

--- a/product/specs/cli.md
+++ b/product/specs/cli.md
@@ -1,6 +1,6 @@
 # cli — spec
 
-> Status: building v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 

--- a/product/specs/eval.md
+++ b/product/specs/eval.md
@@ -1,6 +1,6 @@
 # eval — spec
 
-> Status: building v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -1,6 +1,6 @@
 # hooks — spec
 
-> Status: building v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 

--- a/product/specs/learning.md
+++ b/product/specs/learning.md
@@ -1,6 +1,6 @@
 # learning — spec
 
-> Status: building v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 

--- a/product/specs/obsidian.md
+++ b/product/specs/obsidian.md
@@ -1,6 +1,6 @@
 # obsidian — spec
 
-> Status: building v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 

--- a/product/specs/skill-system.md
+++ b/product/specs/skill-system.md
@@ -1,6 +1,6 @@
 # skill-system — spec
 
-> Status: building v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 

--- a/product/specs/worktrees-loop.md
+++ b/product/specs/worktrees-loop.md
@@ -1,6 +1,6 @@
 # worktrees-loop — spec
 
-> Status: building v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 


### PR DESCRIPTION
Ship playbook product-side flips on the v6.0.0 tag: ROADMAP row → shipped / Tag v6.0.0; seven spec Status headers → shipped v6.0.0.