### PR TITLE
fix(learning): diary enrichment and user-message capture move behind the opt-in (#146, #147)

### DIFF
--- a/docs/guide/hooks-system.md
+++ b/docs/guide/hooks-system.md
@@ -68,8 +68,9 @@ learning loop reads later, and what a diary is built from.
 
 Once a session passes the diary threshold — ten of your messages, or fifty tool
 calls — `session-end` also writes a diary draft under `~/.arcforge/diaries/`.
-The draft is built from the counts above, and its interpretive sections are
-left as `TO BE ENRICHED` stubs.
+The draft is built from the session record above — the counts, the tools used,
+and the files the session touched — and its interpretive sections are left as
+`TO BE ENRICHED` stubs.
 
 Three further things happen at that same threshold, and **only if you have
 turned learning on**: your ten most recent messages (truncated) are stored in

--- a/docs/guide/hooks-system.md
+++ b/docs/guide/hooks-system.md
@@ -71,12 +71,14 @@ calls — `session-end` also writes a diary draft under `~/.arcforge/diaries/`.
 The draft is built from the counts above, and its interpretive sections are
 left as `TO BE ENRICHED` stubs.
 
-Two further things happen at that same threshold, and **only if you have turned
-learning on**: your ten most recent messages (truncated) are stored in the
-session record, and a short background run is started to fill the draft's stubs
-in. With learning off, neither does — so a draft you open will still have its
-stubs. That is the intended state, not a failure, and nothing will warn you
-about it.
+Three further things happen at that same threshold, and **only if you have
+turned learning on**: your ten most recent messages (truncated) are stored in
+the session record, a short background run is started to fill the draft's stubs
+in, and — once a few drafts have accumulated — a note appears at your next
+session start offering to reflect over them. With learning off, none of the
+three does, so a draft you open will still have its stubs. That is the intended
+state, not a failure: nothing warns you about it and nothing keeps offering to
+process it.
 
 `pre-compact` runs just before compaction and captures what is about to be
 dropped, so the part of a long session worth keeping survives the boundary.

--- a/docs/guide/hooks-system.md
+++ b/docs/guide/hooks-system.md
@@ -68,9 +68,9 @@ learning loop reads later, and what a diary is built from.
 
 Once a session passes the diary threshold — ten of your messages, or fifty tool
 calls — `session-end` also writes a diary draft under `~/.arcforge/diaries/`.
-The draft is built from the session record above — the counts, the tools used,
-and the files the session touched — and its interpretive sections are left as
-`TO BE ENRICHED` stubs.
+The draft is built from the session record above — the counts and the files the
+session touched — and its interpretive sections are left as `TO BE ENRICHED`
+stubs.
 
 Three further things happen at that same threshold, and **only if you have
 turned learning on**: your ten most recent messages (truncated) are stored in

--- a/docs/guide/hooks-system.md
+++ b/docs/guide/hooks-system.md
@@ -67,18 +67,25 @@ one, as a JSON file under `~/.arcforge/sessions/`. That record is what the
 learning loop reads later, and what a diary is built from.
 
 Once a session passes the diary threshold — ten of your messages, or fifty tool
-calls — `session-end` also fills that record in with your ten most recent
-messages (truncated), writes a diary draft under `~/.arcforge/diaries/`, and
-starts a short background run to flesh the draft out.
+calls — `session-end` also writes a diary draft under `~/.arcforge/diaries/`.
+The draft is built from the counts above, and its interpretive sections are
+left as `TO BE ENRICHED` stubs.
+
+Two further things happen at that same threshold, and **only if you have turned
+learning on**: your ten most recent messages (truncated) are stored in the
+session record, and a short background run is started to fill the draft's stubs
+in. With learning off, neither does — so a draft you open will still have its
+stubs. That is the intended state, not a failure, and nothing will warn you
+about it.
 
 `pre-compact` runs just before compaction and captures what is about to be
 dropped, so the part of a long session worth keeping survives the boundary.
 
-The two `observe` registrations record tool calls for pattern detection — **but
-only if you have turned learning on**. With learning disabled, the default, each
-checks one file, finds no configuration, and exits before doing any work. That
-opt-in is what gates the learning capture; the session record and diary above
-are continuity, and they run either way. To see where learning stands:
+The two `observe` registrations record tool calls for pattern detection — again
+only with learning on. With learning disabled, the default, each checks one
+file, finds no configuration, and exits before doing any work. The session
+record, its counts, and the diary draft are continuity, and they run either
+way. To see where learning stands:
 
 ```bash
 arcforge learn status

--- a/docs/guide/learning-dashboard.md
+++ b/docs/guide/learning-dashboard.md
@@ -228,10 +228,18 @@ the dashboard.
 ## What is stored, and where
 
 All state stays on your own machine — arcforge has no telemetry and no server of
-its own to report to. The one thing that leaves is diary enrichment: it runs
-`claude` locally over a parsed summary of the session, so that summary reaches
-the model exactly the way anything you type in a session does. State sits in two
-places, split by scope:
+its own to report to. The one thing that leaves is diary enrichment, and it only
+happens once you have turned learning on: it runs `claude` locally over a parsed
+summary of the session, so that summary reaches the model exactly the way
+anything you type in a session does. That run is not privileged — it gets `Read`
+and `Write`, sees only the directory the draft is in, and goes through the
+normal permission checks. Turn learning off and the enrichment stops: diary
+drafts are still written from your session counts, but their `TO BE ENRICHED`
+sections stay unfilled, which is what an un-enriched draft is supposed to look
+like. The same opt-in decides whether your recent message text is stored in the
+session record at all.
+
+State sits in two places, split by scope:
 
 - **Home-global** — under `~/.arcforge/`: diaries in `diaries/<project>/<date>/`,
   raw observations in `observations/<project>/`, activated global instincts in

--- a/docs/guide/learning-dashboard.md
+++ b/docs/guide/learning-dashboard.md
@@ -238,10 +238,10 @@ though: it still starts in your project directory, and edits inside those places
 are approved automatically, because a background run has nobody to ask. What it
 no longer has is a blanket pass over your whole machine.
 
-Turn learning off and the enrichment stops: diary
-drafts are still written from your session counts, but their `TO BE ENRICHED`
-sections stay unfilled, which is what an un-enriched draft is supposed to look
-like. The same opt-in decides whether your recent message text is stored in the
+Turn learning off and the enrichment stops: diary drafts are still written from
+your session record — the counts, the tools used, and the files you touched —
+but their `TO BE ENRICHED` sections stay unfilled, which is what an un-enriched
+draft is supposed to look like. The same opt-in decides whether your recent message text is stored in the
 session record at all.
 
 State sits in two places, split by scope:

--- a/docs/guide/learning-dashboard.md
+++ b/docs/guide/learning-dashboard.md
@@ -239,10 +239,10 @@ are approved automatically, because a background run has nobody to ask. What it
 no longer has is a blanket pass over your whole machine.
 
 Turn learning off and the enrichment stops: diary drafts are still written from
-your session record — the counts, the tools used, and the files you touched —
-but their `TO BE ENRICHED` sections stay unfilled, which is what an un-enriched
-draft is supposed to look like. The same opt-in decides whether your recent message text is stored in the
-session record at all.
+your session record — the counts and the files you touched — but their
+`TO BE ENRICHED` sections stay unfilled, which is what an un-enriched draft is
+supposed to look like. The same opt-in decides whether your recent message text
+is stored in the session record at all.
 
 State sits in two places, split by scope:
 

--- a/docs/guide/learning-dashboard.md
+++ b/docs/guide/learning-dashboard.md
@@ -231,9 +231,14 @@ All state stays on your own machine — arcforge has no telemetry and no server 
 its own to report to. The one thing that leaves is diary enrichment, and it only
 happens once you have turned learning on: it runs `claude` locally over a parsed
 summary of the session, so that summary reaches the model exactly the way
-anything you type in a session does. That run is not privileged — it gets `Read`
-and `Write`, sees only the directory the draft is in, and goes through the
-normal permission checks. Turn learning off and the enrichment stops: diary
+anything you type in a session does. That run used to skip every permission
+check; it no longer does. It gets two tools, `Read` and `Write`, and the diary
+directory is added to the places it is allowed to work in. It is not sealed off,
+though: it still starts in your project directory, and edits inside those places
+are approved automatically, because a background run has nobody to ask. What it
+no longer has is a blanket pass over your whole machine.
+
+Turn learning off and the enrichment stops: diary
 drafts are still written from your session counts, but their `TO BE ENRICHED`
 sections stay unfilled, which is what an un-enriched draft is supposed to look
 like. The same opt-in decides whether your recent message text is stored in the

--- a/docs/plans/check-product-deferred.md
+++ b/docs/plans/check-product-deferred.md
@@ -62,55 +62,21 @@ Two constraints on any rule that hardens it:
   superseded entry still governs the rest of itself, which is exactly what a
   refinement would sharpen.
 
-## 2. `hooks/session-tracker/end.js` — the carry-forward, for the learning-gates PR
+## 2. `hooks/session-tracker/end.js` — the carry-forward (landed)
 
-Not this PR's to fix: the branch that gates session capture behind the learning
-opt-in already rewrites the block, and the product-method PR is process-only.
-Recorded here so the direction is not lost between the two.
+The prose half landed on `fix/learning-gates-146-147` as `pruneUngatedProse` in
+`scripts/lib/diary-capture.js`, called from `hooks/session-tracker/end.js` and
+`hooks/pre-compact/main.js` — the two hooks that reload the whole session record
+and write it back, and therefore the two that could re-serialize prose captured
+before an opt-out. With learning off, either event now deletes
+`userMessageContent` rather than carrying it forward.
 
-`main()` reloads the existing session record, assigns the three transcript-derived
-fields only when the diary threshold fired **and** a transcript actually parsed, and
-otherwise clears `filesModified` alone. Stop fires once per turn and the diary
-capture resets the counters on a hit, so the very next turn is below threshold by
-construction: fresh counters end up beside the previous turn's `userMessageContent`
-and `toolsUsed`, and `scripts/lib/session-utils.js` reads exactly those fields as
-the fallback for the diary's "Tools Used" and "Conversation Trail" sections. The
-record is internally inconsistent rather than newly leaky — the text was written
-legitimately above the threshold — but a later render can label a previous turn's
-prose as this turn's.
-
-Gating only the `userMessageContent` *assignment* does not close it. Once the gates
-PR promises that verbatim user text is absent from the session record with learning
-off, a record written while learning was on keeps re-serializing that text on every
-subsequent Stop. The direction, in `end.js` `main()` — the gate here stands in for
-whichever opt-in helper that PR settles on (`isLearningEnabled` in
-`scripts/lib/learning.js` today):
-
-```js
-if (learningGateOn) {
-  session.userMessageContent = transcriptData.userMessages;
-} else {
-  delete session.userMessageContent;
-}
-```
-
-plus `delete session.userMessageContent; delete session.toolsUsed;` in the
-no-transcript branch alongside the existing `filesModified = []`, so the three
-transcript-derived fields have one lifetime instead of three.
-
-Two cases to add in `hooks/__tests__/session-tracker-end.test.js` — its existing
-cases all start from *no* session file and therefore cannot see this:
-
-- An above-threshold Stop followed by a below-threshold one with no counter reseed,
-  asserting `userMessageContent` and `toolsUsed` are `undefined` after the second.
-- An above-threshold Stop with learning enabled followed by one with learning
-  disabled, asserting the field is gone rather than stale.
-
-`product/specs/hooks.md`'s domain-model section describes today's behavior; whichever
-PR lands the change owns that sentence and the decision entry that covers capture
-depth — either its text says the three fields share one lifetime, or it carries a
-`Residual:` recording that a pre-opt-out record keeps its prose. Delete this section
-once that lands.
+The other half this section proposed — also deleting `toolsUsed` in the
+no-transcript branch, so the three transcript-derived fields share one lifetime —
+was deliberately **not** taken. D-010 makes tool names always-on continuity, so
+dropping them would be a continuity regression rather than a privacy fix.
+`product/specs/hooks.md`'s domain-model note now states the two lifetimes
+separately instead of describing them as one.
 
 ## 3. `docs/guide/eval-system.md` — the verdict table has no `PASS` row
 

--- a/hooks/__tests__/diary-enricher.test.js
+++ b/hooks/__tests__/diary-enricher.test.js
@@ -45,7 +45,7 @@ describe('spawnDiaryEnricher invocation', () => {
     assert.ok(
       !argv.includes('--dangerously-skip-permissions'),
       'the enricher must not bypass every permission check — it runs --tools Read,Write ' +
-        'confined to the draft directory with --permission-mode acceptEdits.',
+        'with the draft directory added via --add-dir and --permission-mode acceptEdits.',
     );
   });
 

--- a/hooks/__tests__/diary-enricher.test.js
+++ b/hooks/__tests__/diary-enricher.test.js
@@ -36,6 +36,19 @@ describe('spawnDiaryEnricher invocation', () => {
     );
   });
 
+  it('never re-introduces --dangerously-skip-permissions (D-009)', () => {
+    // Scan the spawn(...) argv only — the prose above the function explains the
+    // flag's removal and would otherwise match.
+    const spawnIdx = source.indexOf('spawn(');
+    assert.ok(spawnIdx !== -1, 'expected spawn(...) call');
+    const argv = source.slice(spawnIdx, spawnIdx + 1500);
+    assert.ok(
+      !argv.includes('--dangerously-skip-permissions'),
+      'the enricher must not bypass every permission check — it runs --tools Read,Write ' +
+        'confined to the draft directory with --permission-mode acceptEdits.',
+    );
+  });
+
   it('does not silently discard enricher stderr', () => {
     // Find the spawn(...) call body
     const spawnIdx = source.indexOf('spawn(');

--- a/hooks/__tests__/inject-context.test.js
+++ b/hooks/__tests__/inject-context.test.js
@@ -163,3 +163,68 @@ describe('inject-context SessionStart child process (S7-1)', () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────
+// Stale-draft warning is gated on the learning opt-in (D-009)
+// ─────────────────────────────────────────────
+
+describe('inject-context stale-draft warning gate (D-009)', () => {
+  let homeDir;
+  let projectDir;
+  let project;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-stale-home-'));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-stale-proj-'));
+    project = path.basename(projectDir);
+    // One unenriched draft — the shape the warning fires on.
+    const dir = path.join(homeDir, '.arcforge', 'diaries', project, '2026-09-01');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'diary-session-xyz-draft.md'),
+      '# Diary\n\n## Decisions\n<!-- TO BE ENRICHED -->\n- \n',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function runInject() {
+    const env = { ...process.env, HOME: homeDir, CLAUDE_PROJECT_DIR: projectDir };
+    delete env.ARCFORGE_SPAWNED;
+    delete env.ARCFORGE_HOME;
+    return spawnSync('node', [INJECT_CONTEXT], {
+      input: JSON.stringify({
+        cwd: projectDir,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+  }
+
+  it('stays silent with learning off — unenriched drafts are the contract, not a failure', () => {
+    const res = runInject();
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(
+      !res.stdout.includes('unenriched'),
+      `learning-off session must not warn about unenriched drafts. stdout: ${res.stdout}`,
+    );
+  });
+
+  it('warns once learning is on — then the enricher really should have run', () => {
+    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+
+    const res = runInject();
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(
+      res.stdout.includes('unenriched'),
+      `learning-on session must surface the stale-draft warning. stdout: ${res.stdout}`,
+    );
+  });
+});

--- a/hooks/__tests__/inject-context.test.js
+++ b/hooks/__tests__/inject-context.test.js
@@ -16,6 +16,7 @@ const os = require('node:os');
 const { spawnSync } = require('node:child_process');
 
 const INJECT_CONTEXT = path.join(__dirname, '..', 'session-tracker', 'inject-context.js');
+const { loadStaleDraftWarning } = require(INJECT_CONTEXT);
 
 // ─────────────────────────────────────────────
 // loadPendingActions relay isolation (S7-1)
@@ -277,27 +278,35 @@ describe('inject-context stale-draft warning gate (D-009)', () => {
     );
   });
 
+  // Direct call, not a spawn: only mtime can be backdated portably, and this
+  // case is about the CREATION stamp — so the draft is written now and the
+  // floor is placed after it, which is the same ordering a pre-opt-in stub has.
   it('keeps a pre-opt-in draft suppressed after it is hand-edited or touched', () => {
-    const draft = writeStaleDraft('diary-session-old-draft.md', 5 * DAY_MS);
-    enableLearning(3 * DAY_MS);
+    const previousHome = process.env.ARCFORGE_HOME;
+    process.env.ARCFORGE_HOME = path.join(homeDir, '.arcforge');
+    try {
+      const draft = writeStaleDraft('diary-session-old-draft.md', 0);
+      const enabledSince = Date.now() + DAY_MS;
 
-    const before = runInject();
-    assert.strictEqual(before.status, 0, before.stderr);
-    assert.ok(
-      !before.stdout.includes('unenriched'),
-      `the pre-opt-in stub must start out silent. stdout: ${before.stdout}`,
-    );
+      assert.strictEqual(
+        loadStaleDraftWarning(project, enabledSince),
+        null,
+        'a draft that existed before the opt-in must not be reported',
+      );
 
-    // Touching the stub moves mtime past the opt-in; creation time does not
-    // move, so the floor still recognizes it as a pre-opt-in stub.
-    const now = new Date();
-    fs.utimesSync(draft, now, now);
+      // A hand-edit or `touch` moves mtime past the floor. Creation time does
+      // not move, so the draft is still recognized as a pre-opt-in stub.
+      const after = new Date(Date.now() + 3 * DAY_MS);
+      fs.utimesSync(draft, after, after);
 
-    const after = runInject();
-    assert.strictEqual(after.status, 0, after.stderr);
-    assert.ok(
-      !after.stdout.includes('unenriched'),
-      `touching a pre-opt-in stub must not turn it into a reported failure. stdout: ${after.stdout}`,
-    );
+      assert.strictEqual(
+        loadStaleDraftWarning(project, enabledSince),
+        null,
+        'touching a pre-opt-in stub must not turn it into a reported failure',
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.ARCFORGE_HOME;
+      else process.env.ARCFORGE_HOME = previousHome;
+    }
   });
 });

--- a/hooks/__tests__/inject-context.test.js
+++ b/hooks/__tests__/inject-context.test.js
@@ -74,6 +74,126 @@ describe('loadPendingActions relay isolation (S7-1)', () => {
 });
 
 // ─────────────────────────────────────────────
+// reflect-ready delivery gate (D-009)
+//
+// The nudge is gated at queue time in end.js so it never accumulates while
+// learning is off. That cannot retract one already queued: disabling learning
+// between the queuing Stop and the next SessionStart must drop it too, or the
+// learning-off session gets the exact invitation hooks B-6 promises it will not.
+// ─────────────────────────────────────────────
+
+describe('reflect-ready delivery gate (D-009)', () => {
+  const originalEnv = { ...process.env };
+  let homeDir;
+  let projectDir;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-reflect-home-'));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-reflect-proj-'));
+    process.env.HOME = homeDir;
+    delete process.env.ARCFORGE_SPAWNED;
+    delete require.cache[require.resolve('../session-tracker/inject-context')];
+    delete require.cache[require.resolve('../../scripts/lib/pending-actions')];
+    delete require.cache[require.resolve('../../scripts/lib/utils')];
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  function seedAction(project, type, payload) {
+    const { addPendingAction } = require('../../scripts/lib/pending-actions');
+    return addPendingAction(project, type, payload);
+  }
+
+  function unconsumedCount(project) {
+    const { getPendingActions } = require('../../scripts/lib/pending-actions');
+    return getPendingActions(project).length;
+  }
+
+  /** Turn the project-scope learning opt-in on for the temp project root. */
+  function enableLearning() {
+    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+  }
+
+  it('learning off: a queued reflect-ready is suppressed and consumed, not deferred', () => {
+    const project = 'reflect-delivery-off';
+    seedAction(project, 'reflect-ready', { strategy: 'batch', count: 4 });
+    const { loadPendingActions } = require('../session-tracker/inject-context');
+
+    const result = loadPendingActions(project, { projectRoot: projectDir });
+    assert.strictEqual(result.text, null, 'no reflection line with learning off');
+    assert.strictEqual(result.summary, null, 'and nothing in the user summary either');
+    assert.strictEqual(unconsumedCount(project), 0, 'suppressed, not deferred to a later start');
+  });
+
+  it('learning off: diary-ready still renders and reflect-ready leaves no trace', () => {
+    const project = 'reflect-delivery-mixed';
+    seedAction(project, 'diary-ready', { trigger: 'compaction' });
+    seedAction(project, 'reflect-ready', { strategy: 'batch', count: 4 });
+    const { loadPendingActions } = require('../session-tracker/inject-context');
+
+    const result = loadPendingActions(project, { projectRoot: projectDir });
+    assert.ok(result.text.includes('Diary draft ready'), 'diary-ready is unaffected by the gate');
+    assert.ok(
+      !result.text.includes('reflect-ready'),
+      'a suppressed nudge must not fall through to the raw Pending line',
+    );
+    assert.ok(!result.text.includes('ready for reflection'), 'nor to the reflection line');
+    assert.strictEqual(unconsumedCount(project), 0, 'both actions consumed');
+  });
+
+  it('learning on: the queued nudge renders exactly as before', () => {
+    const project = 'reflect-delivery-on';
+    enableLearning();
+    seedAction(project, 'reflect-ready', { strategy: 'batch', count: 4 });
+    const { loadPendingActions } = require('../session-tracker/inject-context');
+
+    const result = loadPendingActions(project, { projectRoot: projectDir });
+    assert.ok(
+      result.text.includes('4 unprocessed diaries ready for reflection'),
+      `expected the reflection line: ${result.text}`,
+    );
+    assert.strictEqual(result.summary, '4 diaries pending reflection');
+    assert.strictEqual(unconsumedCount(project), 0, 'consumed as before');
+  });
+
+  // The gate fails closed on a missing projectRoot, so a main() that never
+  // threaded one through would suppress the nudge for opted-in users too — and
+  // every direct-call case above would still pass. This one spawns the real
+  // hook to pin the wiring.
+  it('main(): SessionStart delivers the nudge to an opted-in project', () => {
+    const project = path.basename(projectDir);
+    enableLearning();
+    seedAction(project, 'reflect-ready', { strategy: 'batch', count: 4 });
+
+    const env = { ...process.env, HOME: homeDir, CLAUDE_PROJECT_DIR: projectDir };
+    delete env.ARCFORGE_SPAWNED;
+    delete env.ARCFORGE_HOME;
+    const res = spawnSync('node', [INJECT_CONTEXT], {
+      input: JSON.stringify({
+        cwd: projectDir,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(
+      res.stdout.includes('unprocessed diaries ready for reflection'),
+      `main() must pass the project root through: ${res.stdout}`,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────
 // SessionStart child process (relay isolation, end-to-end)
 // ─────────────────────────────────────────────
 

--- a/hooks/__tests__/inject-context.test.js
+++ b/hooks/__tests__/inject-context.test.js
@@ -276,4 +276,28 @@ describe('inject-context stale-draft warning gate (D-009)', () => {
       `only the post-opt-in draft should be counted. stdout: ${second.stdout}`,
     );
   });
+
+  it('keeps a pre-opt-in draft suppressed after it is hand-edited or touched', () => {
+    const draft = writeStaleDraft('diary-session-old-draft.md', 5 * DAY_MS);
+    enableLearning(3 * DAY_MS);
+
+    const before = runInject();
+    assert.strictEqual(before.status, 0, before.stderr);
+    assert.ok(
+      !before.stdout.includes('unenriched'),
+      `the pre-opt-in stub must start out silent. stdout: ${before.stdout}`,
+    );
+
+    // Touching the stub moves mtime past the opt-in; creation time does not
+    // move, so the floor still recognizes it as a pre-opt-in stub.
+    const now = new Date();
+    fs.utimesSync(draft, now, now);
+
+    const after = runInject();
+    assert.strictEqual(after.status, 0, after.stderr);
+    assert.ok(
+      !after.stdout.includes('unenriched'),
+      `touching a pre-opt-in stub must not turn it into a reported failure. stdout: ${after.stdout}`,
+    );
+  });
 });

--- a/hooks/__tests__/inject-context.test.js
+++ b/hooks/__tests__/inject-context.test.js
@@ -169,6 +169,7 @@ describe('inject-context SessionStart child process (S7-1)', () => {
 // ─────────────────────────────────────────────
 
 describe('inject-context stale-draft warning gate (D-009)', () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
   let homeDir;
   let projectDir;
   let project;
@@ -177,19 +178,41 @@ describe('inject-context stale-draft warning gate (D-009)', () => {
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-stale-home-'));
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-stale-proj-'));
     project = path.basename(projectDir);
-    // One unenriched draft — the shape the warning fires on.
-    const dir = path.join(homeDir, '.arcforge', 'diaries', project, '2026-09-01');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, 'diary-session-xyz-draft.md'),
-      '# Diary\n\n## Decisions\n<!-- TO BE ENRICHED -->\n- \n',
-    );
   });
 
   afterEach(() => {
     fs.rmSync(homeDir, { recursive: true, force: true });
     fs.rmSync(projectDir, { recursive: true, force: true });
   });
+
+  /**
+   * Write one unenriched draft — the shape the warning fires on — stamped
+   * `ageMs` in the past. Ages are whole days apart so filesystem timestamp
+   * granularity never decides an assertion.
+   */
+  function writeStaleDraft(name, ageMs) {
+    const dir = path.join(homeDir, '.arcforge', 'diaries', project, '2026-09-01');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, name);
+    fs.writeFileSync(file, '# Diary\n\n## Decisions\n<!-- TO BE ENRICHED -->\n- \n');
+    const at = new Date(Date.now() - ageMs);
+    fs.utimesSync(file, at, at);
+    return file;
+  }
+
+  /** Turn the project-scope opt-in on, as of `ageMs` in the past. */
+  function enableLearning(ageMs) {
+    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        scope: 'project',
+        enabled: true,
+        updated_at: new Date(Date.now() - ageMs).toISOString(),
+      }),
+    );
+  }
 
   function runInject() {
     const env = { ...process.env, HOME: homeDir, CLAUDE_PROJECT_DIR: projectDir };
@@ -207,6 +230,8 @@ describe('inject-context stale-draft warning gate (D-009)', () => {
   }
 
   it('stays silent with learning off — unenriched drafts are the contract, not a failure', () => {
+    writeStaleDraft('diary-session-xyz-draft.md', 2 * DAY_MS);
+
     const res = runInject();
     assert.strictEqual(res.status, 0, res.stderr);
     assert.ok(
@@ -215,16 +240,40 @@ describe('inject-context stale-draft warning gate (D-009)', () => {
     );
   });
 
-  it('warns once learning is on — then the enricher really should have run', () => {
-    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
-    fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+  it('warns about a draft written after the opt-in — the enricher really should have run', () => {
+    enableLearning(3 * DAY_MS);
+    writeStaleDraft('diary-session-xyz-draft.md', 2 * DAY_MS);
 
     const res = runInject();
     assert.strictEqual(res.status, 0, res.stderr);
     assert.ok(
       res.stdout.includes('unenriched'),
       `learning-on session must surface the stale-draft warning. stdout: ${res.stdout}`,
+    );
+  });
+
+  it('opting in does not report the learning-off backlog, only what came after', () => {
+    // Three drafts accumulated while learning was off — all by-design stubs.
+    writeStaleDraft('diary-session-a-draft.md', 5 * DAY_MS);
+    writeStaleDraft('diary-session-b-draft.md', 4 * DAY_MS);
+    writeStaleDraft('diary-session-c-draft.md', 3 * DAY_MS);
+    enableLearning(0);
+
+    const first = runInject();
+    assert.strictEqual(first.status, 0, first.stderr);
+    assert.ok(
+      !first.stdout.includes('unenriched'),
+      `the first session after opting in must not report the backlog. stdout: ${first.stdout}`,
+    );
+
+    // A draft the enricher was authorized for, and left stale, still warns —
+    // and reports only itself.
+    writeStaleDraft('diary-session-d-draft.md', 0);
+    const second = runInject();
+    assert.strictEqual(second.status, 0, second.stderr);
+    assert.ok(
+      second.stdout.includes('1 diary draft unenriched'),
+      `only the post-opt-in draft should be counted. stdout: ${second.stdout}`,
     );
   });
 });

--- a/hooks/__tests__/inject-context.test.js
+++ b/hooks/__tests__/inject-context.test.js
@@ -169,6 +169,23 @@ describe('inject-context SessionStart child process (S7-1)', () => {
 // Stale-draft warning is gated on the learning opt-in (D-009)
 // ─────────────────────────────────────────────
 
+// The creation-time half of the floor only exists where the filesystem records
+// one. Where it does not, the engine degrades to last-write alone by design
+// (product/specs/hooks.md B-6), so the case below has nothing to assert and is
+// skipped rather than failed. Probed on the same filesystem the tests use.
+const recordsBirthtime = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-birthtime-'));
+  const probe = path.join(probeDir, 'probe');
+  try {
+    fs.writeFileSync(probe, 'x');
+    return fs.statSync(probe).birthtimeMs > 0;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
 describe('inject-context stale-draft warning gate (D-009)', () => {
   const DAY_MS = 24 * 60 * 60 * 1000;
   let homeDir;
@@ -281,32 +298,36 @@ describe('inject-context stale-draft warning gate (D-009)', () => {
   // Direct call, not a spawn: only mtime can be backdated portably, and this
   // case is about the CREATION stamp — so the draft is written now and the
   // floor is placed after it, which is the same ordering a pre-opt-in stub has.
-  it('keeps a pre-opt-in draft suppressed after it is hand-edited or touched', () => {
-    const previousHome = process.env.ARCFORGE_HOME;
-    process.env.ARCFORGE_HOME = path.join(homeDir, '.arcforge');
-    try {
-      const draft = writeStaleDraft('diary-session-old-draft.md', 0);
-      const enabledSince = Date.now() + DAY_MS;
+  it(
+    'keeps a pre-opt-in draft suppressed after it is hand-edited or touched',
+    { skip: recordsBirthtime ? false : 'filesystem records no creation time' },
+    () => {
+      const previousHome = process.env.ARCFORGE_HOME;
+      process.env.ARCFORGE_HOME = path.join(homeDir, '.arcforge');
+      try {
+        const draft = writeStaleDraft('diary-session-old-draft.md', 0);
+        const enabledSince = Date.now() + DAY_MS;
 
-      assert.strictEqual(
-        loadStaleDraftWarning(project, enabledSince),
-        null,
-        'a draft that existed before the opt-in must not be reported',
-      );
+        assert.strictEqual(
+          loadStaleDraftWarning(project, enabledSince),
+          null,
+          'a draft that existed before the opt-in must not be reported',
+        );
 
-      // A hand-edit or `touch` moves mtime past the floor. Creation time does
-      // not move, so the draft is still recognized as a pre-opt-in stub.
-      const after = new Date(Date.now() + 3 * DAY_MS);
-      fs.utimesSync(draft, after, after);
+        // A hand-edit or `touch` moves mtime past the floor. Creation time does
+        // not move, so the draft is still recognized as a pre-opt-in stub.
+        const after = new Date(Date.now() + 3 * DAY_MS);
+        fs.utimesSync(draft, after, after);
 
-      assert.strictEqual(
-        loadStaleDraftWarning(project, enabledSince),
-        null,
-        'touching a pre-opt-in stub must not turn it into a reported failure',
-      );
-    } finally {
-      if (previousHome === undefined) delete process.env.ARCFORGE_HOME;
-      else process.env.ARCFORGE_HOME = previousHome;
-    }
-  });
+        assert.strictEqual(
+          loadStaleDraftWarning(project, enabledSince),
+          null,
+          'touching a pre-opt-in stub must not turn it into a reported failure',
+        );
+      } finally {
+        if (previousHome === undefined) delete process.env.ARCFORGE_HOME;
+        else process.env.ARCFORGE_HOME = previousHome;
+      }
+    },
+  );
 });

--- a/hooks/__tests__/learning-unification.test.js
+++ b/hooks/__tests__/learning-unification.test.js
@@ -292,13 +292,19 @@ describe('end.js does not reference /learn', () => {
     );
   });
 
-  it('should export formatStats instead of formatStopReason', () => {
+  it('has no stop-reason formatter; the session summary is the shared builder', () => {
     const endModule = require('../session-tracker/end');
-    assert.ok(typeof endModule.formatStats === 'function', 'formatStats should be exported');
     assert.strictEqual(
       endModule.formatStopReason,
       undefined,
       'formatStopReason should no longer be exported',
+    );
+    // The stats line moved to scripts/lib when PreCompact needed the same
+    // summary; end.js no longer owns a formatter of its own.
+    const { buildSessionSummary } = require('../../scripts/lib/diary-capture');
+    assert.ok(
+      typeof buildSessionSummary === 'function',
+      'the enricher summary comes from the shared diary-capture builder',
     );
   });
 });

--- a/hooks/__tests__/pre-compact.test.js
+++ b/hooks/__tests__/pre-compact.test.js
@@ -40,7 +40,7 @@ describe('pre-compact: updateSessionFile', () => {
       '2025-01-15T10:30:00Z',
       'session-123',
     );
-    assert.strictEqual(result, true);
+    assert.ok(result, 'the stamped record is returned');
 
     const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
     assert.strictEqual(updated.compactions.length, 1);
@@ -57,7 +57,7 @@ describe('pre-compact: updateSessionFile', () => {
       '2025-01-15T10:30:00Z',
       'nonexistent',
     );
-    assert.strictEqual(result, false);
+    assert.strictEqual(result, null, 'no record to update reports null');
   });
 
   it('should append multiple compaction markers', () => {
@@ -119,7 +119,7 @@ describe('pre-compact: updateSessionFile', () => {
       'session-prune-off',
       { projectRoot: projectRootWithLearning(false) },
     );
-    assert.strictEqual(result, true);
+    assert.ok(result, 'the stamped record is returned');
 
     const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
     assert.strictEqual(
@@ -477,9 +477,13 @@ describe('pre-compact: diary-capture fixture (ICL-8)', () => {
     return transcriptPath;
   }
 
-  /** Spawn the real hook on an above-threshold PreCompact carrying a transcript. */
-  function compactAboveThreshold(projectDir) {
-    fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\ncat > /dev/null\nexit 0\n', {
+  /**
+   * Spawn the real hook on an above-threshold PreCompact carrying a transcript.
+   * With `promptFile`, the stub enricher writes the prompt it was handed there.
+   */
+  function compactAboveThreshold(projectDir, promptFile) {
+    const sink = promptFile ? `"${promptFile}"` : '/dev/null';
+    fs.writeFileSync(path.join(binDir, 'claude'), `#!/bin/sh\ncat > ${sink}\nexit 0\n`, {
       mode: 0o755,
     });
     fs.writeFileSync(counterPath('user-count'), '12');
@@ -616,6 +620,39 @@ describe('pre-compact: diary-capture fixture (ICL-8)', () => {
       );
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  // The enricher's prompt is the other half of the draft: it fills the prose
+  // sections. A compaction used to hand it {} while Stop handed it the parsed
+  // summary, so those sections were enriched from nothing even once the metrics
+  // above were correct.
+  it('hands the enricher the same populated summary Stop does — and only under the opt-in', async () => {
+    const onDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-summary-on-'));
+    const offDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-summary-off-'));
+    const onPrompt = path.join(binDir, 'prompt-on.txt');
+    const offPrompt = path.join(binDir, 'prompt-off.txt');
+
+    try {
+      enableLearning(onDir);
+      seedStaleRecord(path.basename(onDir));
+      assert.strictEqual(compactAboveThreshold(onDir, onPrompt).status, 0);
+
+      // Detached spawn — poll, as the sibling enricher cases do.
+      assert.ok(await waitFor(onPrompt, 5000), 'enricher stub invoked');
+      const prompt = fs.readFileSync(onPrompt, 'utf-8');
+      assert.match(prompt, /alpha\.js/, 'the summary carries the touched paths');
+      assert.match(prompt, /"Edit"/, 'and the tool names');
+      assert.match(prompt, /ship the fix/, 'and, under the opt-in, the user prose');
+      assert.match(prompt, /12 messages, 55 tool calls/, 'and a populated stats line');
+
+      // Learning off: no summary reaches a model at all, because no enricher runs.
+      seedStaleRecord(path.basename(offDir));
+      assert.strictEqual(compactAboveThreshold(offDir, offPrompt).status, 0);
+      assert.strictEqual(await waitFor(offPrompt, 1000), false, 'enricher must NOT spawn');
+    } finally {
+      fs.rmSync(onDir, { recursive: true, force: true });
+      fs.rmSync(offDir, { recursive: true, force: true });
     }
   });
 });

--- a/hooks/__tests__/pre-compact.test.js
+++ b/hooks/__tests__/pre-compact.test.js
@@ -108,6 +108,13 @@ describe('pre-compact: diary-capture fixture (ICL-8)', () => {
     return path.join(tmpDir, `arcforge-${name}-session-${sessionId}`);
   }
 
+  /** Turn the project-scope learning opt-in on for a project dir. */
+  function enableLearning(projectDir) {
+    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+  }
+
   function pendingActions(project) {
     const file = path.join(homeDir, '.arcforge', 'sessions', project, 'pending-actions.json');
     if (!fs.existsSync(file)) return [];
@@ -138,6 +145,8 @@ describe('pre-compact: diary-capture fixture (ICL-8)', () => {
 
     const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-proj-'));
     const project = path.basename(projectDir);
+    // Enrichment is opt-in (D-009): this case asserts the spawn, so opt in.
+    enableLearning(projectDir);
 
     const env = {
       ...process.env,
@@ -176,6 +185,59 @@ describe('pre-compact: diary-capture fixture (ICL-8)', () => {
       // Enricher stub fired with the relay-isolation env (poll: detached spawn).
       assert.ok(await waitFor(marker, 5000), 'enricher stub invoked');
       assert.strictEqual(fs.readFileSync(marker, 'utf-8'), 'enricher', 'ARCFORGE_SPAWNED=enricher');
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('learning off: draft + diary-ready still happen, but the enricher never spawns', async () => {
+    const marker = path.join(binDir, 'spawned.marker');
+    fs.writeFileSync(
+      path.join(binDir, 'claude'),
+      `#!/bin/sh\ncat > /dev/null\nprintf '%s' "$ARCFORGE_SPAWNED" > "${marker}"\n`,
+      { mode: 0o755 },
+    );
+
+    fs.writeFileSync(counterPath('user-count'), '15');
+    fs.writeFileSync(counterPath('tool-count'), '0');
+
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-proj-'));
+    const project = path.basename(projectDir);
+    // No learning config anywhere — the default.
+
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      TMPDIR: tmpDir,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      CLAUDE_PROJECT_DIR: projectDir,
+    };
+    delete env.CLAUDE_SESSION_ID;
+
+    const res = spawnSync('node', [PRE_COMPACT], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PreCompact',
+        cwd: projectDir,
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+      // Continuity is unchanged by the opt-in.
+      assert.strictEqual(
+        pendingActions(project).filter((a) => a.type === 'diary-ready').length,
+        1,
+        'diary-ready still queued',
+      );
+      assert.ok(
+        fs.existsSync(path.join(homeDir, '.arcforge', 'diaries', project)),
+        'draft still generated',
+      );
+      // Enrichment is not.
+      assert.strictEqual(await waitFor(marker, 1000), false, 'enricher must NOT spawn');
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });
     }

--- a/hooks/__tests__/pre-compact.test.js
+++ b/hooks/__tests__/pre-compact.test.js
@@ -74,6 +74,82 @@ describe('pre-compact: updateSessionFile', () => {
     const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
     assert.strictEqual(updated.compactions.length, 2);
   });
+
+  // -------------------------------------------------------------------
+  // D-010 retention: stamping the compaction marker rewrites the whole
+  // record, so the same opt-in that governs capture governs what survives
+  // here. Without the prune, a compaction re-serializes prose captured
+  // before the user opted out.
+  // -------------------------------------------------------------------
+
+  /** A session record carrying prose an earlier, opted-in Stop wrote. */
+  function seedRecordWithProse(sessionId) {
+    const sessionDir = path.join(testDir, '.arcforge', 'sessions', 'test-project', '2025-01-15');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const sessionFile = path.join(sessionDir, `${sessionId}.json`);
+    fs.writeFileSync(
+      sessionFile,
+      JSON.stringify({
+        toolCalls: 10,
+        compactions: [],
+        userMessageContent: ['carried prose'],
+        toolsUsed: ['Edit'],
+      }),
+    );
+    return sessionFile;
+  }
+
+  /** A project root whose project-scope learning config is written as `enabled`. */
+  function projectRootWithLearning(enabled) {
+    const projectRoot = path.join(testDir, `proj-${enabled ? 'on' : 'off'}`);
+    const configPath = path.join(projectRoot, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled }));
+    return projectRoot;
+  }
+
+  it('prunes carried user prose when the opt-in is off', () => {
+    const { updateSessionFile } = require('../pre-compact/main');
+    const sessionFile = seedRecordWithProse('session-prune-off');
+
+    const result = updateSessionFile(
+      'test-project',
+      '2025-01-15',
+      '2025-01-15T10:30:00Z',
+      'session-prune-off',
+      projectRootWithLearning(false),
+    );
+    assert.strictEqual(result, true);
+
+    const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
+    assert.strictEqual(
+      updated.userMessageContent,
+      undefined,
+      'a compaction must not re-serialize prose captured before the opt-out',
+    );
+    assert.deepStrictEqual(updated.toolsUsed, ['Edit'], 'tool names are continuity, kept');
+    assert.strictEqual(updated.compactions.length, 1, 'the compaction marker still lands');
+  });
+
+  it('keeps carried user prose while the opt-in is on', () => {
+    const { updateSessionFile } = require('../pre-compact/main');
+    const sessionFile = seedRecordWithProse('session-prune-on');
+
+    updateSessionFile(
+      'test-project',
+      '2025-01-15',
+      '2025-01-15T10:30:00Z',
+      'session-prune-on',
+      projectRootWithLearning(true),
+    );
+
+    const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
+    assert.deepStrictEqual(
+      updated.userMessageContent,
+      ['carried prose'],
+      'with learning on the record keeps what an earlier parse wrote',
+    );
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -282,6 +358,59 @@ describe('pre-compact: diary-capture fixture (ICL-8)', () => {
         fs.readFileSync(counterPath('tool-count'), 'utf-8'),
         '3',
         'tool preserved',
+      );
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+  // D-010 retention, end-to-end: updateSessionFile fails closed on a missing
+  // projectRoot, so a main() that never threaded it through would delete prose
+  // even for an opted-in user — and every direct-call test would still pass.
+  // This case spawns the real hook to pin the wiring.
+  it('main(): a compaction with learning ON keeps the prose an earlier Stop wrote', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-keep-proj-'));
+    const project = path.basename(projectDir);
+    enableLearning(projectDir);
+
+    const date = new Date().toISOString().split('T')[0];
+    const sessionDir = path.join(homeDir, '.arcforge', 'sessions', project, date);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const sessionFile = path.join(sessionDir, `session-${sessionId}.json`);
+    fs.writeFileSync(
+      sessionFile,
+      JSON.stringify({ compactions: [], userMessageContent: ['carried prose'] }),
+    );
+
+    // Below the diary threshold, so this compaction only stamps the record.
+    fs.writeFileSync(counterPath('user-count'), '1');
+    fs.writeFileSync(counterPath('tool-count'), '1');
+
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      TMPDIR: tmpDir,
+      CLAUDE_PROJECT_DIR: projectDir,
+    };
+    delete env.CLAUDE_SESSION_ID;
+
+    const res = spawnSync('node', [PRE_COMPACT], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PreCompact',
+        cwd: projectDir,
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+      const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
+      assert.strictEqual(updated.compactions.length, 1, 'the compaction marker landed');
+      assert.deepStrictEqual(
+        updated.userMessageContent,
+        ['carried prose'],
+        'main() must pass the project root through — an opted-in record keeps its prose',
       );
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });

--- a/hooks/__tests__/pre-compact.test.js
+++ b/hooks/__tests__/pre-compact.test.js
@@ -117,7 +117,7 @@ describe('pre-compact: updateSessionFile', () => {
       '2025-01-15',
       '2025-01-15T10:30:00Z',
       'session-prune-off',
-      projectRootWithLearning(false),
+      { projectRoot: projectRootWithLearning(false) },
     );
     assert.strictEqual(result, true);
 
@@ -135,13 +135,9 @@ describe('pre-compact: updateSessionFile', () => {
     const { updateSessionFile } = require('../pre-compact/main');
     const sessionFile = seedRecordWithProse('session-prune-on');
 
-    updateSessionFile(
-      'test-project',
-      '2025-01-15',
-      '2025-01-15T10:30:00Z',
-      'session-prune-on',
-      projectRootWithLearning(true),
-    );
+    updateSessionFile('test-project', '2025-01-15', '2025-01-15T10:30:00Z', 'session-prune-on', {
+      projectRoot: projectRootWithLearning(true),
+    });
 
     const updated = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
     assert.deepStrictEqual(
@@ -411,6 +407,212 @@ describe('pre-compact: diary-capture fixture (ICL-8)', () => {
         updated.userMessageContent,
         ['carried prose'],
         'main() must pass the project root through — an opted-in record keeps its prose',
+      );
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------
+  // Draft freshness. The draft is rendered from the session record by a
+  // subprocess, so a compaction that reaches the threshold before any Stop has
+  // closed the record must stamp the CURRENT counts and paths BEFORE the draft
+  // is generated. Stamping afterwards produced a draft reporting 0 messages and
+  // 0 tool calls for the very compaction the hook logged as 12 msgs / 55 tools.
+  // -------------------------------------------------------------------
+
+  const TODAY = new Date().toISOString().split('T')[0];
+
+  /** A record holding an earlier turn's counts and no touched paths. */
+  function seedStaleRecord(project) {
+    const sessionDir = path.join(homeDir, '.arcforge', 'sessions', project, TODAY);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const sessionFile = path.join(sessionDir, `session-${sessionId}.json`);
+    fs.writeFileSync(
+      sessionFile,
+      JSON.stringify({
+        project,
+        date: TODAY,
+        sessionId: `session-${sessionId}`,
+        started: new Date().toISOString(),
+        lastUpdated: new Date().toISOString(),
+        userMessages: 0,
+        toolCalls: 0,
+        filesModified: [],
+        compactions: [],
+      }),
+    );
+    return sessionFile;
+  }
+
+  /** A harness transcript carrying user prose plus Edit/Write tool uses. */
+  function writeTranscript() {
+    const transcriptPath = path.join(homeDir, 'transcript.jsonl');
+    const entry = (o) => JSON.stringify(o);
+    fs.writeFileSync(
+      transcriptPath,
+      `${[
+        entry({
+          type: 'user',
+          message: { role: 'user', content: [{ type: 'text', text: 'ship the fix' }] },
+        }),
+        entry({
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', name: 'Edit', input: { file_path: '/repo/src/alpha.js' } },
+            ],
+          },
+        }),
+        entry({
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', name: 'Write', input: { file_path: '/repo/src/beta.js' } },
+            ],
+          },
+        }),
+      ].join('\n')}\n`,
+    );
+    return transcriptPath;
+  }
+
+  /** Spawn the real hook on an above-threshold PreCompact carrying a transcript. */
+  function compactAboveThreshold(projectDir) {
+    fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\ncat > /dev/null\nexit 0\n', {
+      mode: 0o755,
+    });
+    fs.writeFileSync(counterPath('user-count'), '12');
+    fs.writeFileSync(counterPath('tool-count'), '55');
+
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      TMPDIR: tmpDir,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      CLAUDE_PROJECT_DIR: projectDir,
+    };
+    delete env.CLAUDE_SESSION_ID;
+
+    return spawnSync('node', [PRE_COMPACT], {
+      input: JSON.stringify({
+        session_id: sessionId,
+        hook_event_name: 'PreCompact',
+        transcript_path: writeTranscript(),
+        cwd: projectDir,
+      }),
+      encoding: 'utf-8',
+      env,
+    });
+  }
+
+  function readDraft(project) {
+    return fs.readFileSync(
+      path.join(
+        homeDir,
+        '.arcforge',
+        'diaries',
+        project,
+        TODAY,
+        `diary-session-${sessionId}-draft.md`,
+      ),
+      'utf-8',
+    );
+  }
+
+  function readRecord(project) {
+    return JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, '.arcforge', 'sessions', project, TODAY, `session-${sessionId}.json`),
+        'utf-8',
+      ),
+    );
+  }
+
+  it('above threshold: the draft renders this compaction, not the stale record', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-fresh-proj-'));
+    const project = path.basename(projectDir);
+    seedStaleRecord(project);
+
+    const res = compactAboveThreshold(projectDir);
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+      const draft = readDraft(project);
+      assert.match(draft, /\*\*User messages\*\*: 12/, 'draft reports the live message count');
+      assert.match(draft, /\*\*Tool calls\*\*: 55/, 'draft reports the live tool count');
+      assert.match(
+        draft,
+        /\*\*Files modified\*\*: .*alpha\.js.*beta\.js/,
+        'draft lists the paths this compaction touched',
+      );
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('above threshold: the record is stamped with the same counts and paths', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-stamp-proj-'));
+    const project = path.basename(projectDir);
+    seedStaleRecord(project);
+
+    const res = compactAboveThreshold(projectDir);
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+      const record = readRecord(project);
+      assert.strictEqual(record.userMessages, 12, 'record carries the live message count');
+      assert.strictEqual(record.toolCalls, 55, 'record carries the live tool count');
+      assert.deepStrictEqual(
+        record.filesModified,
+        ['/repo/src/alpha.js', '/repo/src/beta.js'],
+        'record carries the transcript-derived paths',
+      );
+      assert.deepStrictEqual(record.toolsUsed, ['Edit', 'Write'], 'tool names are continuity');
+      assert.strictEqual(record.compactions.length, 1, 'the compaction marker still lands');
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  // The stamp is a new WRITE path for prose — PreCompact previously only ever
+  // pruned it — so the gate is pinned in both directions (D-010 / B-6).
+  it('learning off: the stamp writes counts and paths but never the user prose', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-gate-off-proj-'));
+    const project = path.basename(projectDir);
+    seedStaleRecord(project);
+    // No learning config anywhere — the default.
+
+    const res = compactAboveThreshold(projectDir);
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+      const record = readRecord(project);
+      assert.strictEqual(
+        record.userMessageContent,
+        undefined,
+        'a compaction must not write verbatim prose while the opt-in is off',
+      );
+      assert.strictEqual(record.userMessages, 12, 'the count is continuity and lands either way');
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('learning on: the stamp includes the verbatim user prose', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-gate-on-proj-'));
+    const project = path.basename(projectDir);
+    enableLearning(projectDir);
+    seedStaleRecord(project);
+
+    const res = compactAboveThreshold(projectDir);
+
+    try {
+      assert.strictEqual(res.status, 0, res.stderr);
+      assert.deepStrictEqual(
+        readRecord(project).userMessageContent,
+        ['ship the fix'],
+        'with the opt-in on the compaction records what the transcript parsed',
       );
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });

--- a/hooks/__tests__/session-tracker-end.test.js
+++ b/hooks/__tests__/session-tracker-end.test.js
@@ -115,16 +115,21 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
   const originalEnv = { ...process.env };
   let tmpDir;
   let homeDir;
+  let binDir;
   const sessionId = 'v5-transcript-gate';
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'v5-tg-tmp-'));
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'v5-tg-home-'));
+    binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'v5-tg-bin-'));
+    // Stub `claude` so an opted-in Stop never launches the real enricher.
+    fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\ncat > /dev/null\n', { mode: 0o755 });
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-    fs.rmSync(homeDir, { recursive: true, force: true });
+    for (const dir of [tmpDir, homeDir, binDir]) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
     for (const key of Object.keys(process.env)) delete process.env[key];
     Object.assign(process.env, originalEnv);
   });
@@ -140,6 +145,37 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
     fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
   }
 
+  /** Turn the project-scope learning opt-in explicitly OFF for a project dir. */
+  function disableLearning(projectDir) {
+    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: false }));
+  }
+
+  /** Reseed the shared counters so a second Stop lands where the test wants it. */
+  function seedCounts(toolCount, userCount) {
+    fs.writeFileSync(counterPath('tool-count'), String(toolCount));
+    fs.writeFileSync(counterPath('user-count'), String(userCount));
+  }
+
+  /** A transcript with one user sentence and one Edit tool call. */
+  function writeTranscript(name, sentence) {
+    const transcript = path.join(tmpDir, name);
+    fs.writeFileSync(
+      transcript,
+      `${[
+        JSON.stringify({ type: 'user', content: sentence }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', name: 'Edit', input: { file_path: '/tmp/foo.ts' } }],
+          },
+        }),
+      ].join('\n')}\n`,
+    );
+    return transcript;
+  }
+
   function runStop(projectDir, transcriptPath) {
     return spawnSync('node', [END], {
       input: JSON.stringify({
@@ -149,7 +185,13 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
         transcript_path: transcriptPath,
       }),
       encoding: 'utf-8',
-      env: { ...process.env, HOME: homeDir, TMPDIR: tmpDir, CLAUDE_PROJECT_DIR: projectDir },
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_PROJECT_DIR: projectDir,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      },
     });
   }
 
@@ -252,6 +294,89 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
       session.filesModified,
       ['/tmp/foo.ts'],
       'filesModified still recorded — the diary Files-modified line depends on it',
+    );
+  });
+
+  // -------------------------------------------------------------------
+  // D-010 retention: the opt-in governs how long prose may STAY, not only
+  // whether it is written. The session record is reloaded and rewritten on
+  // every Stop, so a gate that only skipped the assignment would keep
+  // re-serializing prose captured before the user opted out.
+  // -------------------------------------------------------------------
+  it('learning ON above threshold, then OFF above threshold: prose is removed, not merely not rewritten', () => {
+    const projectDir = path.join(homeDir, 'v5tg-optout-high');
+    fs.mkdirSync(projectDir, { recursive: true });
+    enableLearning(projectDir);
+
+    seedCounts(60, 0);
+    const first = runStop(projectDir, writeTranscript('t1.jsonl', 'a secret sentence'));
+    assert.strictEqual(first.status, 0, first.stderr);
+    assert.deepStrictEqual(savedSession(projectDir).userMessageContent, ['a secret sentence']);
+
+    disableLearning(projectDir);
+    seedCounts(60, 0);
+    const second = runStop(projectDir, writeTranscript('t2.jsonl', 'another sentence'));
+    assert.strictEqual(second.status, 0, second.stderr);
+
+    const session = savedSession(projectDir);
+    assert.strictEqual(
+      session.userMessageContent,
+      undefined,
+      'prose captured under the opt-in must be deleted once it is withdrawn',
+    );
+    assert.deepStrictEqual(
+      session.toolsUsed,
+      ['Edit'],
+      'tool names are continuity, still recorded',
+    );
+    assert.deepStrictEqual(session.filesModified, ['/tmp/foo.ts'], 'paths still recorded');
+  });
+
+  it('learning ON above threshold, then OFF below threshold: prose is removed, tool names carry forward', () => {
+    const projectDir = path.join(homeDir, 'v5tg-optout-low');
+    fs.mkdirSync(projectDir, { recursive: true });
+    enableLearning(projectDir);
+
+    seedCounts(60, 0);
+    const first = runStop(projectDir, writeTranscript('t1.jsonl', 'a secret sentence'));
+    assert.strictEqual(first.status, 0, first.stderr);
+    assert.deepStrictEqual(savedSession(projectDir).userMessageContent, ['a secret sentence']);
+
+    disableLearning(projectDir);
+    seedCounts(3, 2);
+    const second = runStop(projectDir, writeTranscript('t2.jsonl', 'another sentence'));
+    assert.strictEqual(second.status, 0, second.stderr);
+
+    const session = savedSession(projectDir);
+    assert.strictEqual(
+      session.userMessageContent,
+      undefined,
+      'a below-threshold Stop must prune too — it rewrites the record just the same',
+    );
+    assert.deepStrictEqual(
+      session.toolsUsed,
+      ['Edit'],
+      'toolsUsed keeps its documented carry-forward — it is continuity, not prose',
+    );
+  });
+
+  it('learning stays ON: a below-threshold Stop keeps the prose an earlier parse wrote', () => {
+    const projectDir = path.join(homeDir, 'v5tg-stays-on');
+    fs.mkdirSync(projectDir, { recursive: true });
+    enableLearning(projectDir);
+
+    seedCounts(60, 0);
+    const first = runStop(projectDir, writeTranscript('t1.jsonl', 'a secret sentence'));
+    assert.strictEqual(first.status, 0, first.stderr);
+
+    seedCounts(3, 2);
+    const second = runStop(projectDir, writeTranscript('t2.jsonl', 'another sentence'));
+    assert.strictEqual(second.status, 0, second.stderr);
+
+    assert.deepStrictEqual(
+      savedSession(projectDir).userMessageContent,
+      ['a secret sentence'],
+      'with learning on the carry-forward hooks.md documents is unchanged',
     );
   });
 });

--- a/hooks/__tests__/session-tracker-end.test.js
+++ b/hooks/__tests__/session-tracker-end.test.js
@@ -255,3 +255,109 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// D-009: the reflection nudge is behind the same opt-in as the enrichment it
+// follows. Reflection IS the learning loop, and with learning off the diaries
+// it counts are permanent stubs — an ungated nudge would recur at every Stop
+// above the threshold, forever, about work the user declined.
+// ---------------------------------------------------------------------------
+
+describe('Stop reflect-ready nudge gate (D-009)', () => {
+  const originalEnv = { ...process.env };
+  let tmpDir;
+  let homeDir;
+  let binDir;
+  const sessionId = 'reflect-gate';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reflect-gate-tmp-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reflect-gate-home-'));
+    binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reflect-gate-bin-'));
+    // Stub `claude` so the opted-in case never launches the real enricher.
+    fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\ncat > /dev/null\n', { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    for (const dir of [tmpDir, homeDir, binDir]) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  });
+
+  /** Turn the project-scope learning opt-in on for a project dir. */
+  function enableLearning(projectDir) {
+    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+  }
+
+  /** Three unprocessed diaries — REFLECT_READY_MIN_DIARIES. */
+  function seedDiaries(project) {
+    const dir = path.join(homeDir, '.arcforge', 'diaries', project, '2026-09-01');
+    fs.mkdirSync(dir, { recursive: true });
+    for (const name of ['a', 'b', 'c']) {
+      fs.writeFileSync(path.join(dir, `diary-session-${name}.md`), '# Diary\n');
+    }
+  }
+
+  function pendingReflectActions(project) {
+    const file = path.join(homeDir, '.arcforge', 'sessions', project, 'pending-actions.json');
+    if (!fs.existsSync(file)) return [];
+    const { actions = [] } = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    return actions.filter((a) => a.type === 'reflect-ready');
+  }
+
+  /** Run a Stop above the diary threshold, so the nudge is even considered. */
+  function runStop(projectDir) {
+    fs.writeFileSync(path.join(tmpDir, `arcforge-user-count-session-${sessionId}`), '15');
+    fs.writeFileSync(path.join(tmpDir, `arcforge-tool-count-session-${sessionId}`), '0');
+    return spawnSync('node', [END], {
+      input: JSON.stringify({ session_id: sessionId, hook_event_name: 'Stop', cwd: projectDir }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_PROJECT_DIR: projectDir,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+  }
+
+  function makeProject(name) {
+    const projectDir = path.join(homeDir, name);
+    fs.mkdirSync(projectDir, { recursive: true });
+    seedDiaries(path.basename(projectDir));
+    return projectDir;
+  }
+
+  it('learning off: no reflect-ready nudge, however many diaries pile up', () => {
+    const projectDir = makeProject('reflect-off');
+
+    const res = runStop(projectDir);
+    assert.strictEqual(res.status, 0, res.stderr);
+    // Guard against a vacuous pass: this Stop really was above the threshold,
+    // so the nudge was considered and declined, not skipped upstream.
+    assert.ok(res.stdout.includes('Session paused'), `expected a triggered Stop: ${res.stdout}`);
+    assert.deepStrictEqual(
+      pendingReflectActions(path.basename(projectDir)),
+      [],
+      'reflect-ready must not be queued while learning is off',
+    );
+  });
+
+  it('learning on: the nudge is queued as before', () => {
+    const projectDir = makeProject('reflect-on');
+    enableLearning(projectDir);
+
+    const res = runStop(projectDir);
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.strictEqual(
+      pendingReflectActions(path.basename(projectDir)).length,
+      1,
+      'reflect-ready is queued once learning is on',
+    );
+  });
+});

--- a/hooks/__tests__/session-tracker-end.test.js
+++ b/hooks/__tests__/session-tracker-end.test.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const os = require('node:os');
 const { spawnSync } = require('node:child_process');
 
-const { calculateDurationMinutes } = require('../session-tracker/end');
+const { calculateDurationMinutes } = require('../../scripts/lib/diary-capture');
 
 const END = path.join(__dirname, '..', 'session-tracker', 'end.js');
 

--- a/hooks/__tests__/session-tracker-end.test.js
+++ b/hooks/__tests__/session-tracker-end.test.js
@@ -133,6 +133,13 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
     return path.join(tmpDir, `arcforge-${name}-session-${sessionId}`);
   }
 
+  /** Turn the project-scope learning opt-in on for a project dir. */
+  function enableLearning(projectDir) {
+    const configPath = path.join(projectDir, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+  }
+
   function runStop(projectDir, transcriptPath) {
     return spawnSync('node', [END], {
       input: JSON.stringify({
@@ -183,7 +190,7 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
     assert.deepStrictEqual(session.filesModified, [], 'filesModified defaults to empty');
   });
 
-  it('above threshold: transcript IS parsed → enrichment present in session JSON', () => {
+  it('above threshold + learning ON: transcript IS parsed → enrichment present in session JSON', () => {
     fs.writeFileSync(counterPath('tool-count'), '60');
     fs.writeFileSync(counterPath('user-count'), '0');
 
@@ -192,6 +199,7 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
 
     const projectDir = path.join(homeDir, 'v5tg-high');
     fs.mkdirSync(projectDir, { recursive: true });
+    enableLearning(projectDir);
 
     const res = runStop(projectDir, transcript);
     assert.strictEqual(res.status, 0, res.stderr);
@@ -201,6 +209,49 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
       session.userMessageContent,
       ['hello there'],
       'above threshold enriches userMessageContent from the transcript',
+    );
+  });
+
+  // ---------------------------------------------------------------------
+  // D-010: capture depth. Counts, tool names and paths are continuity and
+  // stay always-on; verbatim user prose waits for the learning opt-in.
+  // ---------------------------------------------------------------------
+  it('above threshold + learning OFF: keeps filesModified/toolsUsed, drops user prose', () => {
+    fs.writeFileSync(counterPath('tool-count'), '60');
+    fs.writeFileSync(counterPath('user-count'), '0');
+
+    const transcript = path.join(tmpDir, 'transcript.jsonl');
+    fs.writeFileSync(
+      transcript,
+      [
+        JSON.stringify({ type: 'user', content: 'a secret sentence' }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', name: 'Edit', input: { file_path: '/tmp/foo.ts' } }],
+          },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const projectDir = path.join(homeDir, 'v5tg-off');
+    fs.mkdirSync(projectDir, { recursive: true });
+    // No learning config anywhere — the default.
+
+    const res = runStop(projectDir, transcript);
+    assert.strictEqual(res.status, 0, res.stderr);
+
+    const session = savedSession(projectDir);
+    assert.strictEqual(
+      session.userMessageContent,
+      undefined,
+      'user prose must NOT be stored with learning off',
+    );
+    assert.deepStrictEqual(session.toolsUsed, ['Edit'], 'tool names still recorded');
+    assert.deepStrictEqual(
+      session.filesModified,
+      ['/tmp/foo.ts'],
+      'filesModified still recorded — the diary Files-modified line depends on it',
     );
   });
 });

--- a/hooks/__tests__/session-tracker-end.test.js
+++ b/hooks/__tests__/session-tracker-end.test.js
@@ -223,7 +223,7 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
     const transcript = path.join(tmpDir, 'transcript.jsonl');
     fs.writeFileSync(
       transcript,
-      [
+      `${[
         JSON.stringify({ type: 'user', content: 'a secret sentence' }),
         JSON.stringify({
           type: 'assistant',
@@ -231,7 +231,7 @@ describe('Stop transcript-parse threshold gate (v5)', () => {
             content: [{ type: 'tool_use', name: 'Edit', input: { file_path: '/tmp/foo.ts' } }],
           },
         }),
-      ].join('\n') + '\n',
+      ].join('\n')}\n`,
     );
 
     const projectDir = path.join(homeDir, 'v5tg-off');

--- a/hooks/observe/main.js
+++ b/hooks/observe/main.js
@@ -63,7 +63,7 @@ const {
   getObserverSignalFile,
   getObserverPidFile,
 } = require('../../scripts/lib/session-utils');
-const { getProjectId, isLearningEnabled } = require('../../scripts/lib/learning');
+const { getProjectId, isLearningEnabledAnyScope } = require('../../scripts/lib/learning');
 const {
   sanitizeObservationPayload,
   EVIDENCE_STATUS,
@@ -118,10 +118,7 @@ function shouldObserve({
     if (process.env.ARCFORGE_OBSERVE_EXPLICIT_SKIP === '1') return false;
     if (process.env.ARCFORGE_OBSERVE_SELF_ANALYSIS === '1') return false;
     if (isSkippedPath(projectRoot)) return false;
-    return (
-      isLearningEnabled({ scope: 'project', projectRoot, homeDir }) ||
-      isLearningEnabled({ scope: 'global', projectRoot, homeDir })
-    );
+    return isLearningEnabledAnyScope({ projectRoot, homeDir });
   } catch {
     return false;
   }

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -15,8 +15,12 @@ diary when the threshold is met.
 3. **Threshold-triggered behavior** (when `userCount >= 10 OR toolCount >= 50`):
    Delegates to the shared diary-capture core (`scripts/lib/diary-capture.js`),
    the same path the Stop hook runs:
-   - Generates the auto-diary draft
-   - Spawns the background diary enricher (dual path — Stop AND PreCompact)
+   - Generates the auto-diary draft (always — it is built from counts)
+   - Spawns the background diary enricher **only when learning is enabled in
+     some scope** (dual path — Stop AND PreCompact). With learning off the
+     draft keeps its `TO BE ENRICHED` stubs; that is the contract, not a
+     failure. `projectRoot` is passed explicitly so the opt-in is read from the
+     project, not from the compaction cwd.
    - Resets both counters (the sole reset path)
 
    Then it queues a `diary-ready` pending action for the next `SessionStart`.

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -15,7 +15,8 @@ diary when the threshold is met.
 3. **Threshold-triggered behavior** (when `userCount >= 10 OR toolCount >= 50`):
    Delegates to the shared diary-capture core (`scripts/lib/diary-capture.js`),
    the same path the Stop hook runs:
-   - Generates the auto-diary draft (always — it is built from counts)
+   - Generates the auto-diary draft (always — it is built from the session
+     record's metadata, none of which the opt-in gates)
    - Spawns the background diary enricher **only when learning is enabled in
      some scope** (dual path — Stop AND PreCompact). With learning off the
      draft keeps its `TO BE ENRICHED` stubs; that is the contract, not a

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -11,16 +11,28 @@ diary when the threshold is met.
 2. **Updates the current session file** with compaction markers
    - Adds timestamp to `compactions` array
    - Sets `lastCompaction` field
-   - Deletes `userMessageContent` when the learning opt-in reads off. Stamping
-     the marker rewrites the whole record, so the gate that governs capture
-     governs what survives the rewrite (D-010); an absent project root reads as
-     no consent and prunes.
+   - Above the diary threshold, stamps *this* compaction's counts
+     (`userMessages`, `toolCalls`) and — when the PreCompact payload carries a
+     `transcript_path` — the `toolsUsed` and `filesModified` that transcript
+     parses to, reusing the same shared stamp the Stop hook runs. This happens
+     **before** the draft is generated in step 3, because the draft is rendered
+     from the record: a compaction that reaches the threshold before any Stop
+     has closed the record would otherwise report the previous turn's numbers
+     and none of the paths it touched. With nothing to parse, the record keeps
+     the paths an earlier Stop wrote rather than being blanked. Below the
+     threshold nothing is stamped and the transcript is never parsed — no draft
+     is rendered there, so the parse would be wasted work on the compaction path.
+   - Writes `userMessageContent` only while the learning opt-in reads on, and
+     deletes it when it reads off. Stamping the marker rewrites the whole
+     record, so the gate that governs capture governs what survives the rewrite
+     (D-010); an absent project root reads as no consent and prunes.
 
 3. **Threshold-triggered behavior** (when `userCount >= 10 OR toolCount >= 50`):
    Delegates to the shared diary-capture core (`scripts/lib/diary-capture.js`),
    the same path the Stop hook runs:
    - Generates the auto-diary draft (always — it is built from the session
-     record's metadata, none of which the opt-in gates)
+     record's metadata, none of which the opt-in gates, and step 2 has just
+     refreshed it)
    - Spawns the background diary enricher **only when learning is enabled in
      some scope** (dual path — Stop AND PreCompact). With learning off the
      draft keeps its `TO BE ENRICHED` stubs; that is the contract, not a
@@ -62,6 +74,7 @@ After compaction, the session file includes:
   "lastUpdated": "2025-01-24T12:00:00.000Z",
   "toolCalls": 47,
   "userMessages": 15,
+  "toolsUsed": ["Read", "Edit"],
   "filesModified": ["src/foo.ts"],
   "compactions": [
     "2025-01-24T11:00:00.000Z",

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -34,10 +34,12 @@ diary when the threshold is met.
      record's metadata, none of which the opt-in gates, and step 2 has just
      refreshed it)
    - Spawns the background diary enricher **only when learning is enabled in
-     some scope** (dual path — Stop AND PreCompact). With learning off the
-     draft keeps its `TO BE ENRICHED` stubs; that is the contract, not a
-     failure. `projectRoot` is passed explicitly so the opt-in is read from the
-     project, not from the compaction cwd.
+     some scope** (dual path — Stop AND PreCompact), handing it the same
+     session summary the Stop hook builds — the prose, tool names, paths and
+     stats line of the record step 2 just stamped, not an empty object. With
+     learning off the draft keeps its `TO BE ENRICHED` stubs; that is the
+     contract, not a failure. `projectRoot` is passed explicitly so the opt-in
+     is read from the project, not from the compaction cwd.
    - Resets both counters (the sole reset path)
 
    Then it queues a `diary-ready` pending action for the next `SessionStart`.

--- a/hooks/pre-compact/README.md
+++ b/hooks/pre-compact/README.md
@@ -11,6 +11,10 @@ diary when the threshold is met.
 2. **Updates the current session file** with compaction markers
    - Adds timestamp to `compactions` array
    - Sets `lastCompaction` field
+   - Deletes `userMessageContent` when the learning opt-in reads off. Stamping
+     the marker rewrites the whole record, so the gate that governs capture
+     governs what survives the rewrite (D-010); an absent project root reads as
+     no consent and prunes.
 
 3. **Threshold-triggered behavior** (when `userCount >= 10 OR toolCount >= 50`):
    Delegates to the shared diary-capture core (`scripts/lib/diary-capture.js`),

--- a/hooks/pre-compact/main.js
+++ b/hooks/pre-compact/main.js
@@ -30,6 +30,7 @@ const {
   getSuggesterStatePath,
   pruneUngatedProse,
   applyTranscriptToSession,
+  buildSessionSummary,
 } = require('../../scripts/lib/diary-capture');
 const { shouldTrigger } = require('../../scripts/lib/thresholds');
 
@@ -74,14 +75,16 @@ function resetSuggesterState() {
  * @param {number} [opts.toolCount] - Live tool-call count, the pair of userCount.
  * @param {string} [opts.transcriptPath] - Harness transcript to parse for the
  *   tool names and touched paths of this compaction.
- * @returns {boolean}
+ * @returns {Object|null} The stamped record as written, or null when there was
+ *   no record to update. Returned rather than re-read because the caller hands
+ *   the same record to the enricher summary.
  */
 function updateSessionFile(project, date, timestamp, sessionId, opts = {}) {
   const { projectRoot, userCount, toolCount, transcriptPath } = opts;
   const sessionFile = path.join(getSessionDir(project, date), `${sessionId}.json`);
 
   const content = readFileSafe(sessionFile);
-  if (!content) return false;
+  if (!content) return null;
 
   try {
     const session = JSON.parse(content);
@@ -107,9 +110,9 @@ function updateSessionFile(project, date, timestamp, sessionId, opts = {}) {
     session.lastUpdated = timestamp;
 
     writeFileSafe(sessionFile, JSON.stringify(session, null, 2));
-    return true;
+    return session;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -147,7 +150,10 @@ function main() {
       : undefined;
 
     // Update session file with compaction marker (+ metrics, above threshold)
-    updateSessionFile(project, date, timestamp, sessionId, { projectRoot, ...metrics });
+    const session = updateSessionFile(project, date, timestamp, sessionId, {
+      projectRoot,
+      ...metrics,
+    });
 
     // Reset the compact-suggester state on EVERY compaction (unconditional,
     // independent of the diary threshold) so suggestions don't survive the
@@ -158,11 +164,18 @@ function main() {
     // → counter reset. Enricher fires on PreCompact too (dual-path ON).
     // projectRoot is passed explicitly: runDiaryCapture reads the learning
     // opt-in from it, and the compaction cwd is not a reliable stand-in.
+    //
+    // The enricher gets the same summary the Stop hook builds, from the record
+    // just stamped above — a compaction used to hand it nothing, so the draft's
+    // prose sections were enriched from an empty object. Built only when the
+    // stamp ran (above threshold), since that is the only case the enricher can
+    // fire; below it the summary would be work nothing reads.
     const { triggered } = runDiaryCapture({
       project,
       date,
       sessionId,
       projectRoot,
+      transcriptData: metrics && session ? buildSessionSummary(session) : undefined,
     });
 
     if (triggered) {

--- a/hooks/pre-compact/main.js
+++ b/hooks/pre-compact/main.js
@@ -22,15 +22,16 @@ const {
   readStdinSync,
   parseStdinJson,
   setSessionIdFromInput,
-  loadSession,
-  saveSession,
 } = require('../../scripts/lib/utils');
 const { addPendingAction } = require('../../scripts/lib/pending-actions');
 const {
   runDiaryCapture,
+  readCounts,
   getSuggesterStatePath,
   pruneUngatedProse,
+  applyTranscriptToSession,
 } = require('../../scripts/lib/diary-capture');
+const { shouldTrigger } = require('../../scripts/lib/thresholds');
 
 /**
  * Reset the compact-suggester state on every compaction.
@@ -50,18 +51,33 @@ function resetSuggesterState() {
 }
 
 /**
- * Update session file with compaction marker
+ * Update the session file with the compaction marker and, above the diary
+ * threshold, with the live metrics the draft is rendered from.
+ *
+ * Ordering is the point. The draft generator re-reads this file in a subprocess,
+ * so anything the draft must show has to land here BEFORE runDiaryCapture runs.
+ * Stamping afterwards is what produced a draft reporting the counts of whatever
+ * the record last held — 0 messages / 0 tool calls on a record no Stop had
+ * closed yet — while the record itself was corrected a moment later.
  *
  * @param {string} project
  * @param {string} date
  * @param {string} timestamp
  * @param {string} sessionId
- * @param {string} [projectRoot] - Project root whose learning opt-in governs
+ * @param {Object} [opts]
+ * @param {string} [opts.projectRoot] - Project root whose learning opt-in governs
  *   whether carried user prose may survive this rewrite. Omitted means no
  *   consent, so the prose is pruned.
+ * @param {number} [opts.userCount] - Live user-message count; stamped together
+ *   with toolCount and passed as a pair. Omitted (below the threshold, where no
+ *   draft is rendered) leaves the record's counts alone.
+ * @param {number} [opts.toolCount] - Live tool-call count, the pair of userCount.
+ * @param {string} [opts.transcriptPath] - Harness transcript to parse for the
+ *   tool names and touched paths of this compaction.
  * @returns {boolean}
  */
-function updateSessionFile(project, date, timestamp, sessionId, projectRoot) {
+function updateSessionFile(project, date, timestamp, sessionId, opts = {}) {
+  const { projectRoot, userCount, toolCount, transcriptPath } = opts;
   const sessionFile = path.join(getSessionDir(project, date), `${sessionId}.json`);
 
   const content = readFileSafe(sessionFile);
@@ -70,8 +86,21 @@ function updateSessionFile(project, date, timestamp, sessionId, projectRoot) {
   try {
     const session = JSON.parse(content);
     // The compaction marker rewrites the whole record, so the same opt-in that
-    // governs capture governs what survives here (D-010).
-    pruneUngatedProse(session, { projectRoot });
+    // governs capture governs what survives here (D-010) — and, when the
+    // metrics below are stamped, whether this compaction may write prose at all.
+    const learningOn = pruneUngatedProse(session, { projectRoot });
+
+    // Counts and paths are continuity and are stamped either way; verbatim
+    // prose only under the opt-in. A transcript the harness did not hand us (or
+    // one that parses to nothing) leaves the record's existing paths alone —
+    // blanking paths an earlier Stop wrote would make the draft worse, not
+    // fresher.
+    if (typeof userCount === 'number') {
+      session.userMessages = userCount;
+      session.toolCalls = toolCount;
+      applyTranscriptToSession(session, transcriptPath, { learningOn });
+    }
+
     session.compactions = session.compactions || [];
     session.compactions.push(timestamp);
     session.lastCompaction = timestamp;
@@ -106,8 +135,19 @@ function main() {
 
     const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
 
-    // Update session file with compaction marker
-    updateSessionFile(project, date, timestamp, sessionId, projectRoot);
+    // One counter read serves the stamp, the notification and the log line.
+    const { userCount, toolCount } = readCounts();
+
+    // Above the threshold this compaction is about to render a draft, so the
+    // record it renders from is refreshed first. Below it there is no draft, so
+    // the transcript is not parsed at all — the compaction path keeps the same
+    // "don't parse what nothing reads" discipline the Stop hook does.
+    const metrics = shouldTrigger(userCount, toolCount)
+      ? { userCount, toolCount, transcriptPath: input?.transcript_path }
+      : undefined;
+
+    // Update session file with compaction marker (+ metrics, above threshold)
+    updateSessionFile(project, date, timestamp, sessionId, { projectRoot, ...metrics });
 
     // Reset the compact-suggester state on EVERY compaction (unconditional,
     // independent of the diary threshold) so suggestions don't survive the
@@ -118,7 +158,7 @@ function main() {
     // → counter reset. Enricher fires on PreCompact too (dual-path ON).
     // projectRoot is passed explicitly: runDiaryCapture reads the learning
     // opt-in from it, and the compaction cwd is not a reliable stand-in.
-    const { triggered, userCount, toolCount } = runDiaryCapture({
+    const { triggered } = runDiaryCapture({
       project,
       date,
       sessionId,
@@ -126,14 +166,6 @@ function main() {
     });
 
     if (triggered) {
-      // Stamp the current counts onto the session file.
-      const session = loadSession();
-      if (session) {
-        session.userMessages = userCount;
-        session.toolCalls = toolCount;
-        saveSession(session);
-      }
-
       // Queue notification for next SessionStart (PreCompact stdout doesn't render systemMessage)
       addPendingAction(project, 'diary-ready', {
         trigger: 'compaction',

--- a/hooks/pre-compact/main.js
+++ b/hooks/pre-compact/main.js
@@ -26,7 +26,11 @@ const {
   saveSession,
 } = require('../../scripts/lib/utils');
 const { addPendingAction } = require('../../scripts/lib/pending-actions');
-const { runDiaryCapture, getSuggesterStatePath } = require('../../scripts/lib/diary-capture');
+const {
+  runDiaryCapture,
+  getSuggesterStatePath,
+  pruneUngatedProse,
+} = require('../../scripts/lib/diary-capture');
 
 /**
  * Reset the compact-suggester state on every compaction.
@@ -47,8 +51,17 @@ function resetSuggesterState() {
 
 /**
  * Update session file with compaction marker
+ *
+ * @param {string} project
+ * @param {string} date
+ * @param {string} timestamp
+ * @param {string} sessionId
+ * @param {string} [projectRoot] - Project root whose learning opt-in governs
+ *   whether carried user prose may survive this rewrite. Omitted means no
+ *   consent, so the prose is pruned.
+ * @returns {boolean}
  */
-function updateSessionFile(project, date, timestamp, sessionId) {
+function updateSessionFile(project, date, timestamp, sessionId, projectRoot) {
   const sessionFile = path.join(getSessionDir(project, date), `${sessionId}.json`);
 
   const content = readFileSafe(sessionFile);
@@ -56,6 +69,9 @@ function updateSessionFile(project, date, timestamp, sessionId) {
 
   try {
     const session = JSON.parse(content);
+    // The compaction marker rewrites the whole record, so the same opt-in that
+    // governs capture governs what survives here (D-010).
+    pruneUngatedProse(session, { projectRoot });
     session.compactions = session.compactions || [];
     session.compactions.push(timestamp);
     session.lastCompaction = timestamp;
@@ -88,8 +104,10 @@ function main() {
     const sessionId = getSessionId();
     const timestamp = getTimestamp();
 
+    const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
     // Update session file with compaction marker
-    updateSessionFile(project, date, timestamp, sessionId);
+    updateSessionFile(project, date, timestamp, sessionId, projectRoot);
 
     // Reset the compact-suggester state on EVERY compaction (unconditional,
     // independent of the diary threshold) so suggestions don't survive the
@@ -100,7 +118,6 @@ function main() {
     // → counter reset. Enricher fires on PreCompact too (dual-path ON).
     // projectRoot is passed explicitly: runDiaryCapture reads the learning
     // opt-in from it, and the compaction cwd is not a reliable stand-in.
-    const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
     const { triggered, userCount, toolCount } = runDiaryCapture({
       project,
       date,

--- a/hooks/pre-compact/main.js
+++ b/hooks/pre-compact/main.js
@@ -98,7 +98,15 @@ function main() {
 
     // Shared diary-capture core: threshold gate → draft → background enricher
     // → counter reset. Enricher fires on PreCompact too (dual-path ON).
-    const { triggered, userCount, toolCount } = runDiaryCapture({ project, date, sessionId });
+    // projectRoot is passed explicitly: runDiaryCapture reads the learning
+    // opt-in from it, and the compaction cwd is not a reliable stand-in.
+    const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+    const { triggered, userCount, toolCount } = runDiaryCapture({
+      project,
+      date,
+      sessionId,
+      projectRoot,
+    });
 
     if (triggered) {
       // Stamp the current counts onto the session file.

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -44,8 +44,10 @@ across sessions until the threshold is met; reset is owned exclusively by
 - Saves session metrics (duration, tool calls)
 - Records modified files and tool names from transcript parsing (parseTranscript)
 - Stores verbatim recent user messages (`userMessageContent`) **only when
-  learning is enabled in some scope** — the parse itself is unconditional, so
-  the metadata above is recorded either way
+  learning is enabled in some scope**, and removes the field from the record when
+  it is not, so prose captured under an earlier opt-in does not survive the
+  opt-out — the parse itself is unconditional, so the metadata above is recorded
+  either way
 - Runs diary-capture (threshold-gated draft + counter reset; the enricher spawn
   is behind the same learning opt-in)
 - Queues the `reflect-ready` nudge **only when learning is enabled in some
@@ -96,7 +98,9 @@ Sessions stored in `~/.arcforge/sessions/{project}/{date}/` as JSON:
 
 Every field above is continuity and is written regardless of the learning
 opt-in. One field is not: `userMessageContent` — the last 10 user messages,
-each truncated — is added only when learning is enabled in some scope.
+each truncated — is added only when learning is enabled in some scope, and is
+removed again the first time a Stop or a compaction stamps the record with
+learning off.
 
 ## Output Examples
 

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -48,6 +48,10 @@ across sessions until the threshold is met; reset is owned exclusively by
   the metadata above is recorded either way
 - Runs diary-capture (threshold-gated draft + counter reset; the enricher spawn
   is behind the same learning opt-in)
+- Queues the `reflect-ready` nudge **only when learning is enabled in some
+  scope** — reflection is the learning loop, and with learning off the diaries
+  it counts never get processed, so the nudge would re-queue at every threshold
+  hit forever
 - Outputs session summary
 
 ## Triggers

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -103,7 +103,8 @@ Sessions stored in `~/.arcforge/sessions/{project}/{date}/` as JSON:
   "filesModified": [
     "src/foo.ts",
     "tests/foo.test.ts"
-  ]
+  ],
+  "compactions": []
 }
 ```
 
@@ -111,11 +112,14 @@ Every field above is continuity: the learning opt-in never gates any of them.
 The diary threshold does gate the two the transcript supplies — `toolsUsed` and
 `filesModified` are refreshed only on a Stop or compaction that hits the
 threshold, and below it a Stop clears `filesModified` and leaves `toolsUsed` as
-an earlier parse wrote it. One field is missing from the block above because it
-is not continuity: `userMessageContent` — the last 10 user messages, each
-truncated — is written on that same threshold hit and only when learning is
-enabled in some scope, and is removed again, at any threshold, the first time a
-Stop or a compaction stamps the record with learning off.
+an earlier parse wrote it. `compactions` is seeded empty here; the PreCompact
+hook appends to it and documents the populated shape. Other hooks stamp their
+own fields into the same record and document those themselves.
+One field is deliberately absent because it is not continuity:
+`userMessageContent` — the last 10 user messages, each truncated — is written
+on that same threshold hit and only when learning is enabled in some scope, and
+is removed again, at any threshold, the first time a Stop or a compaction
+stamps the record with learning off.
 
 ## Output Examples
 

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -17,7 +17,10 @@ Provides session persistence and SessionStart context injection.
 Emits one combined JSON with two channels (see `hooks.md` → Output Visibility):
 
 - **additionalContext** (Claude-visible): activated behavioral instincts,
-  pending action notifications, stale-draft warnings.
+  pending action notifications, stale-draft warnings (only for drafts written
+  since the learning opt-in took effect — stubs from a learning-off period are
+  by design, so counting them would report the whole backlog the moment a user
+  opts in).
 - **systemMessage** (user-visible): a brief one-line summary, plus
   discoverability hints (available session aliases, recent global promotions).
 

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -39,8 +39,12 @@ across sessions until the threshold is met; reset is owned exclusively by
 
 ### On Session End (Stop) — `end.js`
 - Saves session metrics (duration, tool calls)
-- Records modified files from transcript parsing (parseTranscript)
-- Runs diary-capture (threshold-gated draft + counter reset)
+- Records modified files and tool names from transcript parsing (parseTranscript)
+- Stores verbatim recent user messages (`userMessageContent`) **only when
+  learning is enabled in some scope** — the parse itself is unconditional, so
+  the metadata above is recorded either way
+- Runs diary-capture (threshold-gated draft + counter reset; the enricher spawn
+  is behind the same learning opt-in)
 - Outputs session summary
 
 ## Triggers
@@ -74,12 +78,18 @@ Sessions stored in `~/.arcforge/sessions/{project}/{date}/` as JSON:
   "started": "2025-01-24T10:00:00.000Z",
   "lastUpdated": "2025-01-24T12:30:00.000Z",
   "toolCalls": 47,
+  "userMessages": 12,
+  "toolsUsed": ["Read", "Edit", "Bash"],
   "filesModified": [
     "src/foo.ts",
     "tests/foo.test.ts"
   ]
 }
 ```
+
+Every field above is continuity and is written regardless of the learning
+opt-in. One field is not: `userMessageContent` — the last 10 user messages,
+each truncated — is added only when learning is enabled in some scope.
 
 ## Output Examples
 

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -20,7 +20,12 @@ Emits one combined JSON with two channels (see `hooks.md` → Output Visibility)
   pending action notifications, stale-draft warnings (only for drafts written
   since the learning opt-in took effect — stubs from a learning-off period are
   by design, so counting them would report the whole backlog the moment a user
-  opts in).
+  opts in). A queued `reflect-ready` is dropped at delivery when learning is off
+  in both scopes, so disabling it between the queuing Stop and this SessionStart
+  retracts the invitation rather than spending it; the action is consumed either
+  way, so a suppressed nudge never resurfaces later with a stale count.
+  `diary-ready` is unaffected — it points at an artifact that exists and can be
+  read now.
 - **systemMessage** (user-visible): a brief one-line summary, plus
   discoverability hints (available session aliases, recent global promotions).
 

--- a/hooks/session-tracker/README.md
+++ b/hooks/session-tracker/README.md
@@ -47,12 +47,18 @@ across sessions until the threshold is met; reset is owned exclusively by
 
 ### On Session End (Stop) — `end.js`
 - Saves session metrics (duration, tool calls)
-- Records modified files and tool names from transcript parsing (parseTranscript)
-- Stores verbatim recent user messages (`userMessageContent`) **only when
-  learning is enabled in some scope**, and removes the field from the record when
-  it is not, so prose captured under an earlier opt-in does not survive the
-  opt-out — the parse itself is unconditional, so the metadata above is recorded
-  either way
+- **Above the diary threshold**, parses the transcript (`parseTranscript`) and
+  records the tool names and modified-file paths it yields. With nothing parsed
+  — below the threshold, or above it with no readable transcript — a Stop clears
+  `filesModified`, while `toolsUsed` is neither written nor cleared: a record an
+  earlier parse filled keeps that turn's tool list until a later parse refreshes
+  it
+- Stores verbatim recent user messages (`userMessageContent`) on that same
+  threshold hit, and then **only when learning is enabled in some scope**.
+  Removal is the half that is unconditional: every Stop drops the field when
+  learning reads off, above or below the threshold, so prose captured under an
+  earlier opt-in does not survive the opt-out, and an opt-out takes effect on the
+  next Stop either way
 - Runs diary-capture (threshold-gated draft + counter reset; the enricher spawn
   is behind the same learning opt-in)
 - Queues the `reflect-ready` nudge **only when learning is enabled in some
@@ -101,11 +107,15 @@ Sessions stored in `~/.arcforge/sessions/{project}/{date}/` as JSON:
 }
 ```
 
-Every field above is continuity and is written regardless of the learning
-opt-in. One field is not: `userMessageContent` — the last 10 user messages,
-each truncated — is added only when learning is enabled in some scope, and is
-removed again the first time a Stop or a compaction stamps the record with
-learning off.
+Every field above is continuity: the learning opt-in never gates any of them.
+The diary threshold does gate the two the transcript supplies — `toolsUsed` and
+`filesModified` are refreshed only on a Stop or compaction that hits the
+threshold, and below it a Stop clears `filesModified` and leaves `toolsUsed` as
+an earlier parse wrote it. One field is missing from the block above because it
+is not continuity: `userMessageContent` — the last 10 user messages, each
+truncated — is written on that same threshold hit and only when learning is
+enabled in some scope, and is removed again, at any threshold, the first time a
+Stop or a compaction stamps the record with learning off.
 
 ## Output Examples
 

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -182,12 +182,19 @@ function main() {
 
   const systemMessages = [];
   if (triggered) {
-    const reflectStatus = checkReflectReady(session.project);
-    if (reflectStatus?.ready) {
-      addPendingAction(session.project, 'reflect-ready', {
-        strategy: reflectStatus.strategy,
-        count: reflectStatus.count,
-      });
+    // The reflection nudge is behind the same opt-in as the enrichment it
+    // follows (D-009). Reflection IS the learning loop — learning.md B-1 says
+    // that loop does not run when learning is off — and the diaries it counts
+    // are permanent stubs in that state, so an ungated nudge would recur at
+    // every Stop above the threshold, forever, about work the user declined.
+    if (learningCaptureEnabled({ projectRoot })) {
+      const reflectStatus = checkReflectReady(session.project);
+      if (reflectStatus?.ready) {
+        addPendingAction(session.project, 'reflect-ready', {
+          strategy: reflectStatus.strategy,
+          count: reflectStatus.count,
+        });
+      }
     }
     // Only surface the 'Session paused' notification when the diary threshold
     // actually fired — a Stop worth telling the user about. Below threshold a

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -27,7 +27,7 @@ const { addPendingAction } = require('../../scripts/lib/pending-actions');
 const {
   runDiaryCapture,
   readCounts,
-  learningCaptureEnabled,
+  pruneUngatedProse,
 } = require('../../scripts/lib/diary-capture');
 const { shouldTrigger } = require('../../scripts/lib/thresholds');
 const { parseTranscript } = require('../../scripts/lib/transcript');
@@ -149,11 +149,19 @@ function main() {
   const transcriptData =
     shouldTrigger(userCount, toolCount) && transcriptPath ? parseTranscript(transcriptPath) : null;
 
+  // D-010 governs both halves: the opt-in decides whether prose is written AND
+  // whether prose an earlier, opted-in Stop wrote may stay. Pruning before the
+  // branch is what makes the second half true — the record is reloaded and
+  // rewritten on every Stop, so an ungated field would otherwise be
+  // re-serialized forever. The returned answer is the opt-in itself, so the
+  // reflect-ready gate below (D-009) reuses this one config read rather than
+  // asking again.
+  const learningOn = pruneUngatedProse(session, { projectRoot });
+
   if (transcriptData) {
     // Counts, tool names and paths are the continuity record and are kept
-    // either way. Verbatim user prose is not — it only lands in the session
-    // file once the learning opt-in is on (D-010).
-    if (learningCaptureEnabled({ projectRoot })) {
+    // either way. Verbatim user prose is not (D-010).
+    if (learningOn) {
       session.userMessageContent = transcriptData.userMessages;
     }
     session.toolsUsed = transcriptData.toolsUsed;
@@ -187,7 +195,7 @@ function main() {
     // that loop does not run when learning is off — and the diaries it counts
     // are permanent stubs in that state, so an ungated nudge would recur at
     // every Stop above the threshold, forever, about work the user declined.
-    if (learningCaptureEnabled({ projectRoot })) {
+    if (learningOn) {
       const reflectStatus = checkReflectReady(session.project);
       if (reflectStatus?.ready) {
         addPendingAction(session.project, 'reflect-ready', {

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -28,9 +28,9 @@ const {
   runDiaryCapture,
   readCounts,
   pruneUngatedProse,
+  applyTranscriptToSession,
 } = require('../../scripts/lib/diary-capture');
 const { shouldTrigger } = require('../../scripts/lib/thresholds');
-const { parseTranscript } = require('../../scripts/lib/transcript');
 const { checkReflectReady: reflectReady } = require('../../scripts/lib/learning-workflow');
 
 /**
@@ -141,34 +141,29 @@ function main() {
   session.userMessages = userCount;
   session.toolCalls = toolCount;
 
+  // D-010 governs both halves: the opt-in decides whether prose is written AND
+  // whether prose an earlier, opted-in Stop wrote may stay. Pruning before the
+  // stamp is what makes the second half true — the record is reloaded and
+  // rewritten on every Stop, so an ungated field would otherwise be
+  // re-serialized forever. The returned answer is the opt-in itself, so both
+  // the stamp below and the reflect-ready gate further down (D-009) reuse this
+  // one config read rather than asking again.
+  const learningOn = pruneUngatedProse(session, { projectRoot });
+
   // Enrich with transcript data ONLY when the diary threshold fired. Below
   // threshold, parsing the transcript is wasted work (the diary won't capture),
   // so it is skipped entirely (documented delta: below-threshold session JSON
-  // loses userMessageContent/toolsUsed/filesModified enrichment).
-  const transcriptPath = input?.transcript_path;
-  const transcriptData =
-    shouldTrigger(userCount, toolCount) && transcriptPath ? parseTranscript(transcriptPath) : null;
+  // loses userMessageContent/toolsUsed/filesModified enrichment). Counts, tool
+  // names and paths are the continuity record and are stamped either way;
+  // verbatim user prose only under the opt-in (D-010) — the shared helper the
+  // PreCompact path also calls owns that split.
+  const stamped =
+    shouldTrigger(userCount, toolCount) &&
+    applyTranscriptToSession(session, input?.transcript_path, { learningOn });
 
-  // D-010 governs both halves: the opt-in decides whether prose is written AND
-  // whether prose an earlier, opted-in Stop wrote may stay. Pruning before the
-  // branch is what makes the second half true — the record is reloaded and
-  // rewritten on every Stop, so an ungated field would otherwise be
-  // re-serialized forever. The returned answer is the opt-in itself, so the
-  // reflect-ready gate below (D-009) reuses this one config read rather than
-  // asking again.
-  const learningOn = pruneUngatedProse(session, { projectRoot });
-
-  if (transcriptData) {
-    // Counts, tool names and paths are the continuity record and are kept
-    // either way. Verbatim user prose is not (D-010).
-    if (learningOn) {
-      session.userMessageContent = transcriptData.userMessages;
-    }
-    session.toolsUsed = transcriptData.toolsUsed;
-    session.filesModified = transcriptData.filesModified;
-  } else {
-    session.filesModified = [];
-  }
+  // Nothing parsed: Stop clears the paths rather than carrying the previous
+  // turn's into a record it just closed.
+  if (!stamped) session.filesModified = [];
 
   saveSessionJson(session);
 

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -29,18 +29,10 @@ const {
   readCounts,
   pruneUngatedProse,
   applyTranscriptToSession,
+  buildSessionSummary,
 } = require('../../scripts/lib/diary-capture');
 const { shouldTrigger } = require('../../scripts/lib/thresholds');
 const { checkReflectReady: reflectReady } = require('../../scripts/lib/learning-workflow');
-
-/**
- * Calculate duration in minutes between two ISO timestamps
- */
-function calculateDurationMinutes(startISO, endISO) {
-  if (!startISO || !endISO) return null;
-  const durationMs = new Date(endISO) - new Date(startISO);
-  return Math.round(durationMs / 60000);
-}
 
 /**
  * Create default session if none exists
@@ -88,22 +80,6 @@ function checkReflectReady(project) {
   } catch {
     return null;
   }
-}
-
-/**
- * Format session stats as a one-liner.
- */
-function formatStats(session) {
-  const duration = calculateDurationMinutes(session.started, session.lastUpdated);
-
-  let stats = `${session.userMessages || 0} messages, ${session.toolCalls} tool calls`;
-  if (duration > 0) {
-    stats = `~${duration} min, ${stats}`;
-  }
-  if (session.filesModified?.length > 0) {
-    stats += `, ${session.filesModified.length} files modified`;
-  }
-  return stats;
 }
 
 /**
@@ -175,12 +151,7 @@ function main() {
     date: session.date,
     sessionId: session.sessionId,
     projectRoot,
-    transcriptData: {
-      userMessages: session.userMessageContent || [],
-      toolsUsed: session.toolsUsed || [],
-      filesModified: session.filesModified || [],
-      stats: formatStats(session),
-    },
+    transcriptData: buildSessionSummary(session),
   });
 
   const systemMessages = [];
@@ -216,10 +187,8 @@ function main() {
 
 // Export for testing
 module.exports = {
-  calculateDurationMinutes,
   getOrCreateSession,
   saveSessionJson,
-  formatStats,
   formatShortMessage,
   formatTriggeredMessage,
   checkReflectReady,

--- a/hooks/session-tracker/end.js
+++ b/hooks/session-tracker/end.js
@@ -24,7 +24,11 @@ const {
   log,
 } = require('../../scripts/lib/utils');
 const { addPendingAction } = require('../../scripts/lib/pending-actions');
-const { runDiaryCapture, readCounts } = require('../../scripts/lib/diary-capture');
+const {
+  runDiaryCapture,
+  readCounts,
+  learningCaptureEnabled,
+} = require('../../scripts/lib/diary-capture');
 const { shouldTrigger } = require('../../scripts/lib/thresholds');
 const { parseTranscript } = require('../../scripts/lib/transcript');
 const { checkReflectReady: reflectReady } = require('../../scripts/lib/learning-workflow');
@@ -130,6 +134,7 @@ function main() {
   setSessionIdFromInput(input);
 
   const session = getOrCreateSession();
+  const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const { userCount, toolCount } = readCounts();
 
   session.lastUpdated = getTimestamp();
@@ -145,7 +150,12 @@ function main() {
     shouldTrigger(userCount, toolCount) && transcriptPath ? parseTranscript(transcriptPath) : null;
 
   if (transcriptData) {
-    session.userMessageContent = transcriptData.userMessages;
+    // Counts, tool names and paths are the continuity record and are kept
+    // either way. Verbatim user prose is not — it only lands in the session
+    // file once the learning opt-in is on (D-010).
+    if (learningCaptureEnabled({ projectRoot })) {
+      session.userMessageContent = transcriptData.userMessages;
+    }
     session.toolsUsed = transcriptData.toolsUsed;
     session.filesModified = transcriptData.filesModified;
   } else {
@@ -161,6 +171,7 @@ function main() {
     project: session.project,
     date: session.date,
     sessionId: session.sessionId,
+    projectRoot,
     transcriptData: {
       userMessages: session.userMessageContent || [],
       toolsUsed: session.toolsUsed || [],

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -38,7 +38,7 @@ const { getArcforgeHome } = require('../../scripts/lib/utils');
 const { listActivatedCandidateIds } = require('../../scripts/lib/learning-curator/activate');
 const {
   isInjectActivatedInstinctsEnabled,
-  isLearningEnabledAnyScope,
+  learningEnabledSince,
 } = require('../../scripts/lib/learning');
 
 const { getPendingActions, consumeAction } = require('../../scripts/lib/pending-actions');
@@ -150,10 +150,32 @@ function loadInstinctFiles(dir) {
 // single owner shared by this healthcheck and the curator batch-assembler.
 
 /**
+ * Whether a draft was written before enrichment was ever authorized.
+ * Fails open — an unreadable timestamp lets the stub probe decide.
+ */
+function draftPredatesOptIn(filePath, enabledSince) {
+  try {
+    return fs.statSync(filePath).mtimeMs < enabledSince;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Returns { count, message } when stale drafts exist, else null.
  * Surfaces silent enrichment failures so they don't accumulate forever.
+ *
+ * Only drafts written since the learning opt-in count. Drafts from a
+ * learning-off period keep their stubs by design (D-009), so counting them
+ * would turn the first session after opting in into a report of the entire
+ * backlog — and the message's diagnosis ("the enricher may be failing") would
+ * be wrong about every one of them.
+ *
+ * @param {string} project
+ * @param {number} [enabledSince] - Epoch ms the opt-in took effect; 0 (the
+ *   default) applies no floor and counts every stale draft.
  */
-function loadStaleDraftWarning(project) {
+function loadStaleDraftWarning(project, enabledSince = 0) {
   try {
     const dir = getProjectDiariesDir(project);
     if (!fs.existsSync(dir)) return null;
@@ -164,7 +186,9 @@ function loadStaleDraftWarning(project) {
       const dateDirPath = path.join(dir, dateEntry.name);
       for (const file of fs.readdirSync(dateDirPath)) {
         if (!file.startsWith('diary-') || !file.endsWith('-draft.md')) continue;
-        if (draftIsStale(path.join(dateDirPath, file))) stale++;
+        const draftPath = path.join(dateDirPath, file);
+        if (draftPredatesOptIn(draftPath, enabledSince)) continue;
+        if (draftIsStale(draftPath)) stale++;
       }
     }
 
@@ -325,11 +349,12 @@ function main() {
   // Stale-draft healthcheck (re-evaluated every session start, not consumed).
   // Only meaningful once enrichment can run: with learning off, drafts keep
   // their TO BE ENRICHED stubs by design (D-009), so the warning would be a
-  // permanent complaint about intended behavior.
+  // permanent complaint about intended behavior. The opt-in TIMESTAMP, not just
+  // the flag, is what bounds it — otherwise the whole learning-off backlog
+  // surfaces at once on the first session after opting in.
   const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-  const staleWarning = isLearningEnabledAnyScope({ projectRoot })
-    ? loadStaleDraftWarning(project)
-    : null;
+  const enabledSince = learningEnabledSince({ projectRoot });
+  const staleWarning = enabledSince === null ? null : loadStaleDraftWarning(project, enabledSince);
   if (staleWarning) {
     contextParts.push(staleWarning.message);
     userParts.push(`${staleWarning.count} unenriched draft${staleWarning.count === 1 ? '' : 's'}`);

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -36,7 +36,10 @@ const {
 const { parseConfidenceFrontmatter } = require('../../scripts/lib/confidence');
 const { getArcforgeHome } = require('../../scripts/lib/utils');
 const { listActivatedCandidateIds } = require('../../scripts/lib/learning-curator/activate');
-const { isInjectActivatedInstinctsEnabled } = require('../../scripts/lib/learning');
+const {
+  isInjectActivatedInstinctsEnabled,
+  isLearningEnabledAnyScope,
+} = require('../../scripts/lib/learning');
 
 const { getPendingActions, consumeAction } = require('../../scripts/lib/pending-actions');
 
@@ -319,8 +322,14 @@ function main() {
     userParts.push(pendingSummary);
   }
 
-  // Stale-draft healthcheck (re-evaluated every session start, not consumed)
-  const staleWarning = loadStaleDraftWarning(project);
+  // Stale-draft healthcheck (re-evaluated every session start, not consumed).
+  // Only meaningful once enrichment can run: with learning off, drafts keep
+  // their TO BE ENRICHED stubs by design (D-009), so the warning would be a
+  // permanent complaint about intended behavior.
+  const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const staleWarning = isLearningEnabledAnyScope({ projectRoot })
+    ? loadStaleDraftWarning(project)
+    : null;
   if (staleWarning) {
     contextParts.push(staleWarning.message);
     userParts.push(`${staleWarning.count} unenriched draft${staleWarning.count === 1 ? '' : 's'}`);

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -155,9 +155,10 @@ function loadInstinctFiles(dir) {
  * The floor is the EARLIER of creation and last-write time, so hand-editing or
  * touching a pre-opt-in stub does not lift it above the floor — mtime alone
  * would, and every later session would then report a by-design stub as an
- * enricher failure. A copy that resets both stamps (a backup restore, a machine
- * migration) still does, because the learning config's `updated_at` is embedded
- * and survives the same copy while file stamps do not.
+ * enricher failure. A copy that preserves NEITHER stamp still does, because the
+ * learning config's `updated_at` is embedded and survives the same copy while
+ * file stamps do not; ordinary restore tooling keeps mtime and so stays below
+ * the floor.
  *
  * Fails open — an unreadable timestamp lets the stub probe decide.
  */

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -151,11 +151,23 @@ function loadInstinctFiles(dir) {
 
 /**
  * Whether a draft was written before enrichment was ever authorized.
+ *
+ * The floor is the EARLIER of creation and last-write time, so hand-editing or
+ * touching a pre-opt-in stub does not lift it above the floor — mtime alone
+ * would, and every later session would then report a by-design stub as an
+ * enricher failure. A copy that resets both stamps (a backup restore, a machine
+ * migration) still does, because the learning config's `updated_at` is embedded
+ * and survives the same copy while file stamps do not.
+ *
  * Fails open — an unreadable timestamp lets the stub probe decide.
  */
 function draftPredatesOptIn(filePath, enabledSince) {
   try {
-    return fs.statSync(filePath).mtimeMs < enabledSince;
+    const { mtimeMs, birthtimeMs } = fs.statSync(filePath);
+    // birthtime is 0 on filesystems that don't record it; fall back to mtime
+    // there rather than collapsing the floor to 0 and going quiet forever.
+    const writtenAt = birthtimeMs > 0 ? Math.min(mtimeMs, birthtimeMs) : mtimeMs;
+    return writtenAt < enabledSince;
   } catch {
     return false;
   }

--- a/hooks/session-tracker/inject-context.js
+++ b/hooks/session-tracker/inject-context.js
@@ -43,7 +43,7 @@ const {
 
 const { getPendingActions, consumeAction } = require('../../scripts/lib/pending-actions');
 
-const { draftIsStale } = require('../../scripts/lib/diary-capture');
+const { draftIsStale, learningCaptureEnabled } = require('../../scripts/lib/diary-capture');
 
 // Max activated instincts injected into SessionStart context (ICL-4).
 const MAX_INJECTED_INSTINCTS = 5;
@@ -218,8 +218,15 @@ function loadStaleDraftWarning(project, enabledSince = 0) {
 
 /**
  * Load and consume pending actions for context injection.
+ *
+ * @param {string} project
+ * @param {Object} [opts]
+ * @param {string} [opts.projectRoot] - Project root whose learning opt-in
+ *   decides whether a queued `reflect-ready` may still be delivered. Omitted or
+ *   blank means no consent, so the nudge is suppressed — the safe direction for
+ *   an invitation.
  */
-function loadPendingActions(project) {
+function loadPendingActions(project, { projectRoot } = {}) {
   try {
     // Relay-isolation: a session arcforge spawned itself (e.g. the detached
     // diary enricher, or a loop's headless task session) must NOT consume the
@@ -234,9 +241,24 @@ function loadPendingActions(project) {
     const lines = [];
     const summaryParts = [];
 
+    // The reflection nudge is gated at BOTH ends of its life: at queue time in
+    // end.js (D-009), so it never accumulates while learning is off, and here at
+    // delivery, so an opt-out between the queuing Stop and this SessionStart
+    // retracts a nudge already in the queue instead of spending it. Both ends
+    // ask the one consent predicate — end.js's queue gate reads it through the
+    // same helper — so the fail-closed-on-a-missing-projectRoot rule is stated
+    // once, in diary-capture.js, rather than restated here.
+    //
+    // The action stays in `actions` either way, so the consume loop below still
+    // clears it — a suppressed nudge is dropped, never deferred to fire later
+    // with a stale count. `reflect-ready` also stays in DEDICATED_TYPES, so a
+    // suppressed nudge cannot fall through to the raw `Pending: <type>` line and
+    // deliver the same invitation with its payload attached.
+    const learningOn = learningCaptureEnabled({ projectRoot });
+
     const DEDICATED_TYPES = ['diary-ready', 'reflect-ready'];
     const diaryActions = actions.filter((a) => a.type === 'diary-ready');
-    const reflectActions = actions.filter((a) => a.type === 'reflect-ready');
+    const reflectActions = learningOn ? actions.filter((a) => a.type === 'reflect-ready') : [];
     const otherActions = actions.filter((a) => !DEDICATED_TYPES.includes(a.type));
 
     if (diaryActions.length > 0) {
@@ -350,8 +372,14 @@ function main() {
     userParts.push(`${instinctCount} active instinct${instinctCount === 1 ? '' : 's'}`);
   }
 
+  // One projectRoot serves both the pending-action delivery gate and the
+  // stale-draft floor below.
+  const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
   // Pending action notifications
-  const { text: pendingContext, summary: pendingSummary } = loadPendingActions(project);
+  const { text: pendingContext, summary: pendingSummary } = loadPendingActions(project, {
+    projectRoot,
+  });
   if (pendingContext) {
     contextParts.push(pendingContext);
   }
@@ -365,7 +393,6 @@ function main() {
   // permanent complaint about intended behavior. The opt-in TIMESTAMP, not just
   // the flag, is what bounds it — otherwise the whole learning-off backlog
   // surfaces at once on the first session after opting in.
-  const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const enabledSince = learningEnabledSince({ projectRoot });
   const staleWarning = enabledSince === null ? null : loadStaleDraftWarning(project, enabledSince);
   if (staleWarning) {

--- a/product/BACKLOG.md
+++ b/product/BACKLOG.md
@@ -43,3 +43,8 @@ playbook in [`product/AGENTS.md`](AGENTS.md).
   every output it returns is a capped tail (about 5 ms per MB on real transcripts);
   bound the read, and correct the hooks spec's B-7 cost enumeration, which already
   omits this parse and the diary subprocess · issue: [#172](https://github.com/GregoryHo/arcforge/issues/172).
+- **stale-probe-window-vs-rendered-paths** — the draft renders every modified
+  path above its enrichment markers while the stale-draft probe reads only the
+  first 2 KB, so thirty long paths push the marker past the window and a stale
+  draft reads as enriched; bound the rendered block so the markers sit inside
+  the probe window by construction · issue: [#177](https://github.com/GregoryHo/arcforge/issues/177).

--- a/product/BACKLOG.md
+++ b/product/BACKLOG.md
@@ -17,13 +17,24 @@ playbook in [`product/AGENTS.md`](AGENTS.md).
 - ~~**gate-session-capture-depth**~~ — graduated into 6.1.0 (D-010).
 - ~~**gate-diary-enricher**~~ — graduated into 6.1.0 (D-009).
 - **stale-draft floor loses an overlapping opt-in** — `learningEnabledSince`
-  (scripts/lib/learning.js:150) derives the floor only from scopes that are
+  (scripts/lib/learning.js) derives the floor only from scopes that are
   enabled *now*, and `setLearningEnabled` keeps one `updated_at` per scope, so
   disabling the scope that opted in first advances the floor even though
   any-scope authorization was continuous; genuine enricher failures in the
   window between the two opt-ins stop being reported. Fix direction: persist the
   enable stamp across a disable and take the start of the continuous effective
   any-scope opt-in. Recorded as the accepted cost in D-009 for 6.1.0.
+- **`learn enable` erases `inject_activated_instincts`** — `setLearningEnabled`
+  (scripts/lib/learning.js) writes a fresh `{ scope, enabled, updated_at }`
+  object, so every other key on the learning config is dropped. The only such
+  key today is `inject_activated_instincts`, which
+  `isInjectActivatedInstinctsEnabled` reads from the global config and which has
+  no CLI setter — a user who hand-wrote `inject_activated_instincts: false` and
+  later ran `arcforge learn enable --global` on an already-enabled scope gets
+  default-ON injection back with no notice, from a command they expect to change
+  nothing. Fix direction: merge over the previous config instead of replacing it
+  (it is already in hand as `previous`). Pre-existing — the same full-replacement
+  object predates the #146/#147 branch; surfaced during its review.
 - **unify-candidate-queues** — point the `learn` transition commands at the
   canonical Layer-5 candidate queue, so the CLI and the dashboard manage the
   same candidates instead of two disjoint queues · issue: [#148](https://github.com/GregoryHo/arcforge/issues/148).

--- a/product/BACKLOG.md
+++ b/product/BACKLOG.md
@@ -14,12 +14,8 @@ playbook in [`product/AGENTS.md`](AGENTS.md).
 - **dashboard-rejections** — surface curator-rejected proposals
   (`rejections.jsonl`) in the review dashboard, so a user can see what the curator
   declined and why.
-- **gate-session-capture-depth** — decide how much of the always-on session
-  record belongs behind the learning opt-in; today the diary threshold also
-  stores recent user-message text, with learning never enabled · issue: [#147](https://github.com/GregoryHo/arcforge/issues/147).
-- **gate-diary-enricher** — the diary enricher is a background model run seeded
-  with a session summary and fired regardless of the learning opt-in; decide
-  whether it should be opt-in, opt-out, or announced · issue: [#146](https://github.com/GregoryHo/arcforge/issues/146).
+- ~~**gate-session-capture-depth**~~ — graduated into 6.1.0 (D-010).
+- ~~**gate-diary-enricher**~~ — graduated into 6.1.0 (D-009).
 - **unify-candidate-queues** — point the `learn` transition commands at the
   canonical Layer-5 candidate queue, so the CLI and the dashboard manage the
   same candidates instead of two disjoint queues · issue: [#148](https://github.com/GregoryHo/arcforge/issues/148).

--- a/product/BACKLOG.md
+++ b/product/BACKLOG.md
@@ -27,3 +27,8 @@ playbook in [`product/AGENTS.md`](AGENTS.md).
 - **unify-candidate-queues** — point the `learn` transition commands at the
   canonical Layer-5 candidate queue, so the CLI and the dashboard manage the
   same candidates instead of two disjoint queues · issue: [#148](https://github.com/GregoryHo/arcforge/issues/148).
+- **bound-transcript-parse** — `parseTranscript` reads and splits the whole
+  session transcript on every above-threshold Stop and PreCompact even though
+  every output it returns is a capped tail (about 5 ms per MB on real transcripts);
+  bound the read, and correct the hooks spec's B-7 cost enumeration, which already
+  omits this parse and the diary subprocess · issue: [#172](https://github.com/GregoryHo/arcforge/issues/172).

--- a/product/BACKLOG.md
+++ b/product/BACKLOG.md
@@ -24,7 +24,7 @@ playbook in [`product/AGENTS.md`](AGENTS.md).
   window between the two opt-ins stop being reported. Fix direction: persist the
   enable stamp across a disable and take the start of the continuous effective
   any-scope opt-in. Recorded as the accepted cost in D-009 for 6.1.0.
-- **`learn enable` erases `inject_activated_instincts`** — `setLearningEnabled`
+- **learn-enable-erases-config** — `setLearningEnabled`
   (scripts/lib/learning.js) writes a fresh `{ scope, enabled, updated_at }`
   object, so every other key on the learning config is dropped. The only such
   key today is `inject_activated_instincts`, which

--- a/product/BACKLOG.md
+++ b/product/BACKLOG.md
@@ -16,6 +16,14 @@ playbook in [`product/AGENTS.md`](AGENTS.md).
   declined and why.
 - ~~**gate-session-capture-depth**~~ — graduated into 6.1.0 (D-010).
 - ~~**gate-diary-enricher**~~ — graduated into 6.1.0 (D-009).
+- **stale-draft floor loses an overlapping opt-in** — `learningEnabledSince`
+  (scripts/lib/learning.js:150) derives the floor only from scopes that are
+  enabled *now*, and `setLearningEnabled` keeps one `updated_at` per scope, so
+  disabling the scope that opted in first advances the floor even though
+  any-scope authorization was continuous; genuine enricher failures in the
+  window between the two opt-ins stop being reported. Fix direction: persist the
+  enable stamp across a disable and take the start of the continuous effective
+  any-scope opt-in. Recorded as the accepted cost in D-009 for 6.1.0.
 - **unify-candidate-queues** — point the `learn` transition commands at the
   canonical Layer-5 candidate queue, so the CLI and the dashboard manage the
   same candidates instead of two disjoint queues · issue: [#148](https://github.com/GregoryHo/arcforge/issues/148).

--- a/product/BACKLOG.md
+++ b/product/BACKLOG.md
@@ -16,7 +16,7 @@ playbook in [`product/AGENTS.md`](AGENTS.md).
   declined and why.
 - ~~**gate-session-capture-depth**~~ — graduated into 6.1.0 (D-010).
 - ~~**gate-diary-enricher**~~ — graduated into 6.1.0 (D-009).
-- **stale-draft floor loses an overlapping opt-in** — `learningEnabledSince`
+- **stale-draft-floor-overlapping-opt-in** — `learningEnabledSince`
   (scripts/lib/learning.js) derives the floor only from scopes that are
   enabled *now*, and `setLearningEnabled` keeps one `updated_at` per scope, so
   disabling the scope that opted in first advances the floor even though

--- a/product/ROADMAP.md
+++ b/product/ROADMAP.md
@@ -8,7 +8,8 @@ decision *and* every reversal. How to maintain this file: [`product/AGENTS.md`](
 
 | Version | Tag | Milestone | Status | What & why | Spec |
 |---|---|---|---|---|---|
-| 6.0.0 | `v6.0.0` | v6 toolkit | **shipped ← we are here** | Ground-up rebuild: 15 self-contained skills behind a prose router, a 5-group CLI reached as bare `arcforge`, 6 hooks, and the retained learning / eval / obsidian systems — Claude Code single-harness, zero runtime deps. | [skill-system](specs/skill-system.md) · [cli](specs/cli.md) · [hooks](specs/hooks.md) · [learning](specs/learning.md) · [eval](specs/eval.md) · [obsidian](specs/obsidian.md) · [worktrees-loop](specs/worktrees-loop.md) |
+| 6.0.0 | `v6.0.0` | v6 toolkit | **shipped** | Ground-up rebuild: 15 self-contained skills behind a prose router, a 5-group CLI reached as bare `arcforge`, 6 hooks, and the retained learning / eval / obsidian systems — Claude Code single-harness, zero runtime deps. | [skill-system](specs/skill-system.md) · [cli](specs/cli.md) · [hooks](specs/hooks.md) · [learning](specs/learning.md) · [eval](specs/eval.md) · [obsidian](specs/obsidian.md) · [worktrees-loop](specs/worktrees-loop.md) |
+| 6.1.0 | — | learning trust · spec-driven method · Codex packaging | **building ← we are here** | Diary enrichment and user-message capture move behind the learning opt-in and the enricher loses blanket permissions; the CLI's candidate commands become a front end onto the canonical queue; the lightweight spec-driven method arcforge runs itself on ships as the `speccing` skill; arcforge installs on Codex as a skills-only plugin over the same tree. | [learning](specs/learning.md) · [hooks](specs/hooks.md) |
 
 > Un-scheduled ideas live in the [Backlog](BACKLOG.md); a wish graduates into a
 > version (row + spec + Decision Log entry) when picked.
@@ -213,3 +214,56 @@ reverse one, append a superseding entry (see AGENTS.md).
   and stays a reading task.
 - Verification: `npm run check:product` red on a partial flip, green on a complete
   one; the negative fixtures in `tests/scripts/check-product.test.js` cover both.
+
+### D-009 — Diary enrichment is opt-in, and the enricher loses blanket permissions
+- Date: 2026-09-03
+- Version: 6.1.0
+- Status: Accepted
+- Decision: The background diary-enrichment run fires only when learning is
+  enabled in some scope, and it no longer runs the host CLI with
+  `--dangerously-skip-permissions` — it carries `--tools Read,Write`,
+  `--add-dir <the draft's directory>` and `--permission-mode acceptEdits`. With
+  learning off the draft is still written from session counts and simply keeps
+  its unfilled sections; that stub is the documented contract, and the
+  stale-draft warning is suppressed in that state rather than complaining about
+  intended behavior forever.
+- Why: Learning's core asset is its trust design — off by default, nothing
+  uninvited. An enrichment run that fires regardless of the opt-in contradicted
+  that in the one place it mattered most: it is the product's single outbound
+  path, and it was seeded with a summary of the user's session. Skipping every
+  permission check on top made the blast radius of a prompt-injected draft the
+  whole machine. A spike against the real CLI established the narrowest argv
+  that still enriches, and both surviving flags are load-bearing: the draft
+  lives outside the spawning cwd, so without `--add-dir` the write is refused
+  outright, and a detached run has nobody to answer a permission prompt, so
+  without `acceptEdits` the write hangs and the draft is never filled in. A
+  per-file `--allowed-tools` allowlist was probed and deliberately left out: it
+  pre-approves rather than denies, so it authorized nothing on its own and
+  would have read like a confinement it does not provide. What the result is
+  NOT, stated so the record does not overclaim: no `cwd` is passed to the
+  spawn, so the child still inherits the hook's working directory — the user's
+  project — and `--add-dir` adds the draft's directory alongside it rather than
+  restricting the run to it. With `acceptEdits` that means edits are
+  auto-approved across both. This is a narrowing of the blanket bypass, not a
+  sandbox, and the specs and guides say so in those terms.
+
+### D-010 — Session capture depth: counts always, user prose only under the opt-in
+- Date: 2026-09-03
+- Version: 6.1.0
+- Status: Accepted
+- Decision: The durable session record stays always-on, and so does its
+  metadata — duration, message and tool counts, compactions, tool names, and
+  modified file paths — along with the diary draft, which is built from those
+  counts alone. Verbatim user-message text (`userMessageContent`) is the one
+  field that moves behind the learning opt-in. The transcript is still parsed
+  unconditionally above the threshold, because the diary's modified-files line
+  depends on it.
+- Why: Continuity is not a learning feature and should not require opting into
+  learning; a record of how long a session ran and what it touched is
+  bookkeeping the user already sees. Storing what the user actually *said* is a
+  different act, and it is the one that would surprise someone who never turned
+  learning on. Splitting on that boundary keeps the always-on record useful
+  while making the depth of it match what the user agreed to. Gating the
+  transcript parse instead of the single assignment was rejected: it would have
+  silently emptied the diary's "Files modified" line for every learning-off
+  user.

--- a/product/ROADMAP.md
+++ b/product/ROADMAP.md
@@ -246,6 +246,23 @@ reverse one, append a superseding entry (see AGENTS.md).
   restricting the run to it. With `acceptEdits` that means edits are
   auto-approved across both. This is a narrowing of the blanket bypass, not a
   sandbox, and the specs and guides say so in those terms.
+- Residual: the stale-draft floor is the earlier of the draft's creation and
+  last-write timestamps. In-place edits and `touch` no longer lift a pre-opt-in
+  stub above it; two things still do, and report it — a copy that preserves
+  neither stamp (a sync re-download or a naive unzip; ordinary restore tooling
+  keeps mtime and stays below the floor), and a filesystem that records no
+  creation time, which leaves the floor on last-write alone. The floor also
+  cuts the other way twice, and both are silences rather than false alarms: a
+  draft first written before the opt-in and rewritten in place afterwards keeps
+  its original creation time, so a genuine post-opt-in enrichment failure over
+  it is never reported; and disabling the scope that carries the earliest
+  opt-in — global on, project on, global off — advances the floor to the
+  surviving scope's stamp even though any-scope authorization never lapsed,
+  because a scope's `updated_at` records its latest transition and the enable it
+  replaced is not recoverable. The learning config's `updated_at` is embedded and
+  survives the same copy, which is what makes the first mismatch possible.
+  Creation time is read from the stat call the check already makes, so the check
+  stays bounded (hooks B-7).
 
 ### D-010 — Session capture depth: counts always, user prose only under the opt-in
 - Date: 2026-09-03

--- a/product/ROADMAP.md
+++ b/product/ROADMAP.md
@@ -287,3 +287,12 @@ reverse one, append a superseding entry (see AGENTS.md).
   transcript parse instead of the single assignment was rejected: it would have
   silently emptied the diary's "Files modified" line for every learning-off
   user.
+- Residual: the opt-in governs how long verbatim prose may stay, not only
+  whether it is written — the session record is reloaded and rewritten on every
+  Stop and on every compaction, so the field is deleted whenever the gate reads
+  off. Tool names are not: they are always-on continuity under this decision, so
+  a record an earlier parse filled keeps that turn's `toolsUsed` until a later
+  parse refreshes it, and the two fields have different lifetimes by design
+  (hooks B-6, and the domain-model note in product/specs/hooks.md). The prose
+  written before an opt-out survives until the first Stop or compaction after
+  it, which is the same event that removes it.

--- a/product/ROADMAP.md
+++ b/product/ROADMAP.md
@@ -253,11 +253,14 @@ reverse one, append a superseding entry (see AGENTS.md).
 - Status: Accepted
 - Decision: The durable session record stays always-on, and so does its
   metadata — duration, message and tool counts, compactions, tool names, and
-  modified file paths — along with the diary draft, which is built from those
-  counts alone. Verbatim user-message text (`userMessageContent`) is the one
-  field that moves behind the learning opt-in. The transcript is still parsed
-  unconditionally above the threshold, because the diary's modified-files line
-  depends on it.
+  modified file paths — along with the diary draft, which renders the counts
+  and the modified-file paths, plus a tool-usage aggregate whenever an
+  observations log already exists for the project. That aggregate is the only
+  place tool names reach a draft, and observation is itself gated, so with
+  learning off it can only be residue of a period when learning was on.
+  Verbatim user-message text (`userMessageContent`) is the one field that moves
+  behind the learning opt-in. The transcript is still parsed unconditionally
+  above the threshold, because the diary's modified-files line depends on it.
 - Why: Continuity is not a learning feature and should not require opting into
   learning; a record of how long a session ran and what it touched is
   bookkeeping the user already sees. Storing what the user actually *said* is a

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -91,12 +91,16 @@ down, never block the user, and never observe them uninvited.
   preserves neither stamp — a sync re-download or a naive unzip, where ordinary
   restore tooling keeps the modification time and so stays below the floor — and
   a filesystem that records no creation time, which leaves the floor resting on
-  last-write alone. The floor cuts the other way once: a draft first written
-  before the opt-in and rewritten in place afterwards keeps its original
-  creation time, so a genuine post-opt-in enrichment failure over it is never
-  reported. There is no per-hook switch: the single opt-in covers the learning
-  loop in either scope, disabling learning stops it, and uninstalling the
-  plugin removes everything.
+  last-write alone. The floor cuts the other way twice, and both are silences
+  rather than false alarms: a draft first written before the opt-in and
+  rewritten in place afterwards keeps its original creation time, so a genuine
+  post-opt-in enrichment failure over it is never reported; and disabling the
+  scope that carries the earliest opt-in — global on, then project on, then
+  global off — advances the floor to the surviving scope's stamp even though
+  authorization never lapsed, because a scope's config records its latest
+  transition and not the enable it replaced. There is no per-hook switch: the
+  single opt-in covers the learning loop in either scope, disabling learning
+  stops it, and uninstalling the plugin removes everything.
 
 ### Performance
 - **B-7 The synchronous path stays small.** Observation writes and

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -77,10 +77,13 @@ down, never block the user, and never observe them uninvited.
 
   So with learning off the draft is written but never filled in: its unfilled
   sections are the contract, not a failed enrichment, and the hooks do not
-  report them as one — at any point, including afterwards. The stale-draft
-  healthcheck counts only drafts written since the opt-in took effect, so
-  turning learning on reports what the enricher has since failed to fill in,
-  never the backlog of stubs from before it was ever asked to. There is no
+  report them as one. The stale-draft healthcheck counts only drafts written
+  since the opt-in took effect, so turning learning on reports what the enricher
+  has since failed to fill in, rather than the backlog of stubs from before it
+  was ever asked to. The floor is the earlier of the draft's creation and
+  last-write times, so hand-editing or touching a pre-opt-in stub does not lift
+  it above the floor; a copy that resets both stamps (a backup restore or
+  machine migration) does, and reports it. There is no
   per-hook switch: the single opt-in covers the learning loop in either scope,
   disabling learning stops it, and uninstalling the plugin removes everything.
 

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -91,9 +91,12 @@ down, never block the user, and never observe them uninvited.
   preserves neither stamp — a sync re-download or a naive unzip, where ordinary
   restore tooling keeps the modification time and so stays below the floor — and
   a filesystem that records no creation time, which leaves the floor resting on
-  last-write alone. There is no
-  per-hook switch: the single opt-in covers the learning loop in either scope,
-  disabling learning stops it, and uninstalling the plugin removes everything.
+  last-write alone. The floor cuts the other way once: a draft first written
+  before the opt-in and rewritten in place afterwards keeps its original
+  creation time, so a genuine post-opt-in enrichment failure over it is never
+  reported. There is no per-hook switch: the single opt-in covers the learning
+  loop in either scope, disabling learning stops it, and uninstalling the
+  plugin removes everything.
 
 ### Performance
 - **B-7 The synchronous path stays small.** Observation writes and

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -73,7 +73,9 @@ down, never block the user, and never observe them uninvited.
   points at a continuity artifact that exists and can be read now, while
   reflection is the learning loop itself, which [learning](learning.md) B-1
   keeps off. Left ungated it would re-queue at every threshold hit, forever,
-  over diaries the user never authorized anything to be made of.
+  over diaries the user never authorized anything to be made of. The nudge is
+  gated at both ends — queue and delivery — so an opt-out between them retracts
+  a nudge already queued instead of spending it on the next session start.
 
   So with learning off the draft is written but never filled in: its unfilled
   sections are the contract, not a failed enrichment, and the hooks do not

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -129,9 +129,12 @@ unconditionally and B-6 bounds. Its path and its safe read/write belong to
 closes it with the counts and, above the diary threshold, with the summary
 `scripts/lib/transcript.js` parses out of the harness transcript (with no parsed
 transcript — below the threshold, or above it with none to read — `filesModified`
-is cleared while `userMessageContent` and `toolsUsed` are neither written nor
-cleared, so a record an earlier parse filled keeps that turn's prose and tool list
-until a later parse refreshes them), and
+is cleared while `toolsUsed` is neither written nor cleared, so a record an earlier
+parse filled keeps that turn's tool list until a later parse refreshes it;
+`userMessageContent` follows a different lifetime, because the opt-in governs how
+long it may stay and not only whether it is written — every Stop, and every
+compaction that stamps the record, removes it whenever learning is off, so prose
+captured under the opt-in does not outlive it), and
 `hooks/pre-compact/main.js` appends each compaction. The diary is
 not a hooks format but learning's ([learning](learning.md)); what this area owns is its
 trigger — the threshold gate and background enrichment `scripts/lib/diary-capture.js`

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -87,8 +87,11 @@ down, never block the user, and never observe them uninvited.
   has since failed to fill in, rather than the backlog of stubs from before it
   was ever asked to. The floor is the earlier of the draft's creation and
   last-write times, so hand-editing or touching a pre-opt-in stub does not lift
-  it above the floor; a copy that resets both stamps (a backup restore or
-  machine migration) does, and reports it. There is no
+  it above the floor. Two things still do, and are reported: a copy that
+  preserves neither stamp — a sync re-download or a naive unzip, where ordinary
+  restore tooling keeps the modification time and so stays below the floor — and
+  a filesystem that records no creation time, which leaves the floor resting on
+  last-write alone. There is no
   per-hook switch: the single opt-in covers the learning loop in either scope,
   disabling learning stops it, and uninstalling the plugin removes everything.
 

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -130,14 +130,20 @@ unconditionally and B-6 bounds. Its path and its safe read/write belong to
 `hooks/session-tracker/start.js` opens the record, `hooks/session-tracker/end.js`
 closes it with the counts and, above the diary threshold, with the summary
 `scripts/lib/transcript.js` parses out of the harness transcript (with no parsed
-transcript — below the threshold, or above it with none to read — `filesModified`
-is cleared while `toolsUsed` is neither written nor cleared, so a record an earlier
-parse filled keeps that turn's tool list until a later parse refreshes it;
+transcript — below the threshold, or above it with none to read — a Stop clears
+`filesModified` while `toolsUsed` is neither written nor cleared, so a record an
+earlier parse filled keeps that turn's tool list until a later parse refreshes it;
 `userMessageContent` follows a different lifetime, because the opt-in governs how
 long it may stay and not only whether it is written — every Stop, and every
 compaction that stamps the record, removes it whenever learning is off, so prose
 captured under the opt-in does not outlive it), and
-`hooks/pre-compact/main.js` appends each compaction. The diary is
+`hooks/pre-compact/main.js` appends each compaction and, above that same
+threshold, stamps the compaction's own counts and parsed summary *before* the
+draft is generated — the draft is rendered from the record, so a compaction that
+reaches the threshold before any Stop has closed it would otherwise report the
+previous turn's numbers and none of the paths it touched. A compaction stamps
+only what it can read: with no parsed transcript it leaves the record's paths as
+an earlier Stop wrote them rather than clearing them. The diary is
 not a hooks format but learning's ([learning](learning.md)); what this area owns is its
 trigger — the threshold gate and background enrichment `scripts/lib/diary-capture.js`
 coordinates for both Stop and PreCompact. Everything else a hook handles — tool

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -1,6 +1,6 @@
 # hooks — spec
 
-> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · extended by 6.1.0 (building) · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 
@@ -56,12 +56,23 @@ down, never block the user, and never observe them uninvited.
   observation registrations check for an enabled configuration and exit before
   doing any work when learning is off — the default — so with learning off
   nothing is observed and no pattern is ever mined. Session bookkeeping sits
-  outside that gate and runs either way: every session leaves a durable record
-  on disk, and a session that passes the activity threshold additionally writes
-  a diary draft, stores in that record the recent user messages the draft is
-  built from, and hands the draft to a background enrichment run. There is no
-  per-hook switch: the single opt-in covers the learning loop, disabling
-  learning stops it, and uninstalling the plugin removes everything.
+  outside that gate and runs either way, but *depth* is split by what the field
+  is: metadata about the session is continuity, the user's own words and
+  anything handed to a model are not.
+
+  | Recorded on a threshold hit | Learning off | Learning on |
+  |---|---|---|
+  | Session record: duration, message and tool counts, compactions | yes | yes |
+  | Tool names used, files modified (paths) | yes | yes |
+  | Diary draft (built from those counts alone) | yes | yes |
+  | Verbatim recent user messages, in the session record | **no** | yes |
+  | Background enrichment run over a session summary | **no** | yes |
+
+  So with learning off the draft is written but never filled in: its unfilled
+  sections are the contract, not a failed enrichment, and the hooks do not
+  report them as one. There is no per-hook switch: the single opt-in covers the
+  learning loop in either scope, disabling learning stops it, and uninstalling
+  the plugin removes everything.
 
 ### Performance
 - **B-7 The synchronous path stays small.** Observation writes and
@@ -105,3 +116,8 @@ of its own (B-5).
 The warn-only and fail-open stances predate this log; their rationale is
 inline above (B-2, B-3). The error-handling tier that
 implements fail-open is pinned in `.claude/rules/coding-standards.md`.
+
+- **D-010** — session capture depth: counts always, verbatim user prose only
+  under the opt-in (B-6).
+- **D-009** — the enrichment run that B-6 gates is also unprivileged
+  ([learning](learning.md) B-9).

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -70,9 +70,12 @@ down, never block the user, and never observe them uninvited.
 
   So with learning off the draft is written but never filled in: its unfilled
   sections are the contract, not a failed enrichment, and the hooks do not
-  report them as one. There is no per-hook switch: the single opt-in covers the
-  learning loop in either scope, disabling learning stops it, and uninstalling
-  the plugin removes everything.
+  report them as one — at any point, including afterwards. The stale-draft
+  healthcheck counts only drafts written since the opt-in took effect, so
+  turning learning on reports what the enricher has since failed to fill in,
+  never the backlog of stubs from before it was ever asked to. There is no
+  per-hook switch: the single opt-in covers the learning loop in either scope,
+  disabling learning stops it, and uninstalling the plugin removes everything.
 
 ### Performance
 - **B-7 The synchronous path stays small.** Observation writes and

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -67,6 +67,13 @@ down, never block the user, and never observe them uninvited.
   | Diary draft (built from those counts alone) | yes | yes |
   | Verbatim recent user messages, in the session record | **no** | yes |
   | Background enrichment run over a session summary | **no** | yes |
+  | Reflection nudge ("N diaries ready for reflection") | **no** | yes |
+
+  The last row is why the nudge and the diary-ready notice split: diary-ready
+  points at a continuity artifact that exists and can be read now, while
+  reflection is the learning loop itself, which [learning](learning.md) B-1
+  keeps off. Left ungated it would re-queue at every threshold hit, forever,
+  over diaries the user never authorized anything to be made of.
 
   So with learning off the draft is written but never filled in: its unfilled
   sections are the contract, not a failed enrichment, and the hooks do not

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -64,7 +64,7 @@ down, never block the user, and never observe them uninvited.
   |---|---|---|
   | Session record: duration, message and tool counts, compactions | yes | yes |
   | Tool names used, files modified (paths) | yes | yes |
-  | Diary draft (renders the two rows above) | yes | yes |
+  | Diary draft (renders row 1 and the paths from row 2) | yes | yes |
   | Verbatim recent user messages, in the session record | **no** | yes |
   | Background enrichment run over a session summary | **no** | yes |
   | Reflection nudge ("N diaries ready for reflection") | **no** | yes |
@@ -77,9 +77,9 @@ down, never block the user, and never observe them uninvited.
 
   So with learning off the draft is written but never filled in: its unfilled
   sections are the contract, not a failed enrichment, and the hooks do not
-  report them as one. What the draft does fill in is the two rows above — the
-  counts, the tool names, and the paths of the files the session touched — plus
-  a tool-usage aggregate whenever an observations log already exists for the
+  report them as one. What the draft does fill in is the counts and the paths
+  of the files the session touched, plus a tool-usage aggregate — the only
+  place tool names appear — whenever an observations log already exists for the
   project; since observation is itself gated, with learning off that aggregate
   can only be residue of a period when learning was on, and nothing new is
   observed to build it. The stale-draft healthcheck counts only drafts written

--- a/product/specs/hooks.md
+++ b/product/specs/hooks.md
@@ -64,7 +64,7 @@ down, never block the user, and never observe them uninvited.
   |---|---|---|
   | Session record: duration, message and tool counts, compactions | yes | yes |
   | Tool names used, files modified (paths) | yes | yes |
-  | Diary draft (built from those counts alone) | yes | yes |
+  | Diary draft (renders the two rows above) | yes | yes |
   | Verbatim recent user messages, in the session record | **no** | yes |
   | Background enrichment run over a session summary | **no** | yes |
   | Reflection nudge ("N diaries ready for reflection") | **no** | yes |
@@ -77,7 +77,12 @@ down, never block the user, and never observe them uninvited.
 
   So with learning off the draft is written but never filled in: its unfilled
   sections are the contract, not a failed enrichment, and the hooks do not
-  report them as one. The stale-draft healthcheck counts only drafts written
+  report them as one. What the draft does fill in is the two rows above — the
+  counts, the tool names, and the paths of the files the session touched — plus
+  a tool-usage aggregate whenever an observations log already exists for the
+  project; since observation is itself gated, with learning off that aggregate
+  can only be residue of a period when learning was on, and nothing new is
+  observed to build it. The stale-draft healthcheck counts only drafts written
   since the opt-in took effect, so turning learning on reports what the enricher
   has since failed to fill in, rather than the backlog of stubs from before it
   was ever asked to. The floor is the earlier of the draft's creation and

--- a/product/specs/learning.md
+++ b/product/specs/learning.md
@@ -1,6 +1,6 @@
 # learning — spec
 
-> Status: shipped v6.0.0 · [ROADMAP](../ROADMAP.md)
+> Status: shipped v6.0.0 · extended by 6.1.0 (building) · [ROADMAP](../ROADMAP.md)
 > Living document — keep in sync with the shipped behavior; record the *why* of any
 > change in the ROADMAP Decision Log.
 
@@ -28,10 +28,15 @@ was recorded about them.
 - **B-1 Off until turned on.** With learning disabled — the default — the
   observation hooks exit before doing any work, so nothing is observed and no
   candidate is ever proposed. What the opt-in does not gate is session
-  bookkeeping: the durable session record, and the diary an active enough
+  bookkeeping: the durable session record, and the diary draft an active enough
   session produces, are continuity features that run either way
-  ([hooks](hooks.md) B-6). Enabling is an explicit, scoped act (`--project` or
-  `--global`), and status is always inspectable.
+  ([hooks](hooks.md) B-6). The line falls where content leaves the machine or
+  the user's own words are stored: **diary enrichment — the one outbound path
+  (B-9) — runs only under the opt-in**, so with learning off a draft keeps its
+  unfilled sections permanently, and that stub is the contract rather than a
+  failure to report. Enabling is an explicit, scoped act (`--project` or
+  `--global`) but *being* enabled is not scoped: either scope authorizes
+  capture. Status is always inspectable.
 - **B-2 Exactly one automatic step in the candidate pipeline.** Once enabled,
   observations become review-queue candidates automatically — and that is the
   *only* step of that pipeline that happens by itself. Every subsequent arrow
@@ -84,7 +89,10 @@ was recorded about them.
   arcforge has no telemetry and no service of its own to report to. The one
   outbound path is diary enrichment, which runs the host tool over a parsed
   summary of the session — so that summary reaches the model the way any turn
-  of the session does, and nowhere else. State follows its scope: home-global
+  of the session does, and nowhere else. It is opt-in (B-1), and it is not
+  privileged: the run gets the two tools it needs, sees only the directory the
+  draft lives in, and never bypasses the host's permission checks. State
+  follows its scope: home-global
   state under
   `~/.arcforge/`, project-scoped state under the project's own
   `.arcforge/learning/`, and materialized artifacts in the project tree itself,
@@ -123,3 +131,8 @@ location (B-9), and one session yields one diary (B-7).
 The conservative trust design — default-off, three gates, bounded injection,
 audit trail — predates this log; its rationale is inline above. The mechanical
 data contracts live in `docs/decisions/learning-curator-schema/`.
+
+- **D-009** — diary enrichment is opt-in, and the enricher loses its blanket
+  permissions (B-1, B-9).
+- **D-010** — session capture depth: counts always, verbatim user prose only
+  under the opt-in ([hooks](hooks.md) B-6).

--- a/product/specs/learning.md
+++ b/product/specs/learning.md
@@ -34,7 +34,10 @@ was recorded about them.
   the user's own words are stored: **diary enrichment — the one outbound path
   (B-9) — runs only under the opt-in**, so with learning off a draft keeps its
   unfilled sections permanently, and that stub is the contract rather than a
-  failure to report. Enabling is an explicit, scoped act (`--project` or
+  failure to report. Nothing invites the user into the loop from that state
+  either: the reflection nudge waits for the same opt-in, because a permanent
+  offer to analyze diaries is itself a way of not taking "off" for an answer.
+  Enabling is an explicit, scoped act (`--project` or
   `--global`) but *being* enabled is not scoped: either scope authorizes
   capture. Status is always inspectable.
 - **B-2 Exactly one automatic step in the candidate pipeline.** Once enabled,

--- a/product/specs/learning.md
+++ b/product/specs/learning.md
@@ -89,9 +89,14 @@ was recorded about them.
   arcforge has no telemetry and no service of its own to report to. The one
   outbound path is diary enrichment, which runs the host tool over a parsed
   summary of the session — so that summary reaches the model the way any turn
-  of the session does, and nowhere else. It is opt-in (B-1), and it is not
-  privileged: the run gets the two tools it needs, sees only the directory the
-  draft lives in, and never bypasses the host's permission checks. State
+  of the session does, and nowhere else. It is opt-in (B-1), and it no longer
+  runs with permissions switched off: it gets two tools, `Read` and `Write`,
+  and the draft's own directory is added to the ones it may work in. It is not
+  a sandbox, and the spec does not claim one — the run still inherits the
+  directory it was started from, which is the project, and edits inside those
+  directories are auto-approved rather than prompted, because a detached run
+  has nobody to answer a prompt. What it no longer carries is the blanket
+  bypass of every check. State
   follows its scope: home-global
   state under
   `~/.arcforge/`, project-scoped state under the project's own

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -154,6 +154,30 @@ function learningCaptureEnabled({ projectRoot } = {}) {
   }
 }
 
+/**
+ * D-010's retention half: verbatim user prose lives in the session record only
+ * while the learning opt-in is on. The record outlives a single event — Stop
+ * fires once per turn and PreCompact once per compaction, both reloading and
+ * rewriting the whole record — so a gate that only skipped the write would keep
+ * re-serializing prose captured before the user opted out.
+ *
+ * Mutates `session` in place and returns whether capture is currently allowed,
+ * so a caller that also writes prose reuses this one gate read.
+ *
+ * @param {Object|null} session - Session record, mutated in place.
+ * @param {Object} [opts]
+ * @param {string} [opts.projectRoot] - Omitted or blank means no consent
+ *   (learningCaptureEnabled fails closed), which prunes.
+ * @returns {boolean} true when the opt-in allows verbatim prose.
+ */
+function pruneUngatedProse(session, { projectRoot } = {}) {
+  const allowed = learningCaptureEnabled({ projectRoot });
+  if (!allowed && session && session.userMessageContent !== undefined) {
+    delete session.userMessageContent;
+  }
+  return allowed;
+}
+
 // ---------------------------------------------------------------------------
 // Draft generation + background enrichment
 // ---------------------------------------------------------------------------
@@ -341,6 +365,7 @@ module.exports = {
   getSuggesterStatePath,
   draftIsStale,
   learningCaptureEnabled,
+  pruneUngatedProse,
   tryGenerateAutoDiary,
   spawnDiaryEnricher,
   runDiaryCapture,

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -178,6 +178,47 @@ function pruneUngatedProse(session, { projectRoot } = {}) {
   return allowed;
 }
 
+/**
+ * Stamp a parsed harness transcript's summary onto a session record.
+ *
+ * Shared by the two hooks that write the record above the diary threshold —
+ * Stop (session-tracker/end.js) and PreCompact (pre-compact/main.js) — so both
+ * render their draft from the same fields instead of one path re-deriving them.
+ *
+ * `./transcript` is required LAZILY for the same reason `./learning` is:
+ * compact-suggester imports this module on the synchronous PostToolUse path
+ * (hooks B-7), and only the Stop/PreCompact paths ever parse a transcript.
+ *
+ * The consent split (D-010) is the caller's: counts, tool names and paths are
+ * continuity and are stamped either way, verbatim prose only under the opt-in.
+ * The caller has already read that gate (pruneUngatedProse returns it), so it is
+ * passed in rather than read a second time here.
+ *
+ * A missing or unparseable transcript leaves the record's existing fields
+ * untouched and reports false. Refreshing what can be read is this function's
+ * job; CLEARING what cannot is the caller's call, and the two callers differ —
+ * Stop clears the paths, a compaction keeps the ones an earlier Stop wrote
+ * rather than blanking a record it cannot refresh.
+ *
+ * @param {Object} session - Session record, mutated in place.
+ * @param {string} [transcriptPath] - Harness transcript to parse.
+ * @param {Object} [opts]
+ * @param {boolean} [opts.learningOn=false] - Whether verbatim prose may be written.
+ * @returns {boolean} true when a transcript was parsed and stamped.
+ */
+function applyTranscriptToSession(session, transcriptPath, { learningOn = false } = {}) {
+  if (!session || !transcriptPath) return false;
+
+  const { parseTranscript } = require('./transcript');
+  const data = parseTranscript(transcriptPath);
+  if (!data) return false;
+
+  if (learningOn) session.userMessageContent = data.userMessages;
+  session.toolsUsed = data.toolsUsed;
+  session.filesModified = data.filesModified;
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Draft generation + background enrichment
 // ---------------------------------------------------------------------------
@@ -366,6 +407,7 @@ module.exports = {
   draftIsStale,
   learningCaptureEnabled,
   pruneUngatedProse,
+  applyTranscriptToSession,
   tryGenerateAutoDiary,
   spawnDiaryEnricher,
   runDiaryCapture,

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -19,7 +19,8 @@
  * imported by inject-context and the curator batch-assembler.
  *
  * Consent split (D-009 / D-010): the draft is continuity and is written either
- * way, from counts alone. ENRICHMENT is not — it hands a session summary to a
+ * way, from the session record's counts, tool names and modified paths.
+ * ENRICHMENT is not — it hands a session summary to a
  * model — so it runs only when learning is enabled in some scope. With learning
  * off the draft therefore keeps its `TO BE ENRICHED` stubs permanently; that is
  * the contract, not a failure.

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -131,11 +131,19 @@ function draftIsStale(filePath) {
  * not pay learning.js's module-load cost on every tool call. The gate is only
  * ever consulted from the Stop/PreCompact paths, which are already off it.
  *
+ * Fails CLOSED on a missing projectRoot rather than falling back to
+ * process.cwd(): consent belongs to a project the caller named, and a cwd is
+ * whatever directory the host happened to start the hook in. Answering from it
+ * would let an unrelated project's opt-in authorize this one's capture. A
+ * caller that forgets the argument gets "no consent", never a guess.
+ *
  * @param {Object} [opts]
- * @param {string} [opts.projectRoot] - Project root whose scoped config to read.
+ * @param {string} [opts.projectRoot] - Project root whose scoped config to
+ *   read. Omitted or blank means no consent.
  * @returns {boolean}
  */
-function learningCaptureEnabled({ projectRoot = process.cwd() } = {}) {
+function learningCaptureEnabled({ projectRoot } = {}) {
+  if (typeof projectRoot !== 'string' || projectRoot.trim() === '') return false;
   try {
     const { isLearningEnabledAnyScope } = require('./learning');
     return isLearningEnabledAnyScope({ projectRoot });
@@ -285,15 +293,19 @@ function spawnDiaryEnricher(draftPath, transcriptData, project) {
  * event-specific work (queuing diary-ready vs reflect-ready, session-file
  * updates).
  *
- * `projectRoot` is required for the consent gate and is deliberately explicit:
- * defaulting it to process.cwd() would make the answer depend on wherever the
- * caller happened to be running from.
+ * `projectRoot` carries the consent gate and is deliberately explicit: it is
+ * never defaulted to process.cwd(), which would make the answer depend on
+ * wherever the caller happened to be running from. Omit it and the gate reads
+ * as "no consent" (learningCaptureEnabled fails closed) — the draft is still
+ * written, the enricher is not spawned. That is a degraded call, not an error:
+ * hooks silently catch, so throwing here would take the draft down with it.
  *
  * @param {Object} opts
  * @param {string} opts.project
  * @param {string} opts.date
  * @param {string} opts.sessionId
- * @param {string} opts.projectRoot - Project root the learning opt-in is read from.
+ * @param {string} opts.projectRoot - Project root the learning opt-in is read
+ *   from. Omitted means no consent: draft yes, enrichment no.
  * @param {Object} [opts.transcriptData] - { userMessages, toolsUsed, filesModified, stats }.
  * @returns {{ triggered: boolean, draftPath: string|null, enriched: boolean,
  *   userCount: number, toolCount: number }}

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -17,6 +17,12 @@
  * (getSuggesterStatePath) so ICL-9's compaction reset re-uses one filename
  * instead of re-deriving it, and the SOLE stale-draft probe (draftIsStale)
  * imported by inject-context and the curator batch-assembler.
+ *
+ * Consent split (D-009 / D-010): the draft is continuity and is written either
+ * way, from counts alone. ENRICHMENT is not — it hands a session summary to a
+ * model — so it runs only when learning is enabled in some scope. With learning
+ * off the draft therefore keeps its `TO BE ENRICHED` stubs permanently; that is
+ * the contract, not a failure.
  */
 
 const fs = require('node:fs');
@@ -114,6 +120,32 @@ function draftIsStale(filePath) {
 }
 
 // ---------------------------------------------------------------------------
+// Consent gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the learning opt-in authorizes handing session content to a model.
+ *
+ * `./learning` is required LAZILY on purpose: compact-suggester imports this
+ * module on the synchronous PostToolUse path (hooks B-7), and that path must
+ * not pay learning.js's module-load cost on every tool call. The gate is only
+ * ever consulted from the Stop/PreCompact paths, which are already off it.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.projectRoot] - Project root whose scoped config to read.
+ * @returns {boolean}
+ */
+function learningCaptureEnabled({ projectRoot = process.cwd() } = {}) {
+  try {
+    const { isLearningEnabledAnyScope } = require('./learning');
+    return isLearningEnabledAnyScope({ projectRoot });
+  } catch {
+    // Unreadable config is not consent.
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Draft generation + background enrichment
 // ---------------------------------------------------------------------------
 
@@ -147,6 +179,24 @@ function tryGenerateAutoDiary(project, date, sessionId) {
  * (inject-context) skips consuming the user's pending actions — otherwise the
  * detached enricher's session would eat diary-ready / reflect-ready /
  * ratify-pending before the user's next session sees them.
+ *
+ * Permissions (D-009). The run used to pass --dangerously-skip-permissions,
+ * which bypasses every check in the child. It now carries the narrowest set
+ * that still enriches, verified by spike against the real CLI:
+ *   --tools Read,Write        the only tools that exist in the child at all.
+ *   --add-dir <draft dir>     the draft lives outside the spawning cwd, so
+ *                             without this the write is refused outright.
+ *   --permission-mode acceptEdits
+ *                             auto-approves file edits inside those
+ *                             directories, replacing the blanket bypass. It is
+ *                             required, not a convenience: a detached run has
+ *                             nobody to answer a permission prompt, so without
+ *                             it the write simply hangs and the draft is never
+ *                             filled in.
+ *
+ * A per-file --allowed-tools allowlist was tried and deliberately left out: it
+ * pre-approves, it does not deny, so it changed nothing here and would have
+ * read like a confinement it does not provide.
  *
  * @param {string} draftPath - Path to the draft to enrich.
  * @param {Object} transcriptData - { userMessages, toolsUsed, filesModified, stats }.
@@ -185,7 +235,10 @@ function spawnDiaryEnricher(draftPath, transcriptData, project) {
         '--max-turns',
         '10',
         '--print',
-        '--dangerously-skip-permissions',
+        '--add-dir',
+        path.dirname(draftPath),
+        '--permission-mode',
+        'acceptEdits',
         '--system-prompt',
         systemPrompt,
         '--tools',
@@ -221,33 +274,44 @@ function spawnDiaryEnricher(draftPath, transcriptData, project) {
  * Shared diary-capture core for Stop and PreCompact.
  *
  * Reads the counters, gates on the shared threshold, and on a hit: generates a
- * draft, spawns the background enricher (BOTH event paths), then resets the
- * counters (the sole reset). Callers handle event-specific work (queuing
- * diary-ready vs reflect-ready, session-file updates).
+ * draft, spawns the background enricher when the learning opt-in allows it
+ * (BOTH event paths), then resets the counters (the sole reset). Callers handle
+ * event-specific work (queuing diary-ready vs reflect-ready, session-file
+ * updates).
+ *
+ * `projectRoot` is required for the consent gate and is deliberately explicit:
+ * defaulting it to process.cwd() would make the answer depend on wherever the
+ * caller happened to be running from.
  *
  * @param {Object} opts
  * @param {string} opts.project
  * @param {string} opts.date
  * @param {string} opts.sessionId
+ * @param {string} opts.projectRoot - Project root the learning opt-in is read from.
  * @param {Object} [opts.transcriptData] - { userMessages, toolsUsed, filesModified, stats }.
- * @returns {{ triggered: boolean, draftPath: string|null, userCount: number, toolCount: number }}
+ * @returns {{ triggered: boolean, draftPath: string|null, enriched: boolean,
+ *   userCount: number, toolCount: number }}
  */
 function runDiaryCapture(opts) {
-  const { project, date, sessionId, transcriptData = {} } = opts;
+  const { project, date, sessionId, projectRoot, transcriptData = {} } = opts;
   const { userCount, toolCount } = readCounts();
 
   if (!shouldTrigger(userCount, toolCount)) {
-    return { triggered: false, draftPath: null, userCount, toolCount };
+    return { triggered: false, draftPath: null, enriched: false, userCount, toolCount };
   }
 
   const draftPath = tryGenerateAutoDiary(project, date, sessionId);
-  if (draftPath) {
+
+  // The draft is continuity and is always written; enrichment sends a session
+  // summary to a model, so it waits for the opt-in (D-009).
+  const enriched = Boolean(draftPath) && learningCaptureEnabled({ projectRoot });
+  if (enriched) {
     spawnDiaryEnricher(draftPath, transcriptData, project);
   }
 
   resetCounters();
 
-  return { triggered: true, draftPath, userCount, toolCount };
+  return { triggered: true, draftPath, enriched, userCount, toolCount };
 }
 
 module.exports = {
@@ -257,6 +321,7 @@ module.exports = {
   incrementSharedToolCount,
   getSuggesterStatePath,
   draftIsStale,
+  learningCaptureEnabled,
   tryGenerateAutoDiary,
   spawnDiaryEnricher,
   runDiaryCapture,

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -220,6 +220,70 @@ function applyTranscriptToSession(session, transcriptPath, { learningOn = false 
 }
 
 // ---------------------------------------------------------------------------
+// The enricher's session summary — built once, from the record both hooks write
+// ---------------------------------------------------------------------------
+
+/**
+ * Duration in minutes between two ISO timestamps, or null if either is missing.
+ * Moved here verbatim from the Stop hook when PreCompact needed the same stats
+ * line; it is a pure function of the record, never Stop-specific.
+ *
+ * @param {string} startISO
+ * @param {string} endISO
+ * @returns {number|null}
+ */
+function calculateDurationMinutes(startISO, endISO) {
+  if (!startISO || !endISO) return null;
+  const durationMs = new Date(endISO) - new Date(startISO);
+  return Math.round(durationMs / 60000);
+}
+
+/**
+ * Format the session's activity as the one-liner the enricher prompt carries.
+ * @param {Object} session
+ * @returns {string}
+ */
+function formatSessionStats(session) {
+  const duration = calculateDurationMinutes(session.started, session.lastUpdated);
+
+  let stats = `${session.userMessages || 0} messages, ${session.toolCalls} tool calls`;
+  if (duration > 0) {
+    stats = `~${duration} min, ${stats}`;
+  }
+  if (session.filesModified?.length > 0) {
+    stats += `, ${session.filesModified.length} files modified`;
+  }
+  return stats;
+}
+
+/**
+ * Build the session summary handed to the background enricher — the shape
+ * spawnDiaryEnricher serializes into its prompt and runDiaryCapture documents.
+ *
+ * Both event paths build it from the same place: Stop from the record it just
+ * closed, PreCompact from the record it just stamped. A compaction used to hand
+ * the enricher `{}`, so the draft's prose sections were enriched from nothing
+ * even after its metrics were correct.
+ *
+ * The opt-in needs no check here and deliberately gets none: `userMessageContent`
+ * is only ever in the record while learning is on (pruneUngatedProse removes it
+ * otherwise, and applyTranscriptToSession never writes it), so with learning off
+ * this yields `userMessages: []` by construction — and runDiaryCapture does not
+ * spawn the enricher at all in that state.
+ *
+ * @param {Object} session - Session record.
+ * @returns {{ userMessages: string[], toolsUsed: string[], filesModified: string[], stats: string }}
+ */
+function buildSessionSummary(session) {
+  return {
+    userMessages: session.userMessageContent || [],
+    toolsUsed: session.toolsUsed || [],
+    filesModified: session.filesModified || [],
+    stats: formatSessionStats(session),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Draft generation + background enrichment
 // ---------------------------------------------------------------------------
 
@@ -408,6 +472,8 @@ module.exports = {
   learningCaptureEnabled,
   pruneUngatedProse,
   applyTranscriptToSession,
+  calculateDurationMinutes,
+  buildSessionSummary,
   tryGenerateAutoDiary,
   spawnDiaryEnricher,
   runDiaryCapture,

--- a/scripts/lib/diary-capture.js
+++ b/scripts/lib/diary-capture.js
@@ -198,6 +198,12 @@ function tryGenerateAutoDiary(project, date, sessionId) {
  * pre-approves, it does not deny, so it changed nothing here and would have
  * read like a confinement it does not provide.
  *
+ * What this is NOT, so no caller or doc overstates it: no `cwd` is passed, so
+ * the child inherits this process's working directory — the user's project —
+ * and --add-dir ADDS the draft's directory alongside it rather than restricting
+ * the run to it. Together with acceptEdits that means edits are auto-approved
+ * across both. This is a narrowing of the old blanket bypass, not a sandbox.
+ *
  * @param {string} draftPath - Path to the draft to enrich.
  * @param {Object} transcriptData - { userMessages, toolsUsed, filesModified, stats }.
  * @param {string} project - Project name (for the enricher.log location).

--- a/scripts/lib/learning.js
+++ b/scripts/lib/learning.js
@@ -130,15 +130,19 @@ function isLearningEnabledAnyScope({ projectRoot = process.cwd(), homeDir } = {}
  * false alarm to the opt-in boundary instead of removing it.
  *
  * The source is `updated_at`, which `setLearningEnabled` writes and nothing
- * else in the engine touches. A config without it (hand-written, or older than
- * the field) falls back to the file's mtime; one that cannot be stat'd returns
- * 0, so an unreadable timestamp warns about everything rather than going quiet
- * on a real failure. When both scopes are enabled the EARLIEST wins — that is
- * the moment enrichment first became authorized.
+ * else in the engine touches. It stamps a state CHANGE, not a write, so
+ * re-running `learn enable` on an already-enabled scope leaves the floor where
+ * the real opt-in put it. A config without it (hand-written, or older than the
+ * field) falls back to the file's mtime; one that cannot be stat'd returns 0,
+ * so an unreadable timestamp warns about everything rather than going quiet on
+ * a real failure. When both scopes are enabled the EARLIEST wins — that is the
+ * moment enrichment first became authorized.
  *
  * Accepted cost: disabling and re-enabling moves the floor forward, so drafts
  * left stale before the toggle stop being reported. A missed warning is the
- * cheaper failure than a permanent one about intended behavior.
+ * cheaper failure than a permanent one about intended behavior. Since an
+ * idempotent re-run preserves the stamp, that toggle is the only way the floor
+ * moves — and it is a real consent boundary, which a repeated enable is not.
  *
  * @param {Object} [opts]
  * @param {string} [opts.projectRoot] - Project root whose scoped config to read.
@@ -192,7 +196,15 @@ function setLearningEnabled({
   now = new Date().toISOString(),
 } = {}) {
   assertScope(scope);
-  const config = { scope, enabled: enabled === true, updated_at: now };
+  const next = enabled === true;
+  const previous = readScopeConfig({ scope, projectRoot, homeDir });
+  // `updated_at` stamps the TRANSITION, not the write. `learningEnabledSince`
+  // reads it as "when the opt-in took effect", so a command that changes
+  // nothing must not move it — advancing the floor there would silently retire
+  // stale-draft warnings for drafts written since the actual opt-in.
+  const keepStamp =
+    previous.enabled === next && !Number.isNaN(Date.parse(previous.updated_at ?? ''));
+  const config = { scope, enabled: next, updated_at: keepStamp ? previous.updated_at : now };
   writeJsonFile(getLearningConfigPath({ scope, projectRoot, homeDir }), config);
   return config;
 }

--- a/scripts/lib/learning.js
+++ b/scripts/lib/learning.js
@@ -99,6 +99,27 @@ function isLearningEnabled({ scope = 'project', projectRoot = process.cwd(), hom
 }
 
 /**
+ * True when learning is enabled in EITHER scope.
+ *
+ * The one question every capture path asks: a user who opted in globally must
+ * not have to opt in again per project, and a project opt-in must work without
+ * the global one. Enabling is scoped (`--project` / `--global`); *being*
+ * enabled is not, so consent lives in one predicate instead of a disjunction
+ * re-derived at each call site.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.projectRoot] - Project root whose scoped config to read.
+ * @param {string} [opts.homeDir] - Override for the global config's home.
+ * @returns {boolean}
+ */
+function isLearningEnabledAnyScope({ projectRoot = process.cwd(), homeDir } = {}) {
+  return (
+    isLearningEnabled({ scope: 'project', projectRoot, homeDir }) ||
+    isLearningEnabled({ scope: 'global', projectRoot, homeDir })
+  );
+}
+
+/**
  * Kill-switch for SessionStart injection of activated instincts (ICL-4).
  *
  * DEFAULT ON: injection happens unless `inject_activated_instincts` is set to
@@ -751,6 +772,7 @@ module.exports = {
   getProjectId,
   inspectCandidate,
   isLearningEnabled,
+  isLearningEnabledAnyScope,
   isInjectActivatedInstinctsEnabled,
   listLearningInbox,
   listMaterializedDrafts,

--- a/scripts/lib/learning.js
+++ b/scripts/lib/learning.js
@@ -132,11 +132,15 @@ function isLearningEnabledAnyScope({ projectRoot = process.cwd(), homeDir } = {}
  * The source is `updated_at`, which `setLearningEnabled` writes and nothing
  * else in the engine touches. It stamps a state CHANGE, not a write, so
  * re-running `learn enable` on an already-enabled scope leaves the floor where
- * the real opt-in put it. A config without it (hand-written, or older than the
- * field) falls back to the file's mtime; one that cannot be stat'd returns 0,
- * so an unreadable timestamp warns about everything rather than going quiet on
- * a real failure. When both scopes are enabled the EARLIEST wins — that is the
- * moment enrichment first became authorized.
+ * the real opt-in put it. A config without it (hand-written) falls back to the
+ * file's mtime, and a write that changes nothing persists that mtime as the
+ * field, so the fallback is computed once rather than re-derived on every read
+ * — a write moves the mtime, so re-deriving would drag the floor forward with
+ * it. (A write that DOES change the state stamps the transition, as always.) A
+ * config that cannot be stat'd returns 0, so an unreadable timestamp warns
+ * about everything rather than going quiet on a real failure. When both scopes
+ * are enabled the EARLIEST wins — that is the moment enrichment first became
+ * authorized.
  *
  * Accepted cost: a disable moves the floor forward, so drafts left stale
  * before it stop being reported. That includes the overlapping case — global
@@ -175,6 +179,21 @@ function scopeEnabledAt(config, configPath) {
 }
 
 /**
+ * The stamp an unchanged scope must keep, or null when there is none to keep.
+ *
+ * A parseable `updated_at` is kept VERBATIM rather than re-serialized, so a
+ * hand-written stamp survives a no-op command unaltered. Otherwise the
+ * effective floor — the file mtime that `scopeEnabledAt` falls back to — is
+ * materialized into the field it stands in for, which is what keeps
+ * `learningEnabledSince` reading the same instant after the write as before it.
+ */
+function preservedStamp(config, configPath) {
+  if (!Number.isNaN(Date.parse(config.updated_at ?? ''))) return config.updated_at;
+  const at = scopeEnabledAt(config, configPath);
+  return at > 0 ? new Date(at).toISOString() : null;
+}
+
+/**
  * Kill-switch for SessionStart injection of activated instincts (ICL-4).
  *
  * DEFAULT ON: injection happens unless `inject_activated_instincts` is set to
@@ -200,15 +219,19 @@ function setLearningEnabled({
 } = {}) {
   assertScope(scope);
   const next = enabled === true;
+  const configPath = getLearningConfigPath({ scope, projectRoot, homeDir });
   const previous = readScopeConfig({ scope, projectRoot, homeDir });
   // `updated_at` stamps the TRANSITION, not the write. `learningEnabledSince`
   // reads it as "when the opt-in took effect", so a command that changes
   // nothing must not move it — advancing the floor there would silently retire
-  // stale-draft warnings for drafts written since the actual opt-in.
-  const keepStamp =
-    previous.enabled === next && !Number.isNaN(Date.parse(previous.updated_at ?? ''));
-  const config = { scope, enabled: next, updated_at: keepStamp ? previous.updated_at : now };
-  writeJsonFile(getLearningConfigPath({ scope, projectRoot, homeDir }), config);
+  // stale-draft warnings for drafts written since the actual opt-in. A config
+  // that never carried the field is read as its file mtime, so an unchanged
+  // state persists THAT rather than `now`; the write itself moves the mtime,
+  // which is exactly why the fallback has to be captured here instead of
+  // re-derived on the next read.
+  const preserved = previous.enabled === next ? preservedStamp(previous, configPath) : null;
+  const config = { scope, enabled: next, updated_at: preserved ?? now };
+  writeJsonFile(configPath, config);
   return config;
 }
 

--- a/scripts/lib/learning.js
+++ b/scripts/lib/learning.js
@@ -138,11 +138,14 @@ function isLearningEnabledAnyScope({ projectRoot = process.cwd(), homeDir } = {}
  * a real failure. When both scopes are enabled the EARLIEST wins — that is the
  * moment enrichment first became authorized.
  *
- * Accepted cost: disabling and re-enabling moves the floor forward, so drafts
- * left stale before the toggle stop being reported. A missed warning is the
- * cheaper failure than a permanent one about intended behavior. Since an
- * idempotent re-run preserves the stamp, that toggle is the only way the floor
- * moves — and it is a real consent boundary, which a repeated enable is not.
+ * Accepted cost: a disable moves the floor forward, so drafts left stale
+ * before it stop being reported. That includes the overlapping case — global
+ * on at T1, project on at T2, global off at T3 — where any-scope authorization
+ * never lapsed yet the floor becomes T2: a scope's `updated_at` records its
+ * latest transition, so the disable overwrites the enable it replaced and T1 is
+ * not recoverable from state. A missed warning is the cheaper failure than a
+ * permanent one about intended behavior, and an idempotent re-enable preserves
+ * the stamp, so only a real consent toggle moves the floor.
  *
  * @param {Object} [opts]
  * @param {string} [opts.projectRoot] - Project root whose scoped config to read.

--- a/scripts/lib/learning.js
+++ b/scripts/lib/learning.js
@@ -120,6 +120,54 @@ function isLearningEnabledAnyScope({ projectRoot = process.cwd(), homeDir } = {}
 }
 
 /**
+ * Timestamp at which the learning opt-in took effect, in epoch ms.
+ *
+ * `isLearningEnabledAnyScope` answers "may we capture now"; this answers "since
+ * when", which is what any healthcheck over accumulated artifacts needs. With
+ * learning off, diary drafts keep their unfilled sections by design (D-009), so
+ * every stub from that period is expected. A check that only asked "is learning
+ * on" would report the whole backlog the moment a user opted in — moving the
+ * false alarm to the opt-in boundary instead of removing it.
+ *
+ * The source is `updated_at`, which `setLearningEnabled` writes and nothing
+ * else in the engine touches. A config without it (hand-written, or older than
+ * the field) falls back to the file's mtime; one that cannot be stat'd returns
+ * 0, so an unreadable timestamp warns about everything rather than going quiet
+ * on a real failure. When both scopes are enabled the EARLIEST wins — that is
+ * the moment enrichment first became authorized.
+ *
+ * Accepted cost: disabling and re-enabling moves the floor forward, so drafts
+ * left stale before the toggle stop being reported. A missed warning is the
+ * cheaper failure than a permanent one about intended behavior.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.projectRoot] - Project root whose scoped config to read.
+ * @param {string} [opts.homeDir] - Override for the global config's home.
+ * @returns {number|null} Epoch ms, or null when learning is off in both scopes.
+ */
+function learningEnabledSince({ projectRoot = process.cwd(), homeDir } = {}) {
+  let earliest = null;
+  for (const scope of ['project', 'global']) {
+    const config = readScopeConfig({ scope, projectRoot, homeDir });
+    if (config.enabled !== true) continue;
+    const at = scopeEnabledAt(config, getLearningConfigPath({ scope, projectRoot, homeDir }));
+    if (earliest === null || at < earliest) earliest = at;
+  }
+  return earliest;
+}
+
+/** When one enabled scope was last written. See learningEnabledSince. */
+function scopeEnabledAt(config, configPath) {
+  const stamped = Date.parse(config.updated_at ?? '');
+  if (!Number.isNaN(stamped)) return stamped;
+  try {
+    return fs.statSync(configPath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/**
  * Kill-switch for SessionStart injection of activated instincts (ICL-4).
  *
  * DEFAULT ON: injection happens unless `inject_activated_instincts` is set to
@@ -773,6 +821,7 @@ module.exports = {
   inspectCandidate,
   isLearningEnabled,
   isLearningEnabledAnyScope,
+  learningEnabledSince,
   isInjectActivatedInstinctsEnabled,
   listLearningInbox,
   listMaterializedDrafts,

--- a/tests/scripts/auto-diary.test.js
+++ b/tests/scripts/auto-diary.test.js
@@ -10,6 +10,8 @@ const {
   summarizeObservations,
   parseArgs,
 } = require('../../scripts/lib/auto-diary');
+const { getSessionDir } = require('../../scripts/lib/utils');
+const { getObservationsPath } = require('../../scripts/lib/session-utils');
 
 describe('auto-diary', () => {
   const testDir = path.join(os.tmpdir(), `auto-diary-test-${Date.now()}`);
@@ -83,6 +85,65 @@ describe('auto-diary', () => {
     it('includes draft timestamp', () => {
       const draft = generateDraft('test-project', '2026-02-08', 'test-session');
       expect(draft).toContain('_Draft generated at');
+    });
+
+    // The always-on draft carries more than counts: the file paths the session
+    // touched, and a tool-usage aggregate when observations already exist.
+    // product/specs/hooks.md B-6 documents both — these pin them.
+    describe('what the always-on draft actually renders (hooks B-6)', () => {
+      const project = 'draft-content-project';
+      const date = '2026-02-08';
+      const sessionId = 'sess-1';
+      const originalArcforgeHome = process.env.ARCFORGE_HOME;
+
+      beforeEach(() => {
+        // getArcforgeHome() reads ARCFORGE_HOME first — without this an
+        // inherited value would point these tests at a real diary store.
+        process.env.ARCFORGE_HOME = path.join(testDir, 'arcforge-home');
+        const sessionDir = getSessionDir(project, date);
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(sessionDir, `${sessionId}.json`),
+          JSON.stringify({
+            started: '2026-02-08T10:00:00.000Z',
+            lastUpdated: '2026-02-08T10:30:00.000Z',
+            toolCalls: 5,
+            userMessages: 2,
+            compactions: [],
+            filesModified: ['src/billing.ts', 'notes/private.md'],
+          }),
+        );
+      });
+
+      afterEach(() => {
+        if (originalArcforgeHome === undefined) delete process.env.ARCFORGE_HOME;
+        else process.env.ARCFORGE_HOME = originalArcforgeHome;
+      });
+
+      it('renders the modified-file paths from the session record', () => {
+        const draft = generateDraft(project, date, sessionId);
+        expect(draft).toContain('**Files modified**:');
+        expect(draft).toContain('src/billing.ts');
+        expect(draft).toContain('notes/private.md');
+      });
+
+      it('includes the tool-usage aggregate only when an observations log exists', () => {
+        expect(generateDraft(project, date, sessionId)).not.toContain('## Tool Usage Summary');
+
+        const obsPath = getObservationsPath(project);
+        fs.mkdirSync(path.dirname(obsPath), { recursive: true });
+        fs.writeFileSync(
+          obsPath,
+          `${[
+            JSON.stringify({ event: 'tool_start', tool: 'Read' }),
+            JSON.stringify({ event: 'tool_start', tool: 'Edit' }),
+          ].join('\n')}\n`,
+        );
+
+        const withObservations = generateDraft(project, date, sessionId);
+        expect(withObservations).toContain('## Tool Usage Summary');
+        expect(withObservations).toContain('**Most used**:');
+      });
     });
   });
 

--- a/tests/scripts/auto-diary.test.js
+++ b/tests/scripts/auto-diary.test.js
@@ -88,8 +88,10 @@ describe('auto-diary', () => {
     });
 
     // The always-on draft carries more than counts: the file paths the session
-    // touched, and a tool-usage aggregate when observations already exist.
-    // product/specs/hooks.md B-6 documents both — these pin them.
+    // touched, and a tool-usage aggregate when observations already exist. What
+    // it does NOT carry is the session record's tool NAMES — those reach a draft
+    // only through the aggregate, which is itself gated on observation.
+    // product/specs/hooks.md B-6 documents all three — these pin them.
     describe('what the always-on draft actually renders (hooks B-6)', () => {
       const project = 'draft-content-project';
       const date = '2026-02-08';
@@ -110,6 +112,7 @@ describe('auto-diary', () => {
             toolCalls: 5,
             userMessages: 2,
             compactions: [],
+            toolsUsed: ['Read', 'Edit', 'Bash'],
             filesModified: ['src/billing.ts', 'notes/private.md'],
           }),
         );
@@ -125,6 +128,18 @@ describe('auto-diary', () => {
         expect(draft).toContain('**Files modified**:');
         expect(draft).toContain('src/billing.ts');
         expect(draft).toContain('notes/private.md');
+      });
+
+      // The session record holds toolsUsed either way, but the draft never reads
+      // it. With no observations log — a fresh learning-off install — a draft
+      // therefore names no tool at all. Pinning the absence keeps the spec
+      // honest: nothing else in the gate can evaluate that claim.
+      it('renders no tool names when there is no observations log', () => {
+        const draft = generateDraft(project, date, sessionId);
+        expect(draft).not.toContain('Tools Used');
+        for (const tool of ['Read', 'Edit', 'Bash']) {
+          expect(draft).not.toContain(tool);
+        }
       });
 
       it('includes the tool-usage aggregate only when an observations log exists', () => {

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -258,11 +258,13 @@ describe('diary-capture', () => {
       savedPath = process.env.PATH;
       process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
       // Stub `claude` so the REAL argv the enricher spawns with is recorded,
-      // one argument per line (paths contain no newlines).
+      // one argument per line (paths contain no newlines). The lines go to a
+      // temp file and are renamed into place, so the poller below can never
+      // read a half-written argv and miss a flag that is simply not there yet.
       const argvFile = path.join(binDir, 'argv.txt');
       fs.writeFileSync(
         path.join(binDir, 'claude'),
-        `#!/bin/sh\ncat > /dev/null\nfor a in "$@"; do printf '%s\\n' "$a"; done > "${argvFile}"\n`,
+        `#!/bin/sh\ncat > /dev/null\nfor a in "$@"; do printf '%s\\n' "$a"; done > "${argvFile}.tmp"\nmv "${argvFile}.tmp" "${argvFile}"\n`,
         { mode: 0o755 },
       );
     });

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -197,6 +197,42 @@ describe('diary-capture', () => {
     });
   });
 
+  // The summary the enricher prompt carries. Both hooks build it here so the
+  // compaction path cannot drift from Stop's.
+  describe('buildSessionSummary', () => {
+    it("carries the record's prose, tool names, paths and a stats line", () => {
+      const { buildSessionSummary } = require('../../scripts/lib/diary-capture');
+      const summary = buildSessionSummary({
+        started: '2025-01-01T10:00:00Z',
+        lastUpdated: '2025-01-01T10:30:00Z',
+        userMessages: 12,
+        toolCalls: 55,
+        userMessageContent: ['ship the fix'],
+        toolsUsed: ['Edit', 'Bash'],
+        filesModified: ['/repo/a.js'],
+      });
+
+      expect(summary).toEqual({
+        userMessages: ['ship the fix'],
+        toolsUsed: ['Edit', 'Bash'],
+        filesModified: ['/repo/a.js'],
+        stats: '~30 min, 12 messages, 55 tool calls, 1 files modified',
+      });
+    });
+
+    it('yields empty lists — never undefined — for a record with nothing parsed', () => {
+      const { buildSessionSummary } = require('../../scripts/lib/diary-capture');
+      // The learning-off shape: pruneUngatedProse has removed the prose, so the
+      // summary carries none by construction rather than by a second gate.
+      const summary = buildSessionSummary({ userMessages: 0, toolCalls: 3 });
+
+      expect(summary.userMessages).toEqual([]);
+      expect(summary.toolsUsed).toEqual([]);
+      expect(summary.filesModified).toEqual([]);
+      expect(summary.stats).toBe('0 messages, 3 tool calls');
+    });
+  });
+
   describe('runDiaryCapture threshold gating', () => {
     it('does NOT trigger or reset below threshold', () => {
       const { createSessionCounter } = require('../../scripts/lib/utils');

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -124,6 +124,79 @@ describe('diary-capture', () => {
     });
   });
 
+  // The stamp both hooks run above the threshold: Stop closes the record with
+  // it, PreCompact refreshes the record the draft is about to be rendered from.
+  describe('applyTranscriptToSession', () => {
+    /** A transcript carrying user prose plus Edit/Write/Bash tool uses. */
+    function writeTranscript() {
+      const transcriptPath = path.join(tmpDir, 'transcript.jsonl');
+      fs.writeFileSync(
+        transcriptPath,
+        `${[
+          JSON.stringify({
+            type: 'user',
+            message: { role: 'user', content: [{ type: 'text', text: 'ship the fix' }] },
+          }),
+          JSON.stringify({
+            type: 'assistant',
+            message: {
+              content: [{ type: 'tool_use', name: 'Edit', input: { file_path: '/repo/a.js' } }],
+            },
+          }),
+          JSON.stringify({
+            type: 'assistant',
+            message: { content: [{ type: 'tool_use', name: 'Bash', input: {} }] },
+          }),
+        ].join('\n')}\n`,
+      );
+      return transcriptPath;
+    }
+
+    it('stamps tool names and paths but no prose when the opt-in is off', () => {
+      const { applyTranscriptToSession } = require('../../scripts/lib/diary-capture');
+      const session = {};
+
+      expect(applyTranscriptToSession(session, writeTranscript(), { learningOn: false })).toBe(
+        true,
+      );
+      expect(session.toolsUsed).toEqual(['Edit', 'Bash']);
+      expect(session.filesModified).toEqual(['/repo/a.js']);
+      expect(session.userMessageContent).toBeUndefined();
+    });
+
+    it('stamps the verbatim prose when the opt-in is on', () => {
+      const { applyTranscriptToSession } = require('../../scripts/lib/diary-capture');
+      const session = {};
+
+      expect(applyTranscriptToSession(session, writeTranscript(), { learningOn: true })).toBe(true);
+      expect(session.userMessageContent).toEqual(['ship the fix']);
+    });
+
+    it('defaults to no prose when the gate is not passed at all', () => {
+      const { applyTranscriptToSession } = require('../../scripts/lib/diary-capture');
+      const session = {};
+
+      expect(applyTranscriptToSession(session, writeTranscript())).toBe(true);
+      expect(session.userMessageContent).toBeUndefined();
+    });
+
+    it('leaves the record untouched when there is nothing to parse', () => {
+      const { applyTranscriptToSession } = require('../../scripts/lib/diary-capture');
+      const carried = { toolsUsed: ['Edit'], filesModified: ['/repo/carried.js'] };
+      const empty = path.join(tmpDir, 'empty.jsonl');
+      fs.writeFileSync(empty, '');
+
+      // Missing path, unreadable path, and a file that parses to nothing all
+      // report false — a compaction keeps the paths an earlier Stop wrote
+      // rather than blanking a record it cannot refresh.
+      expect(applyTranscriptToSession(carried, undefined, { learningOn: true })).toBe(false);
+      expect(applyTranscriptToSession(carried, path.join(tmpDir, 'nope.jsonl'))).toBe(false);
+      expect(applyTranscriptToSession(carried, empty)).toBe(false);
+      expect(carried).toEqual({ toolsUsed: ['Edit'], filesModified: ['/repo/carried.js'] });
+      expect(applyTranscriptToSession(null, writeTranscript())).toBe(false);
+    });
+  });
+
   describe('runDiaryCapture threshold gating', () => {
     it('does NOT trigger or reset below threshold', () => {
       const { createSessionCounter } = require('../../scripts/lib/utils');

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -262,7 +262,7 @@ describe('diary-capture', () => {
       return null;
     }
 
-    it('drops --dangerously-skip-permissions and confines the run to the draft dir', async () => {
+    it('drops --dangerously-skip-permissions and adds the draft dir with acceptEdits', async () => {
       const { spawnDiaryEnricher } = require('../../scripts/lib/diary-capture');
       const draftPath = path.join(homeDir, '.arcforge', 'diaries', 'demo', '2026-06-14', 'd.md');
       fs.mkdirSync(path.dirname(draftPath), { recursive: true });

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -93,6 +93,37 @@ describe('diary-capture', () => {
     });
   });
 
+  // D-010's retention half: the opt-in decides how long verbatim prose may stay
+  // in the session record, not only whether it is written there.
+  describe('pruneUngatedProse', () => {
+    it('deletes carried prose when the opt-in is off and reports no consent', () => {
+      const { pruneUngatedProse } = require('../../scripts/lib/diary-capture');
+      const session = { userMessageContent: ['a secret sentence'], toolsUsed: ['Edit'] };
+
+      expect(pruneUngatedProse(session, { projectRoot })).toBe(false);
+      expect(session.userMessageContent).toBeUndefined();
+      expect(session.toolsUsed).toEqual(['Edit']);
+    });
+
+    it('leaves the record alone when the opt-in is on', () => {
+      enableLearning();
+      const { pruneUngatedProse } = require('../../scripts/lib/diary-capture');
+      const session = { userMessageContent: ['a secret sentence'] };
+
+      expect(pruneUngatedProse(session, { projectRoot })).toBe(true);
+      expect(session.userMessageContent).toEqual(['a secret sentence']);
+    });
+
+    it('fails closed on a missing projectRoot and tolerates a null session', () => {
+      const { pruneUngatedProse } = require('../../scripts/lib/diary-capture');
+
+      expect(pruneUngatedProse(null)).toBe(false);
+      const session = { userMessageContent: ['a secret sentence'] };
+      expect(pruneUngatedProse(session, {})).toBe(false);
+      expect(session.userMessageContent).toBeUndefined();
+    });
+  });
+
   describe('runDiaryCapture threshold gating', () => {
     it('does NOT trigger or reset below threshold', () => {
       const { createSessionCounter } = require('../../scripts/lib/utils');

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -12,11 +12,15 @@ const os = require('node:os');
 describe('diary-capture', () => {
   let homeDir;
   let tmpDir;
+  let projectRoot;
   let savedSession;
 
   beforeEach(() => {
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diary-capture-home-'));
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diary-capture-tmp-'));
+    // Consent is read from projectRoot, never from the runner's cwd — a temp
+    // root keeps the gate's answer independent of local repo state.
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'diary-capture-proj-'));
     jest.spyOn(os, 'homedir').mockReturnValue(homeDir);
     process.env.TMPDIR = tmpDir;
     savedSession = process.env.CLAUDE_SESSION_ID;
@@ -30,7 +34,15 @@ describe('diary-capture', () => {
     else process.env.CLAUDE_SESSION_ID = savedSession;
     fs.rmSync(homeDir, { recursive: true, force: true });
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(projectRoot, { recursive: true, force: true });
   });
+
+  /** Turn the project-scope learning opt-in on for the temp projectRoot. */
+  function enableLearning() {
+    const configPath = path.join(projectRoot, '.arcforge', 'learning', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+  }
 
   describe('counter ownership', () => {
     it('readCounts reflects both counters', () => {
@@ -92,6 +104,7 @@ describe('diary-capture', () => {
         project: 'demo',
         date: '2026-06-14',
         sessionId: 'diary-capture-session',
+        projectRoot,
       });
 
       expect(result.triggered).toBe(false);
@@ -109,6 +122,7 @@ describe('diary-capture', () => {
         project: 'demo',
         date: '2026-06-14',
         sessionId: 'diary-capture-session',
+        projectRoot,
       });
 
       expect(result.triggered).toBe(true);
@@ -148,7 +162,27 @@ describe('diary-capture', () => {
       return null;
     }
 
-    it('spawns the enricher with ARCFORGE_SPAWNED=enricher when triggered', async () => {
+    it('spawns the enricher with ARCFORGE_SPAWNED=enricher when learning is on', async () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { runDiaryCapture } = require('../../scripts/lib/diary-capture');
+      enableLearning();
+      createSessionCounter('user-count').write(15);
+
+      const result = runDiaryCapture({
+        project: 'demo',
+        date: '2026-06-14',
+        sessionId: 'diary-capture-session',
+        projectRoot,
+      });
+      expect(result.triggered).toBe(true);
+      expect(result.enriched).toBe(true);
+
+      const marker = path.join(binDir, 'spawned.marker');
+      const content = await waitForMarker(marker, 5000);
+      expect(content).toBe('enricher');
+    });
+
+    it('writes the draft but does NOT spawn the enricher when learning is off', async () => {
       const { createSessionCounter } = require('../../scripts/lib/utils');
       const { runDiaryCapture } = require('../../scripts/lib/diary-capture');
       createSessionCounter('user-count').write(15);
@@ -157,12 +191,90 @@ describe('diary-capture', () => {
         project: 'demo',
         date: '2026-06-14',
         sessionId: 'diary-capture-session',
+        projectRoot,
       });
+
+      // Continuity survives the gate; enrichment does not (D-009).
       expect(result.triggered).toBe(true);
+      expect(result.draftPath).toBeTruthy();
+      expect(fs.existsSync(result.draftPath)).toBe(true);
+      expect(result.enriched).toBe(false);
 
       const marker = path.join(binDir, 'spawned.marker');
-      const content = await waitForMarker(marker, 5000);
-      expect(content).toBe('enricher');
+      expect(await waitForMarker(marker, 1000)).toBeNull();
+    });
+
+    it('spawns the enricher on a GLOBAL-scope opt-in too', async () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { runDiaryCapture } = require('../../scripts/lib/diary-capture');
+      const globalConfig = path.join(homeDir, '.arcforge', 'learning', 'config.json');
+      fs.mkdirSync(path.dirname(globalConfig), { recursive: true });
+      fs.writeFileSync(globalConfig, JSON.stringify({ scope: 'global', enabled: true }));
+      createSessionCounter('user-count').write(15);
+
+      const result = runDiaryCapture({
+        project: 'demo',
+        date: '2026-06-14',
+        sessionId: 'diary-capture-session',
+        projectRoot,
+      });
+      expect(result.enriched).toBe(true);
+
+      const marker = path.join(binDir, 'spawned.marker');
+      expect(await waitForMarker(marker, 5000)).toBe('enricher');
+    });
+  });
+
+  describe('enricher permissions (D-009)', () => {
+    let binDir;
+    let savedPath;
+
+    beforeEach(() => {
+      binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diary-capture-argv-'));
+      savedPath = process.env.PATH;
+      process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+      // Stub `claude` so the REAL argv the enricher spawns with is recorded,
+      // one argument per line (paths contain no newlines).
+      const argvFile = path.join(binDir, 'argv.txt');
+      fs.writeFileSync(
+        path.join(binDir, 'claude'),
+        `#!/bin/sh\ncat > /dev/null\nfor a in "$@"; do printf '%s\\n' "$a"; done > "${argvFile}"\n`,
+        { mode: 0o755 },
+      );
+    });
+
+    afterEach(() => {
+      process.env.PATH = savedPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+    });
+
+    async function recordedArgv(timeoutMs) {
+      const file = path.join(binDir, 'argv.txt');
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (fs.existsSync(file)) {
+          const lines = fs.readFileSync(file, 'utf-8').split('\n');
+          lines.pop();
+          if (lines.length > 0) return lines;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      return null;
+    }
+
+    it('drops --dangerously-skip-permissions and confines the run to the draft dir', async () => {
+      const { spawnDiaryEnricher } = require('../../scripts/lib/diary-capture');
+      const draftPath = path.join(homeDir, '.arcforge', 'diaries', 'demo', '2026-06-14', 'd.md');
+      fs.mkdirSync(path.dirname(draftPath), { recursive: true });
+
+      spawnDiaryEnricher(draftPath, { userMessages: [] }, 'demo');
+      const argv = await recordedArgv(5000);
+      expect(argv).not.toBeNull();
+
+      expect(argv).not.toContain('--dangerously-skip-permissions');
+      expect(argv[argv.indexOf('--add-dir') + 1]).toBe(path.dirname(draftPath));
+      expect(argv[argv.indexOf('--permission-mode') + 1]).toBe('acceptEdits');
+      expect(argv[argv.indexOf('--tools') + 1]).toBe('Read,Write');
     });
   });
 });

--- a/tests/scripts/diary-capture.test.js
+++ b/tests/scripts/diary-capture.test.js
@@ -204,6 +204,30 @@ describe('diary-capture', () => {
       expect(await waitForMarker(marker, 1000)).toBeNull();
     });
 
+    it('fails closed when projectRoot is omitted — draft yes, enricher no', async () => {
+      const { createSessionCounter } = require('../../scripts/lib/utils');
+      const { runDiaryCapture } = require('../../scripts/lib/diary-capture');
+      // A GLOBAL opt-in answers true for any projectRoot, so nothing but the
+      // fail-closed guard can stop the spawn here: if the gate ever falls back
+      // to process.cwd() again, this test spawns and fails.
+      const globalConfig = path.join(homeDir, '.arcforge', 'learning', 'config.json');
+      fs.mkdirSync(path.dirname(globalConfig), { recursive: true });
+      fs.writeFileSync(globalConfig, JSON.stringify({ scope: 'global', enabled: true }));
+      createSessionCounter('user-count').write(15);
+
+      const result = runDiaryCapture({
+        project: 'demo',
+        date: '2026-06-14',
+        sessionId: 'diary-capture-session',
+        // projectRoot deliberately omitted.
+      });
+
+      expect(result.triggered).toBe(true);
+      expect(fs.existsSync(result.draftPath)).toBe(true);
+      expect(result.enriched).toBe(false);
+      expect(await waitForMarker(path.join(binDir, 'spawned.marker'), 1000)).toBeNull();
+    });
+
     it('spawns the enricher on a GLOBAL-scope opt-in too', async () => {
       const { createSessionCounter } = require('../../scripts/lib/utils');
       const { runDiaryCapture } = require('../../scripts/lib/diary-capture');

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -193,6 +193,39 @@ describe('learning subsystem MVP-1', () => {
       fs.writeFileSync(configPath, JSON.stringify(config));
       expect(learningEnabledSince({ projectRoot, homeDir })).toBe(fs.statSync(configPath).mtimeMs);
     });
+
+    // Writing an unstamped config MOVES its mtime, so the fallback above has to
+    // be captured before the write rather than re-derived after it — otherwise
+    // an idempotent re-enable silently retires every draft that failed
+    // enrichment between the old mtime and the repeated command.
+    function writeUnstampedEnabledConfig() {
+      const configPath = getLearningConfigPath({ scope: 'project', projectRoot, homeDir });
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+      fs.utimesSync(configPath, new Date(EARLY), new Date(EARLY));
+      return configPath;
+    }
+
+    it('preserves the mtime fallback when an unstamped enabled scope is enabled again', () => {
+      writeUnstampedEnabledConfig();
+      const config = setLearningEnabled({
+        scope: 'project',
+        enabled: true,
+        projectRoot,
+        homeDir,
+        now: LATE,
+      });
+      // The CLI prints this returned config, so it carries the preserved stamp.
+      expect(config.updated_at).toBe(EARLY);
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(EARLY));
+    });
+
+    it('still stamps the transition when an unstamped scope is actually toggled', () => {
+      writeUnstampedEnabledConfig();
+      setLearningEnabled({ scope: 'project', enabled: false, projectRoot, homeDir, now: LATE });
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: LATE });
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(LATE));
+    });
   });
 
   describe('inject_activated_instincts kill-switch (ICL-4)', () => {

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -16,6 +16,7 @@ const {
   isLearningEnabled,
   isLearningEnabledAnyScope,
   isInjectActivatedInstinctsEnabled,
+  learningEnabledSince,
   listLearningInbox,
   loadCandidates,
   materializeCandidate,
@@ -114,6 +115,41 @@ describe('learning subsystem MVP-1', () => {
       setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir });
       setLearningEnabled({ scope: 'global', enabled: true, projectRoot, homeDir });
       expect(isLearningEnabledAnyScope({ projectRoot, homeDir })).toBe(true);
+    });
+  });
+
+  // The stale-draft healthcheck needs "since when", not just "is it on":
+  // drafts from a learning-off period are by-design stubs (D-009).
+  describe('learningEnabledSince', () => {
+    const EARLY = '2026-01-01T00:00:00.000Z';
+    const LATE = '2026-06-01T00:00:00.000Z';
+
+    it('is null when neither scope is enabled', () => {
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBeNull();
+    });
+
+    it("returns the enabled scope's updated_at", () => {
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: LATE });
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(LATE));
+    });
+
+    it('returns the EARLIEST scope — when enrichment first became authorized', () => {
+      setLearningEnabled({ scope: 'global', enabled: true, projectRoot, homeDir, now: EARLY });
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: LATE });
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(EARLY));
+    });
+
+    it('ignores a disabled scope, however recently it was written', () => {
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: EARLY });
+      setLearningEnabled({ scope: 'global', enabled: false, projectRoot, homeDir, now: LATE });
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(EARLY));
+    });
+
+    it('falls back to the config mtime when updated_at is missing', () => {
+      const configPath = getLearningConfigPath({ scope: 'project', projectRoot, homeDir });
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(fs.statSync(configPath).mtimeMs);
     });
   });
 

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -164,6 +164,19 @@ describe('learning subsystem MVP-1', () => {
       expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(LATE));
     });
 
+    // Accepted cost, pinned: disabling the scope that carries the earliest
+    // opt-in advances the floor even though any-scope authorization never
+    // lapsed. A scope's `updated_at` records its latest transition, so the
+    // disable overwrites the enable it replaced (D-009 Residual).
+    it('advances to the surviving scope when the earliest-enabled scope is disabled', () => {
+      const MIDDLE = '2026-03-01T00:00:00.000Z';
+      setLearningEnabled({ scope: 'global', enabled: true, projectRoot, homeDir, now: EARLY });
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: MIDDLE });
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(EARLY));
+      setLearningEnabled({ scope: 'global', enabled: false, projectRoot, homeDir, now: LATE });
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(MIDDLE));
+    });
+
     it('ignores a disabled scope, however recently it was written', () => {
       setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: EARLY });
       setLearningEnabled({ scope: 'global', enabled: false, projectRoot, homeDir, now: LATE });

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -14,6 +14,7 @@ const {
   getLearningConfigPath,
   inspectCandidate,
   isLearningEnabled,
+  isLearningEnabledAnyScope,
   isInjectActivatedInstinctsEnabled,
   listLearningInbox,
   loadCandidates,
@@ -92,6 +93,28 @@ describe('learning subsystem MVP-1', () => {
     });
 
     expect(isLearningEnabled({ scope: 'project', projectRoot, homeDir })).toBe(false);
+  });
+
+  describe('isLearningEnabledAnyScope', () => {
+    it('is false when neither scope is enabled', () => {
+      expect(isLearningEnabledAnyScope({ projectRoot, homeDir })).toBe(false);
+    });
+
+    it('is true when only the project scope is enabled', () => {
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir });
+      expect(isLearningEnabledAnyScope({ projectRoot, homeDir })).toBe(true);
+    });
+
+    it('is true when only the global scope is enabled', () => {
+      setLearningEnabled({ scope: 'global', enabled: true, projectRoot, homeDir });
+      expect(isLearningEnabledAnyScope({ projectRoot, homeDir })).toBe(true);
+    });
+
+    it('is true when both scopes are enabled', () => {
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir });
+      setLearningEnabled({ scope: 'global', enabled: true, projectRoot, homeDir });
+      expect(isLearningEnabledAnyScope({ projectRoot, homeDir })).toBe(true);
+    });
   });
 
   describe('inject_activated_instincts kill-switch (ICL-4)', () => {

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -139,6 +139,31 @@ describe('learning subsystem MVP-1', () => {
       expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(EARLY));
     });
 
+    // `learn enable --project` is a copy-paste step in four user-facing
+    // surfaces, so re-running it on an already-enabled scope is routine. It
+    // stamps no transition and must not move the floor.
+    it('does not move when an already-enabled scope is enabled again', () => {
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: EARLY });
+      const config = setLearningEnabled({
+        scope: 'project',
+        enabled: true,
+        projectRoot,
+        homeDir,
+        now: LATE,
+      });
+      // The CLI prints this returned config, so it carries the same stamp.
+      expect(config.updated_at).toBe(EARLY);
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(EARLY));
+    });
+
+    // The documented accepted cost: a real consent toggle DOES move the floor.
+    it('moves when a scope is disabled and re-enabled', () => {
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: EARLY });
+      setLearningEnabled({ scope: 'project', enabled: false, projectRoot, homeDir, now: EARLY });
+      setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: LATE });
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(LATE));
+    });
+
     it('ignores a disabled scope, however recently it was written', () => {
       setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: EARLY });
       setLearningEnabled({ scope: 'global', enabled: false, projectRoot, homeDir, now: LATE });

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -145,10 +145,14 @@ describe('learning subsystem MVP-1', () => {
       expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(EARLY));
     });
 
-    it('falls back to the config mtime when updated_at is missing', () => {
+    it.each([
+      ['missing', { scope: 'project', enabled: true }],
+      ['unparseable', { scope: 'project', enabled: true, updated_at: 'garbage' }],
+      ['not a string', { scope: 'project', enabled: true, updated_at: {} }],
+    ])('falls back to the config mtime when updated_at is %s', (_label, config) => {
       const configPath = getLearningConfigPath({ scope: 'project', projectRoot, homeDir });
       fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+      fs.writeFileSync(configPath, JSON.stringify(config));
       expect(learningEnabledSince({ projectRoot, homeDir })).toBe(fs.statSync(configPath).mtimeMs);
     });
   });

--- a/tests/scripts/learning.test.js
+++ b/tests/scripts/learning.test.js
@@ -198,16 +198,16 @@ describe('learning subsystem MVP-1', () => {
     // be captured before the write rather than re-derived after it — otherwise
     // an idempotent re-enable silently retires every draft that failed
     // enrichment between the old mtime and the repeated command.
-    function writeUnstampedEnabledConfig() {
+    function writeUnstampedConfig(enabled = true) {
       const configPath = getLearningConfigPath({ scope: 'project', projectRoot, homeDir });
       fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled: true }));
+      fs.writeFileSync(configPath, JSON.stringify({ scope: 'project', enabled }));
       fs.utimesSync(configPath, new Date(EARLY), new Date(EARLY));
       return configPath;
     }
 
     it('preserves the mtime fallback when an unstamped enabled scope is enabled again', () => {
-      writeUnstampedEnabledConfig();
+      writeUnstampedConfig();
       const config = setLearningEnabled({
         scope: 'project',
         enabled: true,
@@ -221,10 +221,30 @@ describe('learning subsystem MVP-1', () => {
     });
 
     it('still stamps the transition when an unstamped scope is actually toggled', () => {
-      writeUnstampedEnabledConfig();
+      writeUnstampedConfig();
       setLearningEnabled({ scope: 'project', enabled: false, projectRoot, homeDir, now: LATE });
       setLearningEnabled({ scope: 'project', enabled: true, projectRoot, homeDir, now: LATE });
       expect(learningEnabledSince({ projectRoot, homeDir })).toBe(Date.parse(LATE));
+    });
+
+    // The preservation keys on "the state did not change", not on "the state is
+    // on", so a no-op DISABLE materializes the mtime as well. That is inert, and
+    // this pins WHY rather than just the field: `learningEnabledSince` skips a
+    // scope whose `enabled` is not true, so nothing ever reads the stamp a
+    // disabled config carries. If the floor is ever widened to disabled scopes,
+    // this case fails and names the coupling instead of letting a materialized
+    // mtime quietly become a floor.
+    it('materializes the mtime on a no-op disable, where the floor ignores it', () => {
+      writeUnstampedConfig(false);
+      const config = setLearningEnabled({
+        scope: 'project',
+        enabled: false,
+        projectRoot,
+        homeDir,
+        now: LATE,
+      });
+      expect(config.updated_at).toBe(EARLY);
+      expect(learningEnabledSince({ projectRoot, homeDir })).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #146. Closes #147.

The two learning-trust defects: the background diary enricher fired regardless of the learning opt-in and ran `claude` with `--dangerously-skip-permissions`; the always-on session record stored verbatim user-message text. Both now sit behind the opt-in, and the enricher runs with the narrowest arguments that still enrich.

Stacked on `docs/product-alignment` (merge that first).

## What changed

- **Enricher is opt-in** — `runDiaryCapture` spawns the enricher only when learning is enabled in project or global scope (`learningCaptureEnabled`, fail-closed on a missing `projectRoot`, lazy-required so the synchronous PostToolUse path pays nothing). The draft itself stays always-on: it is built from counts, never from message text.
- **No blanket bypass** — the spawn drops `--dangerously-skip-permissions`; it carries `--tools Read,Write`, `--add-dir <draft dir>` and `--permission-mode acceptEdits`. A spike against the real CLI established that both surviving flags are load-bearing and that a per-file `--allowed-tools` allowlist authorizes nothing on its own (table in the branch's handoff, summarized in D-009). Stated honestly in the specs and guides: this is a narrowing, not a sandbox — no `cwd` is passed, so the child still inherits the project directory.
- **Capture depth** — `userMessageContent` is written only under the opt-in; duration, counts, compactions, tool names and changed-file paths stay always-on, and the transcript is still parsed above the threshold so the diary's "Files modified" line does not regress.
- **No false alarms with learning off** — the stale-draft warning at SessionStart counts only drafts written after the opt-in (`learningEnabledSince`), and the `reflect-ready` nudge fires only while learning is on — gated on the opt-in flag itself, not on the timestamp floor.
- `hooks/observe/main.js` reuses the new `isLearningEnabledAnyScope`.
- Specs (`learning.md` B-1/B-9, `hooks.md` B-6 field map), `docs/guide/hooks-system.md`, `docs/guide/learning-dashboard.md`, hook READMEs updated in the same PR.

**Correction to #147's premise:** the diary *draft* is not built from user text — `auto-diary.js` reads counts only. What moves behind the opt-in is the storage of the text in the session record and the enrichment run that is handed a session summary.

## Product state

Opens the **6.1.0** roadmap row (`building ← we are here`; the 6.0.0 row keeps its text and loses the marker). Decision Log: **D-009** (enrichment opt-in, no blanket permissions), **D-010** (capture depth). Backlog: `gate-diary-enricher` and `gate-session-capture-depth` leave graduation tombstones.

## Verification

`npm run lint` · `npm test` (185 pytest, observer-daemon 16/16, jest + node --test green) · all six static checks incl. `check:product` (the compound spec header `shipped v6.0.0 · extended by 6.1.0 (building)` is exercised by C4) · `ENRICHER_E2E=1 node --test hooks/__tests__/diary-enricher-e2e.test.js` passes against the shipped argv with learning enabled.

Two independent reviewers; their findings (over-stated confinement claim, ungated reflect nudge, stale-draft counting, JSDoc↔code mismatch) were fixed in-branch.

https://claude.ai/code/session_01UkXvCaRugYqRxAskrpXnkF

