### PR TITLE
fix(eval): land the prompt audit's engine-prompt findings (E1-E12)

### DIFF
--- a/docs/guide/eval-system.md
+++ b/docs/guide/eval-system.md
@@ -85,6 +85,11 @@ Runs both arms and stores every trial. Useful flags:
 | `--max-turns` | Turn budget per trial, overriding the scenario |
 | `--plugin-dir` | Load a plugin directory into the treatment arm |
 
+Each trial's `claude -p` session is capped at 900 s; a trial killed at the cap is
+an infra error and never scores. Set `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS=<milliseconds>`
+to move that ceiling for one run — for a treatment whose pipeline builds or
+renders and runs past the cap on a loaded machine.
+
 `--skill-file` injects a skill body into the treatment prompt — that measures a
 **skill**. `--plugin-dir` loads a real plugin instead — that measures a
 **workflow**, the whole environment. They answer different questions; using

--- a/product/ROADMAP.md
+++ b/product/ROADMAP.md
@@ -484,3 +484,33 @@ reverse one, append a superseding entry (see AGENTS.md).
 - Residual: A project adopting the method gets no mechanical check that its own
   log stays dense, its supersessions stay paired, or its spec headers agree with
   their rows. Booked as the `product-cli` wish below.
+
+### D-017 — The per-trial ceiling is overridable per run, and a run that moves it reports the value
+- Date: 2026-09-09
+- Version: unreleased (first version after 6.1.0)
+- Status: Accepted
+- Decision: The eval harness keeps 900 s as the per-trial ceiling and lets
+  `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS` move it for a single run — a positive integer
+  of milliseconds, refused otherwise on the first trial before any session
+  spawns — with the rule that a run which moved it is reported with the value it
+  used.
+- Why: `eval-diagramming-obsidian-unverified-save-claim`'s treatment arm runs a
+  full build-and-render pipeline; on a loaded machine 4 of 5 treatment trials
+  were killed at 900 s, and since a killed-incomplete trial never scores (eval
+  B-10) the arm had nothing to measure. The 900 s ceiling is the standing
+  instrument every other pool was measured under, so a per-run override gets
+  that scenario measured without changing the instrument for the rest, and
+  without editing the engine to do it. Moving the ceiling changes the conditions
+  of the measurement, which is why the value used travels with the result rather
+  than staying an invisible local setting — the same rule eval B-9 applies to a
+  `--since`-bounded snapshot.
+- Symptom: 4 of 5 treatment trials `trial_killed_incomplete` at the 900 s
+  ceiling; one scorable trial in the arm.
+- Residual: no result field records the ceiling a trial ran under, so a pool can
+  mix trials measured under different ceilings and nothing mechanical says so —
+  the reporting rule in B-10 is prose-only. The refusal of a bad value fires
+  from the first trial's spawn, after that trial's fixture `Setup` has already
+  run, not before the run begins.
+- Verification: `tests/scripts/eval.test.js` — `resolveTrialTimeoutMs` returns
+  900000 when the variable is unset or empty, `1800000` when set to it, and
+  throws naming the variable on `abc`, `0`, `-5`, `1.5` and `30m`.

--- a/product/specs/eval.md
+++ b/product/specs/eval.md
@@ -78,6 +78,21 @@ a behavioral claim about a skill ships with a measured delta, not a self-report.
   scenario's *meaning* (task, fixture, assertions) bumps the version and
   empties the pool, because old rows answered a different question; cosmetic
   prose edits do not.
+- **B-10 A trial the runner cut off is an instrument failure, not a
+  measurement.** Every trial's `claude -p` session runs under a per-trial
+  ceiling: 900 s, unless `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS` moves it for one run —
+  unset or empty means the default, and any value that is not a positive
+  integer of milliseconds is refused on the first trial, before any session is
+  spawned. A trial the runner killed before the agent finished its turn is
+  recorded as `trial_killed_incomplete` and excluded from every scored pool —
+  a preflight containing one BLOCKs outright rather than rating the rest —
+  because its half transcript would otherwise grade as if the
+  agent had chosen to stop there; it neither moves the delta against the arm
+  nor counts as a scored trial under B-4's strict bar. A killed trial that had
+  already delivered its answer is a valid measurement and scores. The ceiling
+  is part of the measurement conditions, so a run that moved it MUST be
+  reported with the value it used, the way B-9 treats a `--since`-bounded
+  snapshot.
 
 ### Benchmarks
 - **B-9 Snapshots keep history and gate releases.** `eval report` writes
@@ -101,11 +116,19 @@ module invents a verdict. Delta-CI judging returns `IMPROVED`, `REGRESSED`,
 `PASS` or `REGRESSED` — never `INSUFFICIENT_DATA`, because an empty treatment arm
 fails the bar rather than deferring. That `PASS` is a distinct token from the
 preflight `PASS` in B-3, which is a discriminability outcome (`PASS` / `BLOCK`), not
-an A/B verdict.
+an A/B verdict. A result the runner killed before the agent finished carries
+`errorType: trial_killed_incomplete` and `infraError: true` —
+`scripts/lib/eval-trial-outcome.js` owns the two predicates (killed, output
+complete) — and `scorableResults` in `eval-stats.js` drops every `infraError` /
+`gradeError` row from every scored pool (`eval run`, A/B, benchmark), while
+preflight fails closed on the same flags (B-10). No result field records the
+ceiling a trial ran under.
 
 ## Decisions
 
 The measurement culture — two-arm evidence, the preflight ceiling gate,
 refuse-don't-guess verdicts — predates this log; rationale inline above.
 Scenario mechanics are taught by the `evaluating` skill and specified in
-`docs/guide/eval-system.md`.
+`docs/guide/eval-system.md`. D-017 pins the per-run override of the trial
+ceiling (B-10); the exclusion of killed-incomplete trials predates the log, and
+its rationale is inline at B-10.

--- a/scripts/lib/eval-grader-model.js
+++ b/scripts/lib/eval-grader-model.js
@@ -251,6 +251,48 @@ function buildBlindComparatorPrompt(taskPrompt, outputA, outputB, agentDef) {
   ].join('\n');
 }
 
+/** Margin below which two weighted totals count as a tie. */
+const BLIND_TIE_MARGIN = 0.1;
+
+/**
+ * Compute the blind comparator's weighted totals and winner. The agent supplies
+ * the judgment (rubric weights and per-criterion scores); the arithmetic and the
+ * tie threshold live here, where they are deterministic and testable, rather
+ * than in the prompt.
+ * @param {Array<{criterion: string, weight: number}>} rubric
+ * @param {number[]} scoresA - Per-criterion scores for Output A (rubric order)
+ * @param {number[]} scoresB - Per-criterion scores for Output B (rubric order)
+ * @returns {{ winner: 'A'|'B'|'tie', scoreA: number, scoreB: number }|null}
+ *   null when the rubric is empty or carries a non-finite / negative weight,
+ *   when either score array is missing or not rubric-length, or when any score
+ *   element is not a finite number within [0, 1] inclusive. Nothing is
+ *   coerced or clamped: a string '0.9', a null, a NaN, or a 5 is a malformed
+ *   response and never maps to a winner.
+ */
+function scoreBlindRubric(rubric, scoresA, scoresB) {
+  if (!Array.isArray(rubric) || rubric.length === 0) return null;
+  if (!Array.isArray(scoresA) || !Array.isArray(scoresB)) return null;
+  if (scoresA.length !== rubric.length || scoresB.length !== rubric.length) return null;
+  const weights = rubric.map((r) => (typeof r?.weight === 'number' ? r.weight : Number.NaN));
+  if (weights.some((w) => !Number.isFinite(w) || w < 0)) return null;
+  const totalWeight = weights.reduce((a, b) => a + b, 0);
+  if (totalWeight <= 0) return null;
+  const validScore = (s) => typeof s === 'number' && Number.isFinite(s) && s >= 0 && s <= 1;
+  if (!scoresA.every(validScore) || !scoresB.every(validScore)) return null;
+  const weighted = (scores) =>
+    scores.reduce((sum, s, i) => sum + s * (weights[i] / totalWeight), 0);
+  // Compare in integer hundredths: subtracting two-decimal floats puts an
+  // exact-margin gap on either side of the threshold depending on the operands'
+  // binary representation (0.8 - 0.7 > 0.1, but 0.7 - 0.6 is not).
+  const hundredthsA = Math.round(weighted(scoresA) * 100);
+  const hundredthsB = Math.round(weighted(scoresB) * 100);
+  const marginHundredths = Math.round(BLIND_TIE_MARGIN * 100);
+  let winner = 'tie';
+  if (hundredthsA - hundredthsB > marginHundredths) winner = 'A';
+  else if (hundredthsB - hundredthsA > marginHundredths) winner = 'B';
+  return { winner, scoreA: hundredthsA / 100, scoreB: hundredthsB / 100 };
+}
+
 /**
  * Run the eval-blind-comparator agent on two outputs.
  * Randomly shuffles (baseline, treatment) → (A, B) to prevent label bias,
@@ -315,31 +357,31 @@ function runBlindComparator(taskPrompt, baselineOutput, treatmentOutput, project
 
   if (exitCode !== 0) return null;
 
-  const parsed = extractJsonObject(stdout, ['winner']);
+  const parsed = extractJsonObject(stdout, ['rubric', 'scores_a', 'scores_b']);
   if (!parsed) return null;
 
-  const winner = parsed.winner; // expect 'A', 'B', or 'tie'
-  let winnerOriginalLabel;
-  if (winner === 'tie') {
-    winnerOriginalLabel = 'tie';
-  } else if (winner === 'A') {
-    winnerOriginalLabel = baselineIsA ? 'baseline' : 'treatment';
-  } else if (winner === 'B') {
-    winnerOriginalLabel = baselineIsA ? 'treatment' : 'baseline';
-  } else {
-    // Unknown / malformed winner value (e.g. lowercase 'b', 'baseline',
-    // whitespace-padded 'B '). Surface the failure rather than silently
-    // mapping it to a concrete baseline/treatment outcome — that would
-    // bias the supplementary preference signal.
+  // Malformed, out-of-range, or misaligned scores surface as a failure rather
+  // than being coerced and mapped to a concrete baseline/treatment outcome —
+  // that would bias the supplementary preference signal.
+  const scored = scoreBlindRubric(parsed.rubric, parsed.scores_a, parsed.scores_b);
+  if (!scored) {
+    process.stderr.write(
+      'Warning: blind comparator returned a malformed rubric or scores — dropping this pair.\n',
+    );
     return null;
   }
+
+  const { winner, scoreA, scoreB } = scored;
+  let winnerOriginalLabel = 'tie';
+  if (winner === 'A') winnerOriginalLabel = baselineIsA ? 'baseline' : 'treatment';
+  if (winner === 'B') winnerOriginalLabel = baselineIsA ? 'treatment' : 'baseline';
 
   return {
     winner_original_label: winnerOriginalLabel,
     reasoning: parsed.reasoning || '',
-    rubric: parsed.rubric || [],
-    score_baseline: baselineIsA ? (parsed.score_a ?? 0) : (parsed.score_b ?? 0),
-    score_treatment: baselineIsA ? (parsed.score_b ?? 0) : (parsed.score_a ?? 0),
+    rubric: parsed.rubric,
+    score_baseline: baselineIsA ? scoreA : scoreB,
+    score_treatment: baselineIsA ? scoreB : scoreA,
   };
 }
 
@@ -348,5 +390,7 @@ module.exports = {
   compareWithModel,
   buildBlindComparatorPrompt,
   runBlindComparator,
+  scoreBlindRubric,
   BLIND_COMPARATOR_FORBIDDEN,
+  BLIND_TIE_MARGIN,
 };

--- a/scripts/lib/eval-grader-model.js
+++ b/scripts/lib/eval-grader-model.js
@@ -253,6 +253,8 @@ function buildBlindComparatorPrompt(taskPrompt, outputA, outputB, agentDef) {
 
 /** Margin below which two weighted totals count as a tie. */
 const BLIND_TIE_MARGIN = 0.1;
+/** Tolerance for the tie comparison: far below score precision, above float noise. */
+const BLIND_TIE_EPSILON = 1e-9;
 
 /**
  * Compute the blind comparator's weighted totals and winner. The agent supplies
@@ -263,6 +265,8 @@ const BLIND_TIE_MARGIN = 0.1;
  * @param {number[]} scoresA - Per-criterion scores for Output A (rubric order)
  * @param {number[]} scoresB - Per-criterion scores for Output B (rubric order)
  * @returns {{ winner: 'A'|'B'|'tie', scoreA: number, scoreB: number }|null}
+ *   scoreA / scoreB are the weighted totals rounded to hundredths for display;
+ *   the winner is decided on the unrounded totals.
  *   null when the rubric is empty or carries a non-finite / negative weight,
  *   when either score array is missing or not rubric-length, or when any score
  *   element is not a finite number within [0, 1] inclusive. Nothing is
@@ -281,16 +285,18 @@ function scoreBlindRubric(rubric, scoresA, scoresB) {
   if (!scoresA.every(validScore) || !scoresB.every(validScore)) return null;
   const weighted = (scores) =>
     scores.reduce((sum, s, i) => sum + s * (weights[i] / totalWeight), 0);
-  // Compare in integer hundredths: subtracting two-decimal floats puts an
-  // exact-margin gap on either side of the threshold depending on the operands'
-  // binary representation (0.8 - 0.7 > 0.1, but 0.7 - 0.6 is not).
-  const hundredthsA = Math.round(weighted(scoresA) * 100);
-  const hundredthsB = Math.round(weighted(scoresB) * 100);
-  const marginHundredths = Math.round(BLIND_TIE_MARGIN * 100);
+  const totalA = weighted(scoresA);
+  const totalB = weighted(scoresB);
+  // Decide on the unrounded totals with a tolerance: subtracting two-decimal
+  // floats puts an exact-margin gap on either side of the threshold depending
+  // on the operands' binary representation (0.8 - 0.7 > 0.1, but 0.7 - 0.6 is
+  // not), while rounding the totals first would turn a real gap of 0.104 —
+  // weights need not land on hundredths — into a tie.
   let winner = 'tie';
-  if (hundredthsA - hundredthsB > marginHundredths) winner = 'A';
-  else if (hundredthsB - hundredthsA > marginHundredths) winner = 'B';
-  return { winner, scoreA: hundredthsA / 100, scoreB: hundredthsB / 100 };
+  if (totalA - totalB > BLIND_TIE_MARGIN + BLIND_TIE_EPSILON) winner = 'A';
+  else if (totalB - totalA > BLIND_TIE_MARGIN + BLIND_TIE_EPSILON) winner = 'B';
+  const display = (total) => Math.round(total * 100) / 100;
+  return { winner, scoreA: display(totalA), scoreB: display(totalB) };
 }
 
 /**

--- a/scripts/lib/eval-grader-model.js
+++ b/scripts/lib/eval-grader-model.js
@@ -9,7 +9,6 @@
 
 const path = require('node:path');
 const { execCommand } = require('./utils');
-const { DELTA_IMPROVED_THRESHOLD, DELTA_REGRESSED_THRESHOLD } = require('./eval-stats');
 const {
   loadAgentDef,
   captureTrialArtifacts,
@@ -73,7 +72,8 @@ function gradeWithModel(result, scenario, projectRoot) {
   for (let attempt = 1; attempt <= 2; attempt++) {
     const { stdout, exitCode } = execCommand(
       'claude',
-      ['-p', '--output-format', 'text', '--no-session-persistence'],
+      // The grader reads and never edits ("Your Tools" in eval-grader.md); enforce it.
+      ['-p', '--output-format', 'text', '--no-session-persistence', '--tools', 'Read,Grep,Glob'],
       {
         input: prompt,
         cwd: projectRoot,
@@ -146,13 +146,10 @@ function gradeWithModel(result, scenario, projectRoot) {
  * @returns {{ analysis: string, delta_explanation?: string, weak_assertions_patterns?: string[], variance_notes?: string[], improvements?: string[], regressions?: string[], limitations?: string[] }|null}
  */
 function compareWithModel(scenario, baseline, treatment, projectRoot, metrics) {
-  const rawDef = loadAgentDef(
+  const agentDef = loadAgentDef(
     path.join(projectRoot, 'scripts', 'lib', 'prompts', 'eval-analyzer.md'),
   );
-  if (!rawDef) return null;
-  const agentDef = rawDef
-    .replace(/\{IMPROVED_THRESHOLD\}/g, String(DELTA_IMPROVED_THRESHOLD))
-    .replace(/\{REGRESSED_THRESHOLD\}/g, String(DELTA_REGRESSED_THRESHOLD));
+  if (!agentDef) return null;
   const assertions = scenario.assertions.map((a, i) => `${i + 1}. ${a}`).join('\n');
   const fmtResults = (results) =>
     results
@@ -186,14 +183,15 @@ function compareWithModel(scenario, baseline, treatment, projectRoot, metrics) {
     '### Required Response Format (automated comparison)',
     'Respond with ONLY a JSON object:',
     '```json',
-    '{"analysis": "...", "improvements": ["..."], "regressions": ["..."], "limitations": ["..."], "recommendation": "SHIP"}',
+    '{"analysis": "...", "improvements": ["..."], "regressions": ["..."], "limitations": ["..."], "delta_explanation": "...", "weak_assertions_patterns": ["..."], "variance_notes": ["..."]}',
     '```',
     'Use the provided programmatic metrics as numeric truth. Do not invent missing per-assertion numbers.',
   ].join('\n');
 
   const { stdout, exitCode } = execCommand(
     'claude',
-    ['-p', '--output-format', 'text', '--no-session-persistence'],
+    // The analyzer reads and never edits ("Your Tools" in eval-analyzer.md); enforce it.
+    ['-p', '--output-format', 'text', '--no-session-persistence', '--tools', 'Read,Grep,Glob'],
     {
       input: prompt,
       cwd: projectRoot,

--- a/scripts/lib/eval.js
+++ b/scripts/lib/eval.js
@@ -33,6 +33,29 @@ const {
 const { parseStreamJsonOutput, parseActionsFromTranscript } = require('./eval-transcript');
 const { isTrialKilled, isOutputComplete } = require('./eval-trial-outcome');
 
+// Per-trial ceiling for the spawned `claude -p` session. 900s is the standing
+// instrument (see the lineage note at the execCommand call); a treatment whose
+// pipeline builds or renders can run past it on a loaded machine, so one run can
+// move the ceiling without editing the engine. A killed trial never scores.
+const DEFAULT_TRIAL_TIMEOUT_MS = 900000;
+
+/**
+ * Resolve the per-trial timeout: ARCFORGE_EVAL_TRIAL_TIMEOUT_MS when set, else the default.
+ * @param {NodeJS.ProcessEnv} [env] - Environment to read (injectable for tests)
+ * @returns {number} Timeout in milliseconds
+ */
+function resolveTrialTimeoutMs(env = process.env) {
+  const raw = env.ARCFORGE_EVAL_TRIAL_TIMEOUT_MS;
+  if (raw === undefined || raw === '') return DEFAULT_TRIAL_TIMEOUT_MS;
+  const ms = Number(raw);
+  if (!Number.isInteger(ms) || ms <= 0) {
+    throw new Error(
+      `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS must be a positive integer of milliseconds, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return ms;
+}
+
 /**
  * Eval scenario parsed from a markdown file
  * @typedef {Object} EvalScenario
@@ -208,7 +231,8 @@ function runTrial(scenario, trialNumber, totalTrials, options = {}) {
     // (killed AND incomplete must not score). Raising the ceiling is an
     // instrument fix, not a rubric change (scenario hashes unaffected).
     // P4 history: 300s clipped four of five two-axis treatment trials.
-    timeout: 900000,
+    // ARCFORGE_EVAL_TRIAL_TIMEOUT_MS moves the ceiling for one run.
+    timeout: resolveTrialTimeoutMs(),
     maxBuffer: CLAUDE_MAX_BUFFER,
     // Redirect ONLY the arcforge data home (not HOME) to the trial's isolated
     // fixture. getArcforgeHome() honors ARCFORGE_HOME before falling back to
@@ -668,6 +692,8 @@ module.exports = {
   resolveMaxTurns,
   runTrial,
   buildTrialPrompt,
+  resolveTrialTimeoutMs,
+  DEFAULT_TRIAL_TIMEOUT_MS,
   executeAndGradeTrial,
   runSkillEval,
   runWorkflowEval,

--- a/scripts/lib/eval.js
+++ b/scripts/lib/eval.js
@@ -171,7 +171,7 @@ function runTrial(scenario, trialNumber, totalTrials, options = {}) {
     claudeArgs.push('--strict-mcp-config');
     claudeArgs.push(
       '--append-system-prompt',
-      `IMPORTANT: You are running in an isolated eval trial. Your working directory is ${trialDir}. Do NOT read, search, or access any files outside this directory. All files you need are already in the working directory.`,
+      `You are running in an isolated eval trial. Your working directory is ${trialDir}, and every file you need is already in it — do not read, search, or access files outside this directory.`,
     );
   }
   if (pluginDir) {

--- a/scripts/lib/loop-verifier.js
+++ b/scripts/lib/loop-verifier.js
@@ -81,10 +81,9 @@ function buildTaskCriteria(task) {
 /**
  * Assemble the verifier session prompt at runtime. NEVER edits the prompt file.
  * Layers: agent body → task identity + acceptance criteria → verify-command
- * evidence instruction → a forceful verdict-protocol override. The override
- * deliberately supersedes the agent body's own SHIP/NEEDS WORK/BLOCKED report
- * vocabulary so a real session emits a parseable `Final verdict:` line, not a
- * divergent verdict.
+ * evidence instruction → the verdict protocol. The protocol is restated here,
+ * next to the parser that consumes it, so the `Final verdict:` line stays
+ * required even if the agent body's report format changes.
  * @param {Object} args
  * @param {string} args.agentBody - Verifier agent body (frontmatter stripped)
  * @param {Object} args.task - Task being verified ({ id, text })
@@ -114,10 +113,9 @@ function assembleVerifierPrompt({ agentBody, task, criteria, verifyCommand, feed
       '',
     );
   }
-  parts.push('## Verdict Protocol (overrides any report format above)', '');
+  parts.push('## Verdict Protocol', '');
   parts.push(
-    'Disregard the SHIP / NEEDS WORK / BLOCKED wording in the report format above. ' +
-      'After your verification, your response MUST end with a single line that is ' +
+    'After your verification, your response MUST end with a single line that is ' +
       'EXACTLY one of:',
     '',
     'Final verdict: PASS',

--- a/scripts/lib/prompts/eval-analyzer.md
+++ b/scripts/lib/prompts/eval-analyzer.md
@@ -15,9 +15,7 @@ You have read-only access: Read, Grep, Glob. You read eval results and produce a
 
 ### Step 1: Load Results
 
-- Read baseline results (without skill/change) from JSONL
-- Read treatment results (with skill/change) from JSONL
-- Read the programmatic metrics supplied by the harness
+- The prompt carries the baseline (without skill/change) and treatment (with skill/change) trial rows, per-assertion scores where the harness recorded them, and the programmatic metrics
 - Verify both sets used the same scenario and assertions
 
 ### Step 2: Explain the Delta
@@ -43,36 +41,7 @@ If per-assertion evidence is available:
 - **Mixed outcomes**: call out partial improvements and localized regressions
 - **Hotspot assertions**: identify assertions with high score volatility across trials
 
-## Report Format
-
-```markdown
-## A/B Analysis
-
-### Eval: [scenario name]
-### Baseline: [description] | Treatment: [description]
-### Trials: [baseline k] vs [treatment k]
-
-### Aggregate Metrics
-
-| Metric | Baseline | Treatment | Delta |
-|--------|----------|-----------|-------|
-| Overall Score | [avg] | [avg] | [diff] |
-| Pass Rate | [x/k] | [y/k] | [diff] |
-
-### Delta Explanation
-[Qualitative explanation of why the observed pass-rate delta emerged]
-
-### Weak Assertions
-[Assertions that appear non-discriminative — scoring similarly in both conditions]
-
-### Variance Notes
-[Variance hotspots, trial-to-trial instability observations, sample size caveats]
-
-### Regressions / Risks
-[What regressed, what stayed noisy, and what is still unclear]
-```
-
-## Critical Rules
+## Rules
 
 1. **Same scenario, same model** — never compare results from different scenarios or models
 2. **Programmatic metrics are authoritative** — do not recompute delta, CI, or verdict from scratch
@@ -81,9 +50,9 @@ If per-assertion evidence is available:
 5. **Acknowledge limitations** — small sample sizes, variance, and scenario specificity
 6. **No verdict, no recommendation** — the harness verdict is final; your role is explanation only
 
-## Automated Comparison Mode
+## Response Format
 
-When used by `arcforge eval compare` (automated pipeline), respond with ONLY a JSON object:
+Respond with ONLY a JSON object:
 
 ```json
 {
@@ -115,4 +84,4 @@ When used by `arcforge eval compare` (automated pipeline), respond with ONLY a J
 - `weak_assertions_patterns`: assertions that appear non-discriminative across trials
 - `variance_notes`: variance hotspots, trial-to-trial instability observations
 
-The automated pipeline parses this JSON. Do not include explanations or markdown wrapping in automated mode. Use the provided programmatic metrics as ground truth, and do not invent per-assertion numbers that were not supplied.
+The harness parses this JSON. Do not include explanations or markdown wrapping. Use the provided programmatic metrics as ground truth, and do not invent per-assertion numbers that were not supplied.

--- a/scripts/lib/prompts/eval-blind-comparator.md
+++ b/scripts/lib/prompts/eval-blind-comparator.md
@@ -9,7 +9,7 @@ You are an **Eval Blind Comparator**. You receive two anonymized outputs (labele
 
 ## Critical Constraint
 
-The inputs you receive have been stripped of all identifying information. You MUST NOT use the words "baseline", "treatment", "with_skill", "without_skill", or any specific skill name when reasoning about the outputs. If such terms appear in the outputs themselves, treat them as content and do not assign evaluation weight to them.
+The inputs you receive have been stripped of all identifying information so that label knowledge cannot bias the scores. Refer to the outputs only as Output A and Output B; if condition labels ("baseline", "treatment", "with_skill", "without_skill") or a skill name appear inside an output, treat them as content and give them no evaluation weight.
 
 ## Your Process
 
@@ -53,7 +53,7 @@ Compute the weighted total for each output.
 
 ## Required Response Format
 
-Respond with ONLY a JSON object. Do not include markdown fences, explanations, or any text outside the JSON:
+Respond with ONLY a JSON object:
 
 ```json
 {
@@ -80,10 +80,9 @@ Field definitions:
 - `scores_a`: per-criterion scores for Output A (same order as rubric)
 - `scores_b`: per-criterion scores for Output B (same order as rubric)
 
-## Critical Rules
+## Rules
 
 1. **Never reference the experimental conditions** — only "Output A" and "Output B"
 2. **Derive the rubric from the task** — do not use generic quality signals like "grammar" or "length" unless the task specifically calls for them
 3. **Score independently** — evaluate each output against the rubric without comparing them to each other during scoring
 4. **Be calibrated** — most outputs are somewhere in the middle; reserve 1.0 for clearly excellent and 0.0 for clearly absent
-5. **Respond with pure JSON only** — no markdown, no explanation, no preamble

--- a/scripts/lib/prompts/eval-blind-comparator.md
+++ b/scripts/lib/prompts/eval-blind-comparator.md
@@ -1,11 +1,11 @@
 ---
 name: eval-blind-comparator
 description: |
-  Use this agent when two sets of eval trial outputs need to be compared without knowledge of which is the control condition and which is the modified condition. The blind comparator scores both outputs independently against a task-derived rubric, preventing confirmation bias from label knowledge. Examples: <example>Context: A skill has been tested in A/B conditions and both outputs are available. user: "Compare these two outputs without knowing which used the skill" assistant: "I'll dispatch eval-blind-comparator with anonymized output labels to generate a task rubric and score each output independently." <commentary>Blind scoring removes human and model confirmation bias from A/B preference measurement.</commentary></example> <example>Context: Two model outputs for the same prompt need unbiased preference rating. user: "Which output is better, fairly judged?" assistant: "Dispatching eval-blind-comparator to rate outputs A and B against a rubric derived from the task prompt, returning a winner or tie." <commentary>The comparator never knows which output came from which condition — it derives quality criteria from the task alone.</commentary></example>
+  Use this agent when two sets of eval trial outputs need to be compared without knowledge of which is the control condition and which is the modified condition. The blind comparator scores both outputs independently against a task-derived rubric, preventing confirmation bias from label knowledge. Examples: <example>Context: A skill has been tested in A/B conditions and both outputs are available. user: "Compare these two outputs without knowing which used the skill" assistant: "I'll dispatch eval-blind-comparator with anonymized output labels to generate a task rubric and score each output independently." <commentary>Blind scoring removes human and model confirmation bias from A/B preference measurement.</commentary></example> <example>Context: Two model outputs for the same prompt need unbiased preference rating. user: "Which output is better, fairly judged?" assistant: "Dispatching eval-blind-comparator to rate outputs A and B against a rubric derived from the task prompt; it returns the rubric with per-criterion scores and the harness computes the winner." <commentary>The comparator never knows which output came from which condition — it derives quality criteria from the task alone.</commentary></example>
 model: sonnet
 ---
 
-You are an **Eval Blind Comparator**. You receive two anonymized outputs (labeled **Output A** and **Output B**) and the original task prompt that generated them. You do not know which output came from which experimental condition. Your job is to score both outputs fairly against a rubric you derive from the task, then declare a winner or tie.
+You are an **Eval Blind Comparator**. You receive two anonymized outputs (labeled **Output A** and **Output B**) and the original task prompt that generated them. You do not know which output came from which experimental condition. Your job is to score both outputs fairly against a rubric you derive from the task; the harness computes the weighted totals and the winner from your scores.
 
 ## Critical Constraint
 
@@ -22,7 +22,7 @@ Generate 3-5 rubric criteria that are:
 - Measurable from the output alone (not from external knowledge)
 - Discriminative — criteria that could reasonably differ between good and mediocre responses
 
-Assign a weight to each criterion (all weights must sum to 1.0).
+Assign a weight to each criterion; the harness normalizes the weights.
 
 Example rubric structure:
 ```
@@ -43,24 +43,13 @@ For each rubric criterion, score both Output A and Output B independently on a 0
 - 0.75: Mostly meets the criterion
 - 1.0: Fully meets the criterion
 
-Compute the weighted total for each output.
-
-### Step 3: Declare a Winner
-
-- If Output A's weighted total exceeds Output B's by more than 0.1: winner is "A"
-- If Output B's weighted total exceeds Output A's by more than 0.1: winner is "B"
-- Otherwise: winner is "tie"
-
 ## Required Response Format
 
 Respond with ONLY a JSON object:
 
 ```json
 {
-  "winner": "A",
   "reasoning": "Output A addressed all three sub-questions in the prompt clearly, while Output B only addressed two and used vague language on the third.",
-  "score_a": 0.82,
-  "score_b": 0.61,
   "rubric": [
     { "criterion": "Addresses all parts of the prompt", "weight": 0.4 },
     { "criterion": "Uses concrete examples", "weight": 0.35 },
@@ -72,11 +61,8 @@ Respond with ONLY a JSON object:
 ```
 
 Field definitions:
-- `winner`: `"A"`, `"B"`, or `"tie"`
-- `reasoning`: 1-3 sentences explaining why the winner scored higher, or why it is a tie
-- `score_a`: weighted total score for Output A (0.0-1.0, two decimal places)
-- `score_b`: weighted total score for Output B (0.0-1.0, two decimal places)
-- `rubric`: array of `{ criterion, weight }` objects (weights sum to 1.0)
+- `reasoning`: 1-3 sentences on the decisive quality differences between the outputs
+- `rubric`: array of `{ criterion, weight }` objects
 - `scores_a`: per-criterion scores for Output A (same order as rubric)
 - `scores_b`: per-criterion scores for Output B (same order as rubric)
 

--- a/scripts/lib/prompts/eval-grader.md
+++ b/scripts/lib/prompts/eval-grader.md
@@ -32,10 +32,7 @@ For each assertion in the scenario:
 1. **Find evidence** — does the output contain evidence of this criterion?
 2. **Assess quality** — not just present/absent, but how well?
 3. **Write one short evidence note** — quote or point to the relevant output/artifact
-4. **Score** using the normalized 0.0-1.0 scale requested by the harness:
-   - **1.0** — fully met (clear evidence the criterion is satisfied)
-   - **0.5** — partially met (some evidence, but incomplete or flawed)
-   - **0** — not met (no evidence, or criterion clearly unsatisfied)
+4. **Score** on the normalized 0.0-1.0 scale, using the anchors `0` (not met), `0.25` (weak evidence), `0.5` (partially met), `0.75` (mostly met), `1.0` (fully met)
 
 ### Step 4: Compute Overall Grade
 
@@ -43,29 +40,7 @@ For each assertion in the scenario:
 - Treat them as convenience fields for downstream consumers
 - **The harness is the authority**: it recomputes overall score and pass/fail from the returned assertion scores
 
-## Report Format
-
-```markdown
-## Eval Grade
-
-### Eval: [scenario name]
-### Trial: [trial number]
-
-### Assertions
-
-| # | Assertion | Score | Evidence |
-|---|-----------|-------|----------|
-| 1 | [criterion] | 0.85 | [where in output] |
-| 2 | [criterion] | 0.70 | [where in output] |
-
-### Overall Score: [average]
-### Verdict: [PASS / PARTIAL / FAIL]
-
-### Notes
-[Any observations about the output quality, patterns, or issues]
-```
-
-## Critical Rules
+## Rules
 
 1. **Grade independently** — don't factor in what you know about the agent or baseline/treatment history
 2. **Single-trial only** — do not compare conditions, compute deltas, or judge whether treatment improved
@@ -73,9 +48,9 @@ For each assertion in the scenario:
 4. **No invented evidence** — if support is missing, score conservatively
 5. **Flag ambiguity** — if an assertion is unclear, note it rather than guessing
 
-## Automated Grading Mode
+## Response Format
 
-When used by `arcforge eval run` (automated batch grading), respond with ONLY a JSON object instead of the markdown report:
+Respond with ONLY a JSON object:
 
 ```json
 {
@@ -98,7 +73,7 @@ When used by `arcforge eval run` (automated batch grading), respond with ONLY a 
 }
 ```
 
-- `scores`: normalized 0.0-1.0 scores, preferably using anchors `0`, `0.25`, `0.5`, `0.75`, `1.0`
+- `scores`: one score per assertion, in rubric order, on the anchors above
 - `evidence`: short evidence note for each assertion in the same order
 - `blockRefs`: for each assertion, list the `[Block N]` numbers from the output that contain the evidence (empty array if no specific block)
 - `overall`: optional convenience field
@@ -112,4 +87,4 @@ When used by `arcforge eval run` (automated batch grading), respond with ONLY a 
   - `assertion_id`: 1-based index of the assertion in the rubric
   - `reason`: brief explanation of why the assertion is weak or unverifiable
 
-The automated pipeline parses this JSON. Do not include explanations or markdown wrapping in automated mode. The harness recomputes `overall` and `passed`, so the assertion scores are the authoritative output. `discovered_claims` and `weak_assertions` are stored for analysis but do NOT affect the computed score or pass/fail verdict.
+The harness parses this JSON. Do not include explanations or markdown wrapping. The harness recomputes `overall` and `passed`, so the assertion scores are the authoritative output. `discovered_claims` and `weak_assertions` are stored for analysis but do NOT affect the computed score or pass/fail verdict.

--- a/scripts/lib/prompts/verifier.md
+++ b/scripts/lib/prompts/verifier.md
@@ -5,32 +5,13 @@ description: |
 model: sonnet
 ---
 
-You are a **Verifier** — your core principle is: **NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.** You trust nothing. You verify everything. You run commands in THIS session and read their output.
+You are a **Verifier**. A completion claim counts only when you have produced fresh evidence for it in this session: you run the verification commands yourself, read their real output, and compare it against the acceptance criteria. Reports from the implementer — "it should work", "tests were passing earlier", "I verified this", a summary with no raw output — are claims to check, not evidence.
 
 ## Your Tools
 
 You have verification access: Read, Grep, Glob, Bash. Use Bash exclusively for running tests and verification commands — not for making changes.
 
-## Verification Methodology
-
-### The Gate Function
-
-For every claim you need to verify:
-
-1. **Identify** the verification command
-2. **Run** it in this session
-3. **Read** the actual output
-4. **Compare** against the acceptance criteria
-5. **Report** PASS or FAIL with evidence
-
-### Never Accept
-
-- "It should work" — run it and see
-- "Tests were passing earlier" — run them now
-- "I verified this" — you verify it independently
-- Summary reports without raw evidence
-
-### Verification Checklist
+## Verification Checklist
 
 For each acceptance criterion:
 
@@ -44,8 +25,6 @@ For each acceptance criterion:
 
 ```markdown
 ## Verification Report
-
-### Overall: [PASS / FAIL]
 
 ### Criteria Verification
 
@@ -67,14 +46,13 @@ For each acceptance criterion:
 ### Extra Code Check
 - [Any code found that wasn't in the spec]
 
-### Final Assessment
-[SHIP / NEEDS WORK / BLOCKED — with reasoning]
+Final verdict: PASS
 ```
 
-## Critical Rules
+The last line of your response is `Final verdict: PASS` or `Final verdict: FAIL` — PASS only when every criterion is met with evidence you produced this session; otherwise FAIL, with what failed listed above the verdict line so the implementer can act on it.
+
+## Rules
 
 1. **Run every command yourself** — never trust cached or reported results
 2. **Read every output** — don't assume pass from exit code alone
-3. **One criterion at a time** — systematic, not rushed
-4. **Report failures immediately** — don't try to fix them (that's the implementer's job)
-5. **Be thorough but concise** — evidence over explanation
+3. **Report failures, don't fix them** — fixing is the implementer's job, and a verifier that edits the work stops being evidence

--- a/tests/scripts/eval-blind-autotrigger.test.js
+++ b/tests/scripts/eval-blind-autotrigger.test.js
@@ -63,14 +63,13 @@ function makeScenario(grader = 'model', overrides = {}) {
 }
 
 function makeBlindAgentResponse(winner = 'A') {
+  // The harness derives the winner from the scores; shape them to match.
+  const scores = { A: [[0.8], [0.6]], B: [[0.6], [0.8]], tie: [[0.7], [0.7]] }[winner];
   return JSON.stringify({
-    winner,
     reasoning: `Output ${winner} was more complete.`,
-    score_a: 0.8,
-    score_b: 0.6,
     rubric: [{ criterion: 'Task completion', weight: 1.0 }],
-    scores_a: [0.8],
-    scores_b: [0.6],
+    scores_a: scores[0],
+    scores_b: scores[1],
   });
 }
 

--- a/tests/scripts/eval-blind-comparator.test.js
+++ b/tests/scripts/eval-blind-comparator.test.js
@@ -19,22 +19,23 @@ const {
   buildBlindComparatorPrompt,
   BLIND_COMPARATOR_FORBIDDEN,
 } = require('../../scripts/lib/eval-graders');
+const { scoreBlindRubric } = require('../../scripts/lib/eval-grader-model');
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 /**
  * Make a minimal mock JSON response that the blind comparator would return.
+ * The harness derives the winner from the per-criterion scores, so the fixture
+ * shapes the scores to produce the requested outcome.
  * @param {'A'|'B'|'tie'} winner
  */
 function makeAgentResponse(winner = 'A') {
+  const scores = { A: [[0.8], [0.6]], B: [[0.6], [0.8]], tie: [[0.7], [0.7]] }[winner];
   return JSON.stringify({
-    winner,
     reasoning: 'Output A was more complete.',
-    score_a: 0.8,
-    score_b: 0.6,
     rubric: [{ criterion: 'Addresses the task', weight: 1.0 }],
-    scores_a: [0.8],
-    scores_b: [0.6],
+    scores_a: scores[0],
+    scores_b: scores[1],
   });
 }
 
@@ -283,7 +284,7 @@ describe('runBlindComparator — winner label mapping', () => {
     expect(result).toBeNull();
   });
 
-  it('returns tie when agent returns tie', () => {
+  it('returns tie when the weighted totals are within the tie margin', () => {
     mockUtils.execCommand.mockReturnValueOnce({
       stdout: makeAgentResponse('tie'),
       stderr: '',
@@ -295,12 +296,19 @@ describe('runBlindComparator — winner label mapping', () => {
     expect(result.winner_original_label).toBe('tie');
   });
 
-  it('returns null when agent returns an unrecognized winner value', () => {
-    // Regression (F4): malformed comparator output (lowercase 'b',
-    // 'baseline', whitespace-padded 'B ', etc.) used to be silently
-    // mapped as if winner === 'B', biasing results.
+  it('returns null when the scores do not align with the rubric', () => {
+    // A score array of the wrong length cannot be weighted; surface the failure
+    // rather than deriving a winner from partial data.
     mockUtils.execCommand.mockReturnValueOnce({
-      stdout: makeAgentResponse('b'), // lowercase, not a valid label
+      stdout: JSON.stringify({
+        reasoning: 'A wins.',
+        rubric: [
+          { criterion: 'Clarity', weight: 0.5 },
+          { criterion: 'Completeness', weight: 0.5 },
+        ],
+        scores_a: [0.9],
+        scores_b: [0.5, 0.5],
+      }),
       stderr: '',
       exitCode: 0,
     });
@@ -312,10 +320,7 @@ describe('runBlindComparator — winner label mapping', () => {
   it('includes reasoning and rubric in the result', () => {
     mockUtils.execCommand.mockReturnValueOnce({
       stdout: JSON.stringify({
-        winner: 'A',
         reasoning: 'Output A was clearer.',
-        score_a: 0.9,
-        score_b: 0.5,
         rubric: [{ criterion: 'Clarity', weight: 1.0 }],
         scores_a: [0.9],
         scores_b: [0.5],
@@ -331,16 +336,32 @@ describe('runBlindComparator — winner label mapping', () => {
     expect(result.rubric[0].criterion).toBe('Clarity');
   });
 
+  it('returns null when a score element is a string (F4 regression class)', () => {
+    // Regression (F4): malformed comparator output used to be silently mapped
+    // to a concrete baseline/treatment outcome. A string score is not a score;
+    // coercing it to a number would bias the supplementary preference signal.
+    mockUtils.execCommand.mockReturnValueOnce({
+      stdout: JSON.stringify({
+        reasoning: 'A wins.',
+        rubric: [{ criterion: 'Clarity', weight: 1.0 }],
+        scores_a: ['0.9'],
+        scores_b: [0.5],
+      }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const result = runBlindComparator(TASK_PROMPT, BASELINE_OUTPUT, TREATMENT_OUTPUT, '/fake/root');
+    expect(result).toBeNull();
+  });
+
   it('exposes score_baseline and score_treatment in result', () => {
     mockUtils.execCommand.mockReturnValueOnce({
       stdout: JSON.stringify({
-        winner: 'A',
         reasoning: 'A wins.',
-        score_a: 0.8,
-        score_b: 0.4,
-        rubric: [],
-        scores_a: [],
-        scores_b: [],
+        rubric: [{ criterion: 'Task completion', weight: 1.0 }],
+        scores_a: [0.8],
+        scores_b: [0.4],
       }),
       stderr: '',
       exitCode: 0,
@@ -351,5 +372,74 @@ describe('runBlindComparator — winner label mapping', () => {
     // score_baseline and score_treatment must both be present
     expect(typeof result.score_baseline).toBe('number');
     expect(typeof result.score_treatment).toBe('number');
+  });
+});
+
+// ── harness-side arithmetic: the prompt no longer asks the agent to compute ────
+
+describe('scoreBlindRubric — harness-side arithmetic', () => {
+  it('weights scores by the rubric and normalizes weights that do not sum to 1', () => {
+    const result = scoreBlindRubric(
+      [
+        { criterion: 'x', weight: 2 },
+        { criterion: 'y', weight: 2 },
+      ],
+      [1.0, 0.5],
+      [0.5, 0.5],
+    );
+    expect(result).toEqual({ winner: 'A', scoreA: 0.75, scoreB: 0.5 });
+  });
+
+  it('declares a tie inside the margin', () => {
+    const result = scoreBlindRubric([{ criterion: 'x', weight: 1 }], [0.75], [0.7]);
+    expect(result.winner).toBe('tie');
+  });
+
+  it('treats a gap of exactly the margin as a tie regardless of float representation', () => {
+    // 0.8 - 0.7 > 0.1 in binary floating point while 0.7 - 0.6 is not; the
+    // comparison runs in integer hundredths so both land on the same side.
+    for (const [a, b] of [
+      [0.8, 0.7],
+      [0.7, 0.6],
+      [1.0, 0.9],
+      [0.35, 0.25],
+    ]) {
+      expect(scoreBlindRubric([{ criterion: 'x', weight: 1 }], [a], [b]).winner).toBe('tie');
+    }
+    expect(scoreBlindRubric([{ criterion: 'x', weight: 1 }], [0.81], [0.7]).winner).toBe('A');
+    expect(scoreBlindRubric([{ criterion: 'x', weight: 1 }], [0.7], [0.81]).winner).toBe('B');
+  });
+
+  it('rejects a malformed rubric', () => {
+    expect(scoreBlindRubric([], [], [])).toBeNull();
+    expect(scoreBlindRubric([{ criterion: 'x', weight: 'heavy' }], [1], [1])).toBeNull();
+  });
+
+  const RUBRIC = [{ criterion: 'x', weight: 1 }];
+
+  it('returns null for a string score instead of coercing it', () => {
+    expect(scoreBlindRubric(RUBRIC, ['0.9'], [0.5])).toBeNull();
+    expect(scoreBlindRubric(RUBRIC, [0.5], ['0.9'])).toBeNull();
+  });
+
+  it('returns null for a null score instead of treating it as 0', () => {
+    expect(scoreBlindRubric(RUBRIC, [null], [0.5])).toBeNull();
+    expect(scoreBlindRubric(RUBRIC, [0.5], [null])).toBeNull();
+  });
+
+  it('returns null for a NaN score instead of declaring a tie', () => {
+    expect(scoreBlindRubric(RUBRIC, [Number.NaN], [0.5])).toBeNull();
+    expect(scoreBlindRubric(RUBRIC, [0.5], [Number.NaN])).toBeNull();
+  });
+
+  it('returns null for an out-of-range score instead of clamping it', () => {
+    expect(scoreBlindRubric(RUBRIC, [5], [0.5])).toBeNull();
+    expect(scoreBlindRubric(RUBRIC, [0.5], [1.01])).toBeNull();
+    expect(scoreBlindRubric(RUBRIC, [-0.1], [0.5])).toBeNull();
+    expect(scoreBlindRubric(RUBRIC, [0.5], [-1])).toBeNull();
+  });
+
+  it('accepts the inclusive bounds 0 and 1', () => {
+    expect(scoreBlindRubric(RUBRIC, [1], [0])).toEqual({ winner: 'A', scoreA: 1, scoreB: 0 });
   });
 });

--- a/tests/scripts/eval-blind-comparator.test.js
+++ b/tests/scripts/eval-blind-comparator.test.js
@@ -397,7 +397,7 @@ describe('scoreBlindRubric — harness-side arithmetic', () => {
 
   it('treats a gap of exactly the margin as a tie regardless of float representation', () => {
     // 0.8 - 0.7 > 0.1 in binary floating point while 0.7 - 0.6 is not; the
-    // comparison runs in integer hundredths so both land on the same side.
+    // comparison carries a tolerance so both land on the same side.
     for (const [a, b] of [
       [0.8, 0.7],
       [0.7, 0.6],
@@ -408,6 +408,23 @@ describe('scoreBlindRubric — harness-side arithmetic', () => {
     }
     expect(scoreBlindRubric([{ criterion: 'x', weight: 1 }], [0.81], [0.7]).winner).toBe('A');
     expect(scoreBlindRubric([{ criterion: 'x', weight: 1 }], [0.7], [0.81]).winner).toBe('B');
+  });
+
+  it('decides the winner on the unrounded totals, not on their two-decimal display', () => {
+    // Weights need not land on hundredths: 0.416 / 0.292 / 0.292 give totals of
+    // 0.854 and 0.75, a gap of 0.104 past the margin, although the displayed
+    // totals round to 0.85 and 0.75.
+    const rubric = [
+      { criterion: 'x', weight: 0.416 },
+      { criterion: 'y', weight: 0.292 },
+      { criterion: 'z', weight: 0.292 },
+    ];
+    expect(scoreBlindRubric(rubric, [1, 0.75, 0.75], [0.75, 0.75, 0.75])).toEqual({
+      winner: 'A',
+      scoreA: 0.85,
+      scoreB: 0.75,
+    });
+    expect(scoreBlindRubric(rubric, [0.75, 0.75, 0.75], [1, 0.75, 0.75]).winner).toBe('B');
   });
 
   it('rejects a malformed rubric', () => {

--- a/tests/scripts/eval.test.js
+++ b/tests/scripts/eval.test.js
@@ -3172,3 +3172,24 @@ Do something.
     });
   });
 });
+
+describe('resolveTrialTimeoutMs — per-run ceiling override', () => {
+  const { resolveTrialTimeoutMs, DEFAULT_TRIAL_TIMEOUT_MS } = require('../../scripts/lib/eval');
+
+  it('defaults to the standing 900s instrument when the variable is unset or empty', () => {
+    expect(resolveTrialTimeoutMs({})).toBe(DEFAULT_TRIAL_TIMEOUT_MS);
+    expect(resolveTrialTimeoutMs({ ARCFORGE_EVAL_TRIAL_TIMEOUT_MS: '' })).toBe(900000);
+  });
+
+  it('reads a positive integer of milliseconds', () => {
+    expect(resolveTrialTimeoutMs({ ARCFORGE_EVAL_TRIAL_TIMEOUT_MS: '1800000' })).toBe(1800000);
+  });
+
+  it('fails loudly on anything that is not a positive integer', () => {
+    for (const bad of ['abc', '0', '-5', '1.5', '30m']) {
+      expect(() => resolveTrialTimeoutMs({ ARCFORGE_EVAL_TRIAL_TIMEOUT_MS: bad })).toThrow(
+        /ARCFORGE_EVAL_TRIAL_TIMEOUT_MS/,
+      );
+    }
+  });
+});

--- a/tests/scripts/loop-verifier.test.js
+++ b/tests/scripts/loop-verifier.test.js
@@ -60,9 +60,9 @@ describe('parseVerdict', () => {
   it('takes the LAST verdict line when multiple appear', () => {
     expect(parseVerdict('Final verdict: FAIL\nrecheck\nFinal verdict: PASS')).toBe('PASS');
   });
-  it('returns null for SHIP-only output (verifier.md vocabulary divergence)', () => {
-    // The agent body's own report format says SHIP/NEEDS WORK/BLOCKED — that must
-    // NEVER be mapped to PASS. No `Final verdict:` line → null → block.
+  it('returns null for SHIP-only output (no verdict line)', () => {
+    // A session that answers in some other vocabulary must never be mapped to
+    // PASS. No `Final verdict:` line → null → block.
     expect(parseVerdict('### Final Assessment\nSHIP')).toBeNull();
   });
   it('returns null for garbage / no verdict line', () => {
@@ -108,15 +108,17 @@ describe('assembleVerifierPrompt', () => {
     verifyCommand: ['npm', 'test'],
   };
 
-  it('layers body + criteria + verify-cmd evidence + verdict override', () => {
+  it('layers body + criteria + verify-cmd evidence + verdict protocol', () => {
     const prompt = assembleVerifierPrompt(base);
     expect(prompt).toContain('AGENT BODY');
     expect(prompt).toContain('criterion one');
     expect(prompt).toContain('npm test');
     expect(prompt).toContain('Final verdict: PASS');
     expect(prompt).toContain('Final verdict: FAIL');
-    // The override must forcefully supersede the SHIP/NEEDS WORK/BLOCKED wording.
-    expect(prompt).toContain('Disregard the SHIP');
+    // The protocol is stated once, next to the parser; nothing in the assembled
+    // prompt carries the retired SHIP / NEEDS WORK / BLOCKED vocabulary.
+    expect(prompt).toContain('## Verdict Protocol');
+    expect(prompt).not.toContain('SHIP');
   });
 
   it('prepends verbatim feedback when provided', () => {


### PR DESCRIPTION
## Summary

Lands the engine-prompt findings of the prompt audit (E1–E12): the four prompts under `scripts/lib/prompts/` and the request code that assembles them, plus one instrument change the audit's own eval run needed. Four commits.

| Findings | What changed |
|---|---|
| E1–E3, E11 `verifier.md` + `loop-verifier.js` | The verifier prompt ended its report with SHIP / NEEDS WORK / BLOCKED while the loop appended "Disregard the SHIP … wording above" and required `Final verdict: PASS|FAIL` — one prompt, two verdict contracts. The prompt now states the PASS/FAIL line once; the override sentence is gone; the caps opener, the five-step "Gate Function", the "Never Accept" list and rules 1–2 (the same instruction four ways) collapse to one paragraph with its reason; "Critical Rules" → "Rules". `parseVerdict`'s SHIP→null guard stays. |
| E4–E8, E10–E12 grader / analyzer / comparator prompts, `eval-grader-model.js`, `eval.js` | Each grader prompt carried a markdown report format no code path requests beside the JSON contract the harness parses, gated on a condition the model cannot evaluate; the grader's three-anchor and five-anchor scales disagreed; the analyzer said it reads JSONL it never receives; the analyzer's runtime block asked for a `recommendation` field the prompt forbids and the code discards; `{IMPROVED_THRESHOLD}` substitution ran against a placeholder that no longer exists; "You have read-only access: Read, Grep, Glob" was unenforced — both spawns now pass `--tools Read,Grep,Glob`; the isolation instruction in `eval.js` and the comparator's "MUST NOT" drop to normal volume with their reasons. |
| E9 comparator arithmetic → `scoreBlindRubric()` | The blind comparator asked the model to normalize weights, compute weighted totals and apply a 0.1 tie margin. The agent now returns rubric + per-criterion scores; the harness computes totals and the winner. Malformed output (non-number, NaN, out-of-[0,1], misaligned lengths, bad weights) returns null with a stderr note rather than a coerced winner — the F4 bias class the old "unrecognized winner" test guarded. The winner is decided on the unrounded totals with a 1e-9 tolerance, so a gap of exactly 0.1 is a tie whatever the operands' float representation (qa caught `0.8 − 0.7 > 0.1` vs `0.7 − 0.6` landing on opposite sides), while a real gap of 0.104 from weights off the hundredths grid is not — the first cut rounded before comparing and lost it (Codex review, abc0b3cd). 29 comparator tests (was 20). |

| Trial timeout override (not an audit finding) | `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS` moves the per-trial 900 s ceiling for one run; default unchanged, non-integer values throw. Needed to measure `eval-diagramming-obsidian-unverified-save-claim`, whose treatment arm (a full build-and-render pipeline) was killed at the cap in 4 of 5 trials on a loaded machine; documented in `docs/guide/eval-system.md`, and — after the Codex review pointed at AGENTS.md rule 4 — recorded in the living contract as `product/specs/eval.md` B-10 plus ROADMAP D-017 (f39c6eb8). |

Not in this PR: the skill findings (`fix/prompt-audit-skills`). Kept separate so the skill evals ran under the unchanged grader and stay comparable to the standing benchmark.

## Type

- [x] CLI Engine

## Iron Law Compliance (Skills Only)

Not a skill PR. Evidence instead:

- Live smoke, grader spawn with `--tools Read,Grep,Glob`: `node scripts/cli.js eval run eval-maintaining-obsidian-vault-only-answer --k 1` on this branch produced a parsed model grade (`grading/trial-1.json` with per-assertion scores and `discovered_claims`), no `model_grader_failed`.
- Live smoke, verifier vocabulary: a one-task loop (`--max-runs 1 --verifier`) on this branch recorded `verifier_attempts[0].verdict = "PASS"` from the real verifier session and completed the task — the parseable line is emitted without the override.
- Unit: jest 74 suites / 2,099 tests incl. the D1/D8 boundary lints; `tests/skills/test_eval_agents_contract.py` still pins the JSON fields; biome clean.

**Baseline provenance:**
- Model + version: harness default model; Claude Code 2.1.263
- Harness + version: this branch @ 08d3387b; `qa` agent review green on all 5 runners + 6 static checks

## Testing

- [x] `npm test` passes (all 5 runners)
- [x] New tests added for new functionality (`scoreBlindRubric` unit tests; string-score F4 regression on `runBlindComparator`)
- [x] Tested on Claude Code (primary platform)
- [x] The six static checks green
