### PR TITLE
fix(skills): land the prompt audit's skill and contributor findings

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -39,7 +39,8 @@ the skill.
 
 ## Test file convention
 
-- Single generic checker: `tests/skills/test_skill_structure.py` (no per-skill file)
+- Single generic structure checker: `tests/skills/test_skill_structure.py` (no
+  per-skill structure file)
 - Runner: pytest — discovers every `skills/core/*/SKILL.md` dynamically, so
   merges, renames, and new skills need zero test edits. Adding or removing a
   skill does need one edit: `EXPECTED_SKILL_COUNT`, which pins the scan against
@@ -47,6 +48,10 @@ the skill.
 - Validates frontmatter against the frozen schema, `name` == dirname, the
   description register, section/body structure, referenced supporting files,
   and the line budget
+- A skill-local script (`skills/core/<name>/references/*.py`) ships its
+  contract test as `tests/skills/test_<script>.py`, driving the script as the
+  subprocess the skill runs and asserting on its output — it tests the
+  script, never a skill's structure, which stays with the generic checker
 
 The line budget is a hard cap owned by that test. Do not negotiate an exemption
 for a skill that doesn't fit — split it into references or move behavior into

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -81,7 +81,7 @@ commit. Lowering the floor requires a written reason in the same commit.
 
 ## Custom Runner (`tests/node/`)
 
-- CLI integration, schema validation, model definitions, YAML parsing
+- CLI manifest contract, CLI integration (eval flags, obsidian, finishing/worktree), eval graders, YAML parser, file locking
 - Lightweight — no test framework overhead
 
 ## Principles

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: releasing
-description: Use this skill whenever the user (an arcforge contributor) says they want to bump arcforge's version, cut a release, "ship vX.Y.Z", "準備發版", "ready to release", or any equivalent intent on the arcforge repo itself — even if they don't use the word "release". Runs the canonical release workflow: pre-flight checks → vault ingest → outdated-doc audit → CHANGELOG → product-state flip → 9-file version bump (incl. website + Codex manifest) → commit/push/PR → post-merge tag. Contributor-only; do NOT trigger inside projects that merely install arcforge as a plugin.
+description: Use this skill whenever the user (an arcforge contributor) says they want to bump arcforge's version, cut a release, "ship vX.Y.Z", "準備發版", "ready to release", or any equivalent intent on the arcforge repo itself — even if they don't use the word "release". Runs the canonical release workflow: pre-flight checks → vault ingest → outdated-doc audit → CHANGELOG → product-state flip → version bump across every canonical location → commit/push/PR → post-merge tag. Contributor-only; do NOT trigger inside projects that merely install arcforge as a plugin.
 ---
 
 # releasing
 
-You are helping an arcforge contributor ship a new version. The goal of this skill is zero silent drift between the canonical version files, the CHANGELOG, shipped documentation, and the Obsidian vault knowledge base. Those four surfaces get out of sync surprisingly easily — a prior release (v1.4.0) discovered that `marketplace.json` had been stuck two versions behind, and v1.4.1 discovered the observer daemon and the JS side had diverged state roots. The checklist below is designed to catch exactly those classes of drift before they ship.
+You are helping an arcforge contributor ship a new version. The goal of this skill is zero silent drift between the canonical version files, the CHANGELOG, shipped documentation, and the Obsidian vault knowledge base. Those four surfaces drift independently — a manifest left behind by a bump, a state root moved in code but not in docs — and the checklist below exists to catch those classes of drift before they ship.
 
 This is a **project-local, contributor-only** skill. It lives in `.claude/skills/` (not the shipped `skills/` directory) because releasing arcforge is a maintainer activity, not a user activity. If you see this skill trigger inside a project that merely *installs* arcforge, something is wrong — stop and tell the user.
 
@@ -60,11 +60,11 @@ Do these in order. Each step depends on the previous one being correct.
 
 ### 1. Ingest the release into the Obsidian vault
 
-Invoke `/arcforge:maintaining-obsidian` in **ingest** mode. Scope depends on the release shape — always propose scope before bulk-processing, because ingest is the most expensive step in the workflow:
+Ingest with the `maintaining-obsidian` skill in **ingest** mode (the arcforge plugin is disabled in this repo, so the skill resolves only in a session started with `claude --plugin-dir .`). Scope depends on the release shape — always propose scope before bulk-processing, because ingest is the most expensive step in the workflow:
 
 | Release shape | Ingest scope |
 |---|---|
-| Patch with an architectural decision inside (e.g., v1.4.1's `~/.arcforge/` consolidation) | Decision note + refresh Source notes whose content substantively changed + propagate + index/log + daily note |
+| Patch with an architectural decision inside | Decision note + refresh Source notes whose content substantively changed + propagate + index/log + daily note |
 | Patch with only small fixes | Skip, or just append a single `log.md` entry |
 | Minor release (new skill or feature) | Full sync: new Source notes for new skills/guides, Decision notes for any architectural shifts, update affected MOCs, propagate cross-refs |
 | Major release | Everything above, plus update `MOC-ArcForge.md` to reflect the new surface |
@@ -109,7 +109,7 @@ A release that changes skill behavior must ship a benchmark that reflects *this*
 
 1. **Regenerate the benchmark** against the release branch (manual/CI live-eval run — see `skills/core/evaluating/SKILL.md` for the regeneration procedure). This refreshes `evals/benchmarks/latest.json` and `evals/benchmarks/raw/latest.json`.
 
-   > Path note: the canonical report location is `evals/benchmarks/` (`latest.json` + `raw/latest.json`), each carrying a top-level `generated` ISO-8601 timestamp. Older notes that say `evals/reports/latest.json` are referring to this same artifact under its prior name.
+   > Path note: the canonical report location is `evals/benchmarks/` (`latest.json` + `raw/latest.json`), each carrying a top-level `generated` ISO-8601 timestamp.
 
 2. **Assert freshness.** The `generated` timestamp in both `evals/benchmarks/latest.json` and `evals/benchmarks/raw/latest.json` must be **newer than the previous release tag's commit date**. If the timestamp predates the last tag, the benchmark was never re-run for this release — stop and regenerate.
 
@@ -196,10 +196,13 @@ git add product/
 git commit -m "docs(product): flip vX.Y.Z to shipped"
 ```
 
-Keeping it separate is deliberate — the release commit in step 7 stays exactly the 10
-release files, so reverting a bad bump does not drag the product history back with it.
+Keeping it separate is deliberate — the release commit in step 7 stays exactly the
+version files plus `CHANGELOG.md`, so reverting a bad bump does not drag the product
+history back with it.
 
-### 6. Bump the version in **all 9 canonical locations**
+### 6. Bump the version in every canonical location
+
+The list is `LOCATIONS` in `scripts/check-version-sync.js`; the table below shows what each location holds and is illustrative, not the list.
 
 | File | Where in the file |
 |---|---|
@@ -227,7 +230,7 @@ Verify with a single grep after bumping + building:
 grep -rn "X\.Y\.Z" package.json .claude-plugin/ .codex-plugin/ README.md website/page/
 ```
 
-Expect **exactly 9 hits**. Fewer means a split-brain bump (dangerous — Claude Code, Codex, or the website disagree about the current version). More means a stale copy elsewhere that also needs attention.
+Every hit must be one of the `LOCATIONS` files. A location with no hit means a split-brain bump (dangerous — Claude Code, Codex, or the website disagree about the current version); a hit outside the list means a stale copy elsewhere that also needs attention.
 
 For an authoritative pass/fail that compares every location against the canonical `plugin.json` version, run `npm run check:versions` (zero-dep `scripts/check-version-sync.js`). It prints a location → version table and exits non-zero on any drift. The same check runs in CI and gates `release.yml` before the GitHub Release is created, so a drifted bump fails the release rather than shipping silently.
 
@@ -238,13 +241,13 @@ For releases that change **shipped surface area** (new skill, removed CLI flag, 
 ### 7. Commit, push, open PR
 
 - Commit message: `chore(release): vX.Y.Z` with a brief body summarizing scope
-- Stage exactly the 10 release files (9 version locations + `CHANGELOG.md`) — the product-state flip from step 5 is already its own commit on this branch, so do not fold it in. Avoid `git add -A` — it tends to pull in lock files, editor droppings, and workspace metadata
+- Stage exactly the release files (the version locations + `CHANGELOG.md`) — the product-state flip from step 5 is already its own commit on this branch, so do not fold it in. Avoid `git add -A` — it tends to pull in lock files, editor droppings, and workspace metadata
 - `git push -u origin <branch>`
-- `gh pr create` with a test-plan checklist in the body: 5 runners green, 6 static checks green, lint green, secret scan clean, canonical 9-location grep returned exactly 9 hits
+- `gh pr create` with a test-plan checklist in the body: 5 runners green, 6 static checks green, lint green, secret scan clean, `check:versions` green and the version grep returned only canonical locations
 
 ### 8. After PR merges to main — tag it
 
-Arcforge has tagged every release since `v1.0.0`. Skipping a tag breaks the `git log vPREV..HEAD` workflow that the *next* release relies on to scope its CHANGELOG.
+Every release is tagged. Skipping a tag breaks the `git log vPREV..HEAD` workflow that the *next* release relies on to scope its CHANGELOG.
 
 ```bash
 git checkout main && git pull
@@ -254,7 +257,7 @@ git push origin vX.Y.Z
 
 If the user is merging via GitHub UI (squash or merge), run the tag commands against `main` after the merge completes — the merge commit on main is what represents the release on the main timeline, not the source branch's tip.
 
-## Things That Are Easy to Forget
+## Easy to forget
 
 These are the steps that get skipped when a contributor is in a hurry. The skill's job is to surface them even when the user doesn't ask:
 
@@ -264,16 +267,9 @@ These are the steps that get skipped when a contributor is in a hurry. The skill
 - **Secret scan.** Release commits are large diffs. `git diff --cached | grep -iE "api[_-]?key|token|secret|password"` before pushing. The cost of a false positive is low; the cost of a committed secret is very high.
 - **Daily note append.** After the release ships, `obsidian daily:append` with a one-line release summary so the release is preserved in the vault's chronological log, not only in `log.md`.
 - **The product-state flip.** The roadmap row, its `Tag` cell, the spec headers, and the `← we are here` marker are four edits in four files, and a version bump touches none of them. `npm run check:product` proves the first three; where the marker ended up is on you.
-- **The post-merge tag.** Merging the PR does not auto-tag. This is the single most commonly skipped step.
-
-## Anti-Patterns (from real arcforge release incidents)
-
-- **Silent version drift** — v1.4.0 discovered `.claude-plugin/marketplace.json` had been stuck two versions behind. The 9-location grep is designed to catch exactly this. v3.0.1 expanded the surface to include `website/page/{hero,sections}.{jsx,js}` after the website was found to have been silently bumped manually during v3.0.0; 6.1.0 added `.codex-plugin/plugin.json`, which is hand-maintained beside its Claude Code twin and drifts the same way.
-- **Version bump without CHANGELOG entry** — the marketplace release cache is version-keyed. A bump with no CHANGELOG entry ships to users who have no way to tell what changed. The checklist order (CHANGELOG *before* version bump) enforces pairing them.
-- **Editing past CHANGELOG entries** — downstream users and vault Decision notes depend on past entries being stable. Add corrections to the current entry; never stealth-edit the past.
-- **Partial bump shipped** — bumping a subset of the 9 locations produces a release where Claude Code, Codex, the marketplace JSON, or the website disagree about the current version. Always use the 9-location grep as a post-bump gate.
-- **Mixing release commit with other work** — `chore(release): vX.Y.Z` should be *only* the 10 release files (9 version locations + `CHANGELOG.md`). Unrelated fixes bundled in make bisect and rollback painful. Commit work-in-progress separately *before* the release commit.
-- **Skipping the post-merge tag** — without the tag, the next release can't use `git log vPREV..HEAD` to scope its CHANGELOG. Missing tags cause the *next* release to either drop entries or include already-shipped ones.
+- **Version bump without a CHANGELOG entry.** The marketplace release cache is version-keyed, so a bump with no entry ships to users who have no way to tell what changed. The checklist order (CHANGELOG before bump) pairs them, and `release.yml` fails without the section.
+- **A release commit that carries other work.** `chore(release): vX.Y.Z` is the version files plus `CHANGELOG.md`, nothing else — unrelated fixes bundled in make bisect and rollback painful. Commit work-in-progress separately *before* the release commit.
+- **The post-merge tag.** Merging the PR does not auto-tag, and without the tag the next release can't use `git log vPREV..HEAD` to scope its CHANGELOG. This is the single most commonly skipped step.
 
 ## After the Release
 

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -202,7 +202,7 @@ history back with it.
 
 ### 6. Bump the version in every canonical location
 
-The list is `LOCATIONS` in `scripts/check-version-sync.js`; the table below shows what each location holds and is illustrative, not the list.
+The authoritative set is `CANONICAL_FILE` plus `LOCATIONS` in `scripts/check-version-sync.js` — the canonical `.claude-plugin/plugin.json` is the version every `LOCATIONS` entry is compared against, so it is bumped too, never inferred. The table below shows what each location holds and is illustrative, not the list.
 
 | File | Where in the file |
 |---|---|
@@ -230,7 +230,7 @@ Verify with a single grep after bumping + building:
 grep -rn "X\.Y\.Z" package.json .claude-plugin/ .codex-plugin/ README.md website/page/
 ```
 
-Every hit must be one of the `LOCATIONS` files. A location with no hit means a split-brain bump (dangerous — Claude Code, Codex, or the website disagree about the current version); a hit outside the list means a stale copy elsewhere that also needs attention.
+Every hit must be `CANONICAL_FILE` or one of the `LOCATIONS` files. A location with no hit means a split-brain bump (dangerous — Claude Code, Codex, or the website disagree about the current version); a hit outside the list means a stale copy elsewhere that also needs attention.
 
 For an authoritative pass/fail that compares every location against the canonical `plugin.json` version, run `npm run check:versions` (zero-dep `scripts/check-version-sync.js`). It prints a location → version table and exits non-zero on any drift. The same check runs in CI and gates `release.yml` before the GitHub Release is created, so a drifted bump fails the release rather than shipping silently.
 

--- a/evals/scenarios/eval-maintaining-obsidian-audit-runs-lint-script.md
+++ b/evals/scenarios/eval-maintaining-obsidian-audit-runs-lint-script.md
@@ -1,0 +1,318 @@
+# Eval: eval-maintaining-obsidian-audit-runs-lint-script
+
+## Scope
+skill
+
+## Target
+skills/core/maintaining-obsidian/SKILL.md
+
+## Context
+An Obsidian vault lives at `./vault` in this directory: a small team's
+operational notes for its checkout service. Its `AGENTS.md` and `SCHEMA.md`
+declare the note types, the tag taxonomy, and the audit thresholds. A copy of
+the `maintaining-obsidian` skill's `references/` directory sits at
+`./maintaining-obsidian/references`.
+
+## Scenario
+The user says:
+
+> Run `audit lint` on the vault and tell me what it found. Don't fix anything — I want the findings first.
+
+Do it now, then report the findings.
+
+## Design Notes
+Not sent to the agent (only `## Context` and `## Scenario` reach it) — this
+section is for whoever maintains the scenario.
+
+This is the runtime acceptance for the one behavioral line the prompt audit
+added to `maintaining-obsidian/SKILL.md`: *the deterministic scans run in
+code* — `references/lint_vault.py` emits the LINT fact base and the agent works
+from its JSON. The claim under test is that, given that line, an agent locates
+the script, passes the vault's declared thresholds to it as flags, and reports
+what it found rather than what a hand scan would guess.
+
+Skill scope, with a caveat the fixture has to carry. A skill-scope trial injects
+`SKILL.md` and nothing else, so the script the line points at would not exist on
+disk; `## Setup` copies the skill's `references/` from `$PROJECT_ROOT` into the
+trial directory to stand in for the base directory a real skill load announces.
+The copy is the shipped script at the commit under test, so the measurement is
+of the shipped skill, not a fixture reimplementation. `## Plugin Dir` is not
+used: headless trials carry `--disable-slash-commands`, the Skill tool never
+exists in them, and the 6.1.0 benchmark recorded a skill that never routed under
+that modality (#179) — a plugin-dir run here would measure routing, which is
+P6's acceptance, not this line.
+
+Why `## Verdict Policy non-regression` with `## Preflight skip`, like
+`eval-d1-bare-cli-invocation`: the script is in the fixture for both arms, so a
+baseline agent that explores hard enough can find and run it. That leak makes a
+delta meaningless as evidence for the line — but it does not touch the question
+the scenario asks, which is whether the treatment arm reliably does the target
+behavior. The strict bar is the honest instrument: every scored treatment trial
+must pass. Baseline is run and recorded as context only.
+
+The three fixture facts are chosen so that a hand scan gets some and the script
+gets all: the orphan is findable by reading; the deleted file named in `log.md`
+is findable by reading `log.md` against the tree; the sha256 drift on the Raw
+Source is not — it needs the digest recomputed over the body after the
+frontmatter, which is exactly the rule the script encodes. `Deploy-Pipeline`
+carries its tags as an indented YAML block list, the shape a line-wise scan
+reads as empty; it is there so a report that invents an "empty tags" finding
+has a fact to be wrong about, though no assertion pins it.
+
+The two negative assertions keep the run a lint: LINT reports and proposes, only
+LINK writes to the wiki layer, and the user said not to fix anything. Writing
+the report under `vault/_audits/` is expected and is not caught by them.
+
+Max Turns is 40: read the two contract files, find and run the script, read the
+JSON, read the three files it names, write the report.
+
+## Preflight
+skip
+
+## Verdict Policy
+non-regression
+
+## Max Turns
+40
+
+## Setup
+mkdir -p vault/Wiki vault/Raw/2026-03-28 maintaining-obsidian
+cp -R "$PROJECT_ROOT/skills/core/maintaining-obsidian/references" maintaining-obsidian/references
+
+cat > vault/AGENTS.md <<'EOF'
+---
+type: agents-contract
+created: 2026-01-14
+scope: How our team runs and operates the checkout service
+preset: minimal
+schema_path: SCHEMA.md
+raw_source: adopted
+---
+
+# ops-notes — Agent Runtime Contract
+
+## Schema Authority
+
+- `schema_path: SCHEMA.md` — load it after this file.
+- SCHEMA.md governs note types, frontmatter, the tag taxonomy, and audit thresholds. Where this file and SCHEMA.md disagree, SCHEMA.md wins.
+- Do not invent a type or a threshold SCHEMA.md does not declare.
+
+## Identity
+
+This vault is the team's operational memory for the checkout service: how it is deployed, what has broken, and what was decided. Raw Sources under `Raw/` are immutable captures; typed notes live under `Wiki/`.
+
+## Language Policy
+
+Single language: English. No callouts.
+
+## Paths
+
+- Index: `index.md`
+- Log: `log.md`
+- Audit reports: `_audits/`
+
+## Domain Policy
+
+See SCHEMA.md for types, frontmatter, taxonomy, and audit thresholds.
+EOF
+
+cat > vault/SCHEMA.md <<'EOF'
+---
+type: schema
+created: 2026-01-14
+scope: type definitions for ops-notes
+preset: minimal
+---
+
+# ops-notes — Domain Schema
+
+## Universal Frontmatter
+
+```yaml
+---
+type: runbook | decision
+created: YYYY-MM-DD
+tags: []
+---
+```
+
+## Runbook
+
+```yaml
+---
+type: runbook
+owner: ""                  # team that owns the procedure
+---
+```
+
+## Decision
+
+```yaml
+---
+type: decision
+status: proposed | accepted | superseded
+---
+```
+
+## Raw Source
+
+This vault adopts the Raw Source pattern: captures live under `Raw/<YYYY-MM-DD>/<slug>.md` with the generic Raw Source frontmatter (`source_url`, `source_author`, `fetched`, `ingested`, `sha256` of the body after the frontmatter).
+
+## Tag Taxonomy
+
+- `deploy` — release and rollback procedure
+- `checkout` — the checkout service
+- `alerting` — detection and paging
+
+LINT checks:
+- Unknown top-level tags → flag.
+
+## Audit Thresholds
+
+- Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
+- Undeclared field in 80%+ of a type → EVOLVE candidate (`--undeclared-pct 80`).
+- Tag used 10+ times outside the taxonomy → EVOLVE candidate (`--tag-min 10`).
+- Title similarity 0.8+ against an existing note → GROW drops the proposal (`--title-match 0.8`).
+EOF
+
+cat > vault/index.md <<'EOF'
+# ops-notes Index
+Last updated: 2026-04-02
+
+## Runbooks
+- [[Deploy-Pipeline]] — how a release reaches production and how it comes back
+
+## Decisions
+- [[Decision-Blue-Green]] — deployment strategy
+EOF
+
+cat > vault/log.md <<'EOF'
+# Log
+
+## [2026-01-20] create | runbook | Wiki/Deploy-Pipeline.md
+## [2026-01-22] create | runbook | Wiki/Runbook-Legacy.md
+## [2026-01-18] create | decision | Wiki/Decision-Blue-Green.md
+## [2026-03-28] ingest | raw | Raw/2026-03-28/vendor-status-page.md
+## [2026-04-02] audit | 50 most recent
+EOF
+
+cat > vault/Wiki/Deploy-Pipeline.md <<'EOF'
+---
+type: runbook
+created: 2026-01-20
+owner: sre
+tags:
+  - deploy
+  - checkout
+---
+
+# Deploy Pipeline
+
+## Procedure
+
+1. `./scripts/deploy.sh --target staging` builds the image and brings up the staging colour.
+2. The staging gate is the integration suite plus a manual smoke of the payment path.
+3. `./scripts/deploy.sh --target production` swaps which colour the load balancer points at.
+
+## Rollback
+
+`./scripts/rollback.sh` points the load balancer back at the previous colour. The old colour stays warm for 30 minutes after every promotion, so this is a pointer swap, not a redeploy.
+
+## Relationships
+
+Follows the strategy recorded in [[Decision-Blue-Green]].
+EOF
+
+cat > vault/Wiki/Decision-Blue-Green.md <<'EOF'
+---
+type: decision
+created: 2026-01-18
+status: accepted
+tags: [deploy]
+---
+
+# Decision: Blue-Green over Canary
+
+## Decision
+
+Deploy blue-green. Keep the previous colour warm for 30 minutes after promotion.
+
+## Reasoning
+
+Canary needs per-request routing and a way to compare the two populations. We have neither. Blue-green gives a rollback measured in seconds for the cost of running two colours briefly.
+
+## Relationships
+
+Implemented by [[Deploy-Pipeline]].
+EOF
+
+cat > vault/Wiki/Alerting-Proposal-2025.md <<'EOF'
+---
+type: decision
+created: 2025-11-03
+status:
+tags: [alerting]
+---
+
+# Alerting Proposal 2025
+
+## Decision
+
+Page on-call when checkout 5xx exceeds 2% for five minutes. Never agreed; never revisited.
+
+## Reasoning
+
+Written after the November near-miss. Nobody picked it up.
+EOF
+
+cat > vault/Raw/2026-03-28/vendor-status-page.md <<'EOF'
+---
+source_url: https://status.example-payments.com/incidents/4821
+source_author: Example Payments
+fetched: 2026-03-28
+ingested: 2026-03-28
+sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+---
+# Incident 4821 — Elevated authorization failures
+
+Between 14:00 and 14:45 UTC a subset of authorization requests returned errors. The issue was traced to a credential rotation on our side and has been resolved. Merchants who retried after 14:45 UTC saw normal success rates.
+EOF
+
+## Assertions
+- [tool_called] Bash:re:lint_vault\.py
+- [tool_called] Bash:re:lint_vault\.py[^\n]*--field-empty-pct\s+90
+- [tool_not_called] Edit:vault/Wiki
+- [tool_not_called] Write:vault/Wiki
+- [ ] A1: The report names `Alerting-Proposal-2025` as an orphan — a note with no inbound and no outbound wikilinks — and leaves it as a finding, not a fix.
+- [ ] A2: The report says `log.md` names `Wiki/Runbook-Legacy.md`, a file that no longer exists in the vault.
+- [ ] A3: The report flags source drift on `Raw/2026-03-28/vendor-status-page.md` — the stored `sha256` does not match the body — and does not rewrite the Raw Source or its digest.
+
+## Grader
+mixed
+
+## Grader Config
+Grade from the transcript, including tool calls and the final reply. Do not
+credit findings the agent says it will look for but never reports.
+
+A1 scores 1 when the reply reports `Alerting-Proposal-2025` (any spelling that
+identifies the note) as having no links in and no links out, or as an orphan.
+It scores 0 when the note is not mentioned, or when it is mentioned only as
+something the agent linked, edited, or deleted.
+
+A2 scores 1 when the reply says that `log.md` refers to `Runbook-Legacy` (or
+`Wiki/Runbook-Legacy.md`) and that the file is not present in the vault. A
+reply that lists log entries without noting the missing file scores 0.
+
+A3 scores 1 when the reply reports the Raw Source `vendor-status-page` as
+drifted, changed, or hash-mismatched — the stored `sha256` does not match its
+body — and the transcript shows no write to that file. A reply that reports it
+as fresh or unhashed, omits it, or rewrites its `sha256` scores 0. Recomputing
+the digest and reporting the new value is fine; writing it into the file is not.
+
+Score each assertion 1 or 0; partial credit is not available.
+
+## Trials
+5
+
+## Version
+1

--- a/evals/scenarios/eval-maintaining-obsidian-audit-runs-lint-script.md
+++ b/evals/scenarios/eval-maintaining-obsidian-audit-runs-lint-script.md
@@ -66,6 +66,18 @@ the report under `vault/_audits/` is expected and is not caught by them.
 Max Turns is 40: read the two contract files, find and run the script, read the
 JSON, read the three files it names, write the report.
 
+### Version 2 — every declared threshold is asserted
+
+Version 1 asserted one of the four thresholds the vault declares
+(`--field-empty-pct 90`), on the reasoning that one flag proves the vault's
+numbers reach the script. The Codex review on #182 pointed out that the
+`SKILL.md` line under test says thresholds reach the script as flags — all of
+them — so a treatment that passed one and dropped three would have satisfied
+version 1. Version 2 asserts each declared flag. The stored version-1
+transcripts (run `20260909-070419`) show all four flags in every one of the ten
+trials, so this is a sharper instrument, not a different expectation; the pool
+starts over because the assertion set changed (eval B-8).
+
 ## Preflight
 skip
 
@@ -281,6 +293,9 @@ EOF
 ## Assertions
 - [tool_called] Bash:re:lint_vault\.py
 - [tool_called] Bash:re:lint_vault\.py[^\n]*--field-empty-pct\s+90
+- [tool_called] Bash:re:lint_vault\.py[^\n]*--undeclared-pct\s+80
+- [tool_called] Bash:re:lint_vault\.py[^\n]*--tag-min\s+10
+- [tool_called] Bash:re:lint_vault\.py[^\n]*--title-match\s+0\.8
 - [tool_not_called] Edit:vault/Wiki
 - [tool_not_called] Write:vault/Wiki
 - [ ] A1: The report names `Alerting-Proposal-2025` as an orphan — a note with no inbound and no outbound wikilinks — and leaves it as a finding, not a fix.
@@ -315,4 +330,4 @@ Score each assertion 1 or 0; partial credit is not available.
 5
 
 ## Version
-1
+2

--- a/evals/skill-eval-coverage.md
+++ b/evals/skill-eval-coverage.md
@@ -68,6 +68,76 @@ p7-benchmark-evidence.md「協定修正案」）。
 | writing-skills | unmet-but-covered（P7 ceiling ×2，新支無 delta 史） | 存廢建議書 |
 | evaluating | unmet-but-covered（P5）；P7 preflight 67% 恢復鑑別力 | 存廢建議書（傾向保留） |
 
+## Prompt audit (2026-09-08) — non-regression on the three `SKILL.md` edits
+
+The prompt audit (`/claude-api prompt-audit`, target: the Claude 5 generation
+the evals are baselined on) changed three `SKILL.md` bodies: `executing` (B1, a
+cross-reference sentence), `finishing` (B2, a table cell's version pin), and
+`diagramming-obsidian` (A7, the "think first, draw second" scaffold replaced by
+"every concept has a verb"). Under `.claude/rules/skills.md` those are behavioral
+edits, so each gets harness evidence. The audit's other skill edits live in
+`references/` and presets, which a skill-scope trial never receives (the trial
+gets `SKILL.md` only), so they carry no eval delta by construction; an
+independent refuter per package and the `qa` agent are the evidence for those.
+
+**Run.** `node scripts/cli.js eval ab <scenario> --k 5` on `fix/prompt-audit-skills`
+(skill edits only — the grader prompts changed in the same audit sit on
+`fix/prompt-audit-eval`, so these rows were graded by the unchanged instrument),
+default model, isolated, no `--plugin-dir`, the same conditions as the standing
+P7 rows. Claude Code 2.1.263. Preflight records reused at their current hashes
+(executing `223fe220d5b4dc34` PASS 1/3, finishing `21a613c70fd71f8d` PASS 0/3,
+diagramming `091682c484dd86c7` PASS 0/3, all `-default`).
+
+**Threshold, pre-registered before the run** (`~/.claude/plans/audit-report-toasty-dahl.md`,
+Phase D). This is a **non-regression** claim: PASS requires both (1) the new
+delta's CI lower bound is **> 0** and (2) the new CI **overlaps** the standing
+CI for the row — executing **+0.40 [0.03, 0.77]**, finishing **+0.54 [0.46, 0.62]**,
+diagramming **+0.23 [0.09, 0.38]** (`evals/benchmarks/latest.json`, generated
+2026-09-07). A smaller delta whose interval satisfies both is a PASS and is read
+as one; FAIL on either half means the edited sentence is the suspect.
+
+| scenario | run id | baseline avg (pass) | treatment avg (pass) | delta | standing | verdict |
+|---|---|---|---|---|---|---|
+| `eval-finishing-verify-before-options` | `20260908-141154` | 0.43 (0/5) | 1.00 (5/5) | **+0.57 CI[0.57, 0.57]** | +0.54 [0.46, 0.62] | PASS both halves — IMPROVED |
+| `eval-executing-verify-decides-done` | `20260908-141154` + top-up `20260908-162050` | 0.80 (4/5) | 1.00 (5/5 scorable; one trial per run killed at the runner timeout) | **+0.20 CI[−0.36, 0.76]** | +0.40 [0.03, 0.77] | INCONCLUSIVE — half 1 not met, half 2 met; recorded, not rerun |
+| `eval-diagramming-obsidian-unverified-save-claim` | `20260908-141154` (instrument-capped: 4 of 5 treatment trials killed at 900 s), rerun `20260909-015919` with `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS=1800000` | 0.50 (0/5) | 0.90 (3/5) | **+0.40 CI[0.16, 0.64]** | +0.23 [0.09, 0.38] | PASS both halves — IMPROVED (on the rerun) |
+
+**Verdict.** finishing: PASS on both halves — the new interval sits inside the
+standing one, so B2 (the `git 2.52` cell) moved nothing. executing: **half 1 not met, half 2 met — recorded as INCONCLUSIVE, not rerun.**
+Treatment sat at the ceiling (5/5, avg 1.00) and the delta's interval overlaps the
+standing one, but its lower bound is −0.36 because this run's baseline scored 0.80
+with one 0 among four 1s (CV 0.56; the standing baseline was 0.60), and a k=5
+delta cannot separate a ceiling treatment from a 0.8 baseline. One trial per arm
+was killed at the runner timeout under a load average of 20 and does not score;
+a symmetric `--k 1` top-up (run `20260908-162050`) restored the treatment arm to
+five scorable rows, while the baseline top-up trial was itself killed. The
+pre-registration makes the edited sentence the suspect when a half fails; B1 is
+the one sentence of `executing/SKILL.md` that changed — a cross-reference to the
+`dispatching` skill ("model tier" → "acceptance", the tier text having left
+dispatching in v6) that this scenario never reaches. The maintainer's decision is
+to record the row as not established rather than buy a narrower interval with
+another twenty trials; the release's full benchmark regeneration re-measures it.
+diagramming: **PASS on both halves, on the rerun.** The first run was not
+evaluable under the standing instrument: four of the five treatment trials were
+killed at the runner's fixed 900 s ceiling (the standing row already ran at that
+ceiling — treatment avg 721 s, max 894 s — and the machine sat at a load average
+of 20). A killed, incomplete trial never scores, so instead of a top-up the
+instrument was changed: `fix/prompt-audit-eval` adds `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS`,
+and the rerun set it to 1,800 s from a detached worktree of this branch plus that
+one commit (grader prompts unchanged). All ten trials completed; three of the five
+treatment trials ran 841–1,171 s, past the old cap. Baseline 0.50 [0.28, 0.72],
+treatment 0.90 [0.73, 1], delta +0.40 CI[0.16, 0.64], overlapping the standing
+[0.09, 0.38]; pooled with the first run's five baseline rows and its one surviving
+treatment row, `eval compare` reads +0.38 CI[0.16, 0.61] — IMPROVED either way. The
+cost regression the harness flags (treatment about twice the baseline's duration
+and output tokens) is the skill running the pipeline the baseline skips, as in the
+standing row.
+
+`evals/benchmarks/latest.json` was **not** regenerated here: `eval report` pools
+every row in the window per scenario, so a regeneration now would average the
+2026-08-15 treatment rows with these; the release's benchmark-freshness gate
+forces a full regeneration anyway because `skills/` changed.
+
 ## v6.1.0 — Codex packaging: the router's per-host note (non-regression, instrument-capped)
 
 `skills/core/using/SKILL.md` gained a per-host invocation note during Codex

--- a/evals/skill-eval-coverage.md
+++ b/evals/skill-eval-coverage.md
@@ -105,7 +105,7 @@ as one; FAIL on either half means the edited sentence is the suspect.
 | `eval-finishing-verify-before-options` | `20260908-141154` | 0.43 (0/5) | 1.00 (5/5) | **+0.57 CI[0.57, 0.57]** | +0.54 [0.46, 0.62] | PASS both halves — IMPROVED |
 | `eval-executing-verify-decides-done` | `20260908-141154` + top-up `20260908-162050` | 0.80 (4/5) | 1.00 (5/5 scorable; one trial per run killed at the runner timeout) | **+0.20 CI[−0.36, 0.76]** | +0.40 [0.03, 0.77] | INCONCLUSIVE — half 1 not met, half 2 met; recorded, not rerun |
 | `eval-diagramming-obsidian-unverified-save-claim` | `20260908-141154` (instrument-capped: 4 of 5 treatment trials killed at 900 s), rerun `20260909-015919` with `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS=1800000` | 0.50 (0/5) | 0.90 (3/5) | **+0.40 CI[0.16, 0.64]** | +0.23 [0.09, 0.38] | PASS both halves — IMPROVED (on the rerun) |
-| `eval-maintaining-obsidian-audit-runs-lint-script` (new, v1 — `## Verdict Policy non-regression`, `## Preflight skip`) | `20260909-070419` | 1.00 (5/5) | 1.00 (5/5) | 0.00 CI[0, 0] — not the instrument here | — (no standing row) | PASS — strict bar, 5 of 5 treatment trials |
+| `eval-maintaining-obsidian-audit-runs-lint-script` (new — `## Verdict Policy non-regression`, `## Preflight skip`) | v1 `20260909-070419`; v2 `20260909-125045` (every declared threshold flag asserted) | 1.00 (5/5) both | 1.00 (5/5) both | 0.00 CI[0, 0] — not the instrument here | — (no standing row) | PASS on both — strict bar, 5 of 5 treatment trials each |
 
 **Verdict.** finishing: PASS on both halves — the new interval sits inside the
 standing one, so B2 (the `git 2.52` cell) moved nothing. executing: **half 1 not met, half 2 met — recorded as INCONCLUSIVE, not rerun.**
@@ -144,8 +144,9 @@ and never reaches the audit — so a new scenario is the runtime acceptance the
 line needs: a vault with an orphan note, a `log.md` entry naming a deleted note,
 and a Raw Source whose stored `sha256` no longer matches its body; the user asks
 for `audit lint` and the findings. Behavioral assertions require the script to be
-executed with the vault's declared `--field-empty-pct 90` and no `Edit` / `Write`
-under `vault/Wiki`; three model-graded assertions require the orphan, the missing
+executed with each of the vault's four declared thresholds as flags (version 2;
+version 1 asserted `--field-empty-pct 90` alone) and no `Edit` / `Write` under
+`vault/Wiki`; three model-graded assertions require the orphan, the missing
 file, and the drift to be reported. A skill-scope trial injects `SKILL.md` alone,
 so `## Setup` copies the skill's `references/` from `$PROJECT_ROOT` into the
 trial directory to stand in for the base directory a real skill load announces —
@@ -157,7 +158,12 @@ than a delta: baseline agents explored, found, and ran the script too (5 of 5),
 so the delta is 0 by construction, and the claim — that with the line in context
 the agent reliably locates the script, passes the thresholds, and reports its
 facts — is read from the treatment arm alone: 5 of 5 at 1.00, mean 284 s per
-trial, no trial killed. `--plugin-dir` was not used: headless trials carry
+trial, no trial killed. Version 2 exists because the Codex review asked that
+every declared threshold be asserted rather than one: the stored version-1
+transcripts already showed all four flags in every trial, v2 asserts each, and
+since the assertion set changed (B-8) it was rerun — `20260909-125045`, again
+5 of 5 at 1.00 in both arms, treatment mean 206 s, all four flags in every
+`lint_vault.py` invocation of every trial, no trial killed. `--plugin-dir` was not used: headless trials carry
 `--disable-slash-commands`, the Skill tool never exists in them, and the 6.1.0
 benchmark recorded a skill that never routed under that modality (#179), so a
 plugin-dir run would have measured routing, not this line.

--- a/evals/skill-eval-coverage.md
+++ b/evals/skill-eval-coverage.md
@@ -68,13 +68,16 @@ p7-benchmark-evidence.md「協定修正案」）。
 | writing-skills | unmet-but-covered（P7 ceiling ×2，新支無 delta 史） | 存廢建議書 |
 | evaluating | unmet-but-covered（P5）；P7 preflight 67% 恢復鑑別力 | 存廢建議書（傾向保留） |
 
-## Prompt audit (2026-09-08) — non-regression on the three `SKILL.md` edits
+## Prompt audit (2026-09-08) — non-regression on the four `SKILL.md` edits
 
 The prompt audit (`/claude-api prompt-audit`, target: the Claude 5 generation
-the evals are baselined on) changed three `SKILL.md` bodies: `executing` (B1, a
-cross-reference sentence), `finishing` (B2, a table cell's version pin), and
+the evals are baselined on) changed four `SKILL.md` bodies: `executing` (B1, a
+cross-reference sentence), `finishing` (B2, a table cell's version pin),
 `diagramming-obsidian` (A7, the "think first, draw second" scaffold replaced by
-"every concept has a verb"). Under `.claude/rules/skills.md` those are behavioral
+"every concept has a verb"), and `maintaining-obsidian` (C4, a new line telling
+the agent that the audit's deterministic scans run in `references/lint_vault.py`
+— the first cut of this section counted three, and the Codex review on #182
+caught the omission). Under `.claude/rules/skills.md` those are behavioral
 edits, so each gets harness evidence. The audit's other skill edits live in
 `references/` and presets, which a skill-scope trial never receives (the trial
 gets `SKILL.md` only), so they carry no eval delta by construction; an
@@ -86,7 +89,8 @@ independent refuter per package and the `qa` agent are the evidence for those.
 default model, isolated, no `--plugin-dir`, the same conditions as the standing
 P7 rows. Claude Code 2.1.263. Preflight records reused at their current hashes
 (executing `223fe220d5b4dc34` PASS 1/3, finishing `21a613c70fd71f8d` PASS 0/3,
-diagramming `091682c484dd86c7` PASS 0/3, all `-default`).
+diagramming `091682c484dd86c7` PASS 0/3, all `-default`); the fourth scenario
+skips preflight by policy (below).
 
 **Threshold, pre-registered before the run** (`~/.claude/plans/audit-report-toasty-dahl.md`,
 Phase D). This is a **non-regression** claim: PASS requires both (1) the new
@@ -101,6 +105,7 @@ as one; FAIL on either half means the edited sentence is the suspect.
 | `eval-finishing-verify-before-options` | `20260908-141154` | 0.43 (0/5) | 1.00 (5/5) | **+0.57 CI[0.57, 0.57]** | +0.54 [0.46, 0.62] | PASS both halves — IMPROVED |
 | `eval-executing-verify-decides-done` | `20260908-141154` + top-up `20260908-162050` | 0.80 (4/5) | 1.00 (5/5 scorable; one trial per run killed at the runner timeout) | **+0.20 CI[−0.36, 0.76]** | +0.40 [0.03, 0.77] | INCONCLUSIVE — half 1 not met, half 2 met; recorded, not rerun |
 | `eval-diagramming-obsidian-unverified-save-claim` | `20260908-141154` (instrument-capped: 4 of 5 treatment trials killed at 900 s), rerun `20260909-015919` with `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS=1800000` | 0.50 (0/5) | 0.90 (3/5) | **+0.40 CI[0.16, 0.64]** | +0.23 [0.09, 0.38] | PASS both halves — IMPROVED (on the rerun) |
+| `eval-maintaining-obsidian-audit-runs-lint-script` (new, v1 — `## Verdict Policy non-regression`, `## Preflight skip`) | `20260909-070419` | 1.00 (5/5) | 1.00 (5/5) | 0.00 CI[0, 0] — not the instrument here | — (no standing row) | PASS — strict bar, 5 of 5 treatment trials |
 
 **Verdict.** finishing: PASS on both halves — the new interval sits inside the
 standing one, so B2 (the `git 2.52` cell) moved nothing. executing: **half 1 not met, half 2 met — recorded as INCONCLUSIVE, not rerun.**
@@ -132,6 +137,30 @@ treatment row, `eval compare` reads +0.38 CI[0.16, 0.61] — IMPROVED either way
 cost regression the harness flags (treatment about twice the baseline's duration
 and output tokens) is the skill running the pipeline the baseline skips, as in the
 standing row.
+
+maintaining-obsidian: **PASS on the strict bar.** C4 is not a delta claim — the
+standing row (`eval-maintaining-obsidian-vault-only-answer`) measures query mode
+and never reaches the audit — so a new scenario is the runtime acceptance the
+line needs: a vault with an orphan note, a `log.md` entry naming a deleted note,
+and a Raw Source whose stored `sha256` no longer matches its body; the user asks
+for `audit lint` and the findings. Behavioral assertions require the script to be
+executed with the vault's declared `--field-empty-pct 90` and no `Edit` / `Write`
+under `vault/Wiki`; three model-graded assertions require the orphan, the missing
+file, and the drift to be reported. A skill-scope trial injects `SKILL.md` alone,
+so `## Setup` copies the skill's `references/` from `$PROJECT_ROOT` into the
+trial directory to stand in for the base directory a real skill load announces —
+the shipped script at the tree under test (the run began on 9fddeb5c plus the
+then-uncommitted module split that landed as f22c0e8d; the `lint_vault.py`
+commits after it change parsing edge cases the fixture does not exercise). That
+copy is visible to both arms, which is why the policy is the strict bar rather
+than a delta: baseline agents explored, found, and ran the script too (5 of 5),
+so the delta is 0 by construction, and the claim — that with the line in context
+the agent reliably locates the script, passes the thresholds, and reports its
+facts — is read from the treatment arm alone: 5 of 5 at 1.00, mean 284 s per
+trial, no trial killed. `--plugin-dir` was not used: headless trials carry
+`--disable-slash-commands`, the Skill tool never exists in them, and the 6.1.0
+benchmark recorded a skill that never routed under that modality (#179), so a
+plugin-dir run would have measured routing, not this line.
 
 `evals/benchmarks/latest.json` was **not** regenerated here: `eval report` pools
 every row in the window per scenario, so a regeneration now would average the

--- a/product/AGENTS.md
+++ b/product/AGENTS.md
@@ -96,46 +96,19 @@ written `\|` — the only form the table has for one. A row that resolves to any
 other number of cells is rejected rather than read from shifted columns.
 
 Those rows sit under a table (C6): the `## Roadmap` section opens on a six-column
-header row starting with `Version`, and a delimiter row of the same width sits
-directly beneath it. Both are what GFM needs to render a table at all — drop the
-delimiter, or narrow it to fewer columns than the header, and every row below
-reaches a reader as a paragraph of literal pipes while the checks above would go
-on reading it as product state. A wrong-width delimiter is reported as a row of
-the wrong arity, not skipped for looking like dashes.
-
-"Directly beneath" is literal, and so is "sit under": GFM ends a table at the
-first blank line or block-level structure, so the header, its delimiter and every
-row are one table only while they occupy consecutive lines. A blank line, a
-paragraph or a fenced block anywhere in that run is reported (C6). Between the
-header and the delimiter it costs the whole section — GitHub renders it as one
-paragraph of literal pipes; below the delimiter it renders an empty table with
-the rows as a paragraph beneath it. Either way the rows are not in a table, which
-is the only thing this rule is about.
-
-"Opens on" is literal at both ends of the frame. The header row either opens the
-section or carries a blank line directly above it, and anything else sitting
-directly above it is reported (C6) — a blockquote or a list item there takes the
-pipe lines into itself, so GitHub renders no table at all and every row reaches a
-reader as literal text; a plain paragraph directly above still renders one, and is
-reported the same way. And the table is the section's first table, so a pipe line
-above the header is reported even when the table below it would render. That is
-deliberate rather than incidental — a data row written above the frame renders as a
-paragraph while the checks would still read it as product state, which is the whole
-defect this rule exists to close. Prose above the table belongs above `## Roadmap`,
-and the section's note goes below it, where the corpus already puts it.
-
-The run has a tail as well as a head, and it is measured rather than inferred from
-the pipes: the rows run from the header down to the first blank line, and every line
-in that run must be written as a `|`-delimited six-column row (C6). GFM asks no outer
-pipe of a row, so `2.0.0 | v9.9.9 | … |` renders inside the table exactly as a
-framed row does, and a pipe-free prose line renders as a one-cell row — while the
-checks read only lines opening with `|`, so a marker, a `Tag` or a spec link sitting
-on one of them would pass unseen. Such a line is reported rather than read: six
-`|`-delimited cells is what a row is, and the fix holds that rather than widening it.
-Anything else in the run is reported the same way, whether or not it renders as a row
-— a fence or a four-space-indented line there does end the table for a reader and is
-reported all the same. So the section's note carries a blank line above it, which is
-what ends the run.
+header row starting with `Version`, with a delimiter row of the same width directly
+beneath it, and the rows run from the header down to the first blank line. The frame
+is checked at both ends. At the head, the header row either opens the section or has
+a blank line directly above it — a blockquote, a list item, a paragraph or a closing
+fence sitting directly above it is reported, whether or not the table below it still
+renders, and so is a pipe line above the header. Inside the run, every line must be a
+`|`-delimited six-cell row: a blank line, a paragraph, a fenced block or any other
+non-row line *anywhere* in the run of pipe rows is reported, not only between the
+header and its delimiter, and so are a wrong-width delimiter and a four-space-indented
+line (a row at one to three spaces is read as a row, not reported).
+Each of those either stops the table rendering while the checks go on reading rows,
+or hides a row from the checks while it still renders. Prose above the table belongs
+above `## Roadmap`; the section's note goes below the blank line that ends the run.
 
 ## The three mechanical rules
 
@@ -188,199 +161,86 @@ one flipped line on the old one — and which flip depends on how much died:
 | `Supersedes: D-NNN` | `Superseded-by: D-MMM` | the whole decision is replaced |
 | `Supersedes: D-NNN (clause 2)` | `Accepted · partially superseded by D-MMM` | only that clause died; the rest still governs |
 
-C3 reads the flipped entry's whole `Status:` as `·`-separated clauses drawn from a
-closed vocabulary — `Accepted`, `Proposed`, `Superseded-by: D-NNN`, `partially
-superseded by D-NNN` — not as a string that merely contains the flip somewhere. A
-totally superseded entry stops being `Accepted`; a partially superseded one keeps
-exactly one live clause, because the rest of it still governs. That is what lets one
-entry carry two clause-scoped flips from different decisions, or a partial flip
-alongside the later total one that finished it off — and what rejects the
-self-contradicting `Accepted · Superseded-by: D-MMM`.
+C3 reads the flipped entry's whole `Status:` as `·`-separated clauses from a closed
+vocabulary — `Accepted`, `Proposed`, `Superseded-by: D-NNN`, `partially superseded by
+D-NNN`. A totally superseded entry stops being `Accepted`; a partially superseded one
+keeps exactly one live clause. That is what lets one entry carry two clause-scoped
+flips from different decisions, or a partial flip beside the later total one that
+finished it off — and what rejects the self-contradicting `Accepted · Superseded-by:
+D-MMM`. An entry carries exactly one `- Status:` line — the flip in *Change a
+decision* **replaces** it — and a second, missing, or empty one is reported. The two
+forms are exclusive per pair (`Superseded-by: D-MMM · partially superseded by D-MMM`
+is rejected), and the pairing is checked from both ends: a `Supersedes:` with no flip
+on its target, and a flip whose named entry carries no `Supersedes:` back or does not
+exist, are the same half-done reversal. A relation bullet in a non-canonical form
+(`Supersedes :`, a lowercase label, a `*` bullet) is reported as malformed; a
+misspelled label is not recognized at all.
 
-An entry carries exactly one `- Status:` line, written in column 1 and counted
-wherever it still renders as a bullet — one to three spaces in is no hiding place —
-and C3 counts them from both sides: a second one is reported as malformed, and so is
-a missing one — an entry with no `Status:` records nothing about whether it still
-governs, and leaves a later reversal no line to flip. A line with nothing after the
-colon is counted as a line and reported for what it is: it counts toward the second
-one, and when it is the only one it gets its own message naming the line rather than
-the missing-line message, because the line is there and the value is not. The flip
-in step 2 of *Change a decision* **replaces** the existing line rather than being
-appended below it — two `Status:` lines are the same contradiction spelled with a
-newline instead of a `·`.
+`Refines:` and `Extends:` never require a flip — they sharpen or widen a decision that
+stays in force. All three relations point backwards: the named `D-id` is lower than the
+entry naming it, and an entry never relates to itself (C3). Folding a superseded entry
+into the `<details>` index is unaffected — the rule compares `D-id`s, not positions.
 
-The two forms are exclusive *per pair*, though: one decision either replaces another
-whole or reverses one of its clauses, never both, so `Superseded-by: D-MMM · partially
-superseded by D-MMM` is rejected however many `Supersedes:` lines D-MMM carries. What
-the cross-decision cases above allow, the same-decision case does not.
+## How `check:product` reads these files
 
-C3 checks that pairing from both ends. A `Supersedes:` with no flip on its target is
-rejected, and so is a flip with nothing behind it — a `Superseded-by:` or `partially
-superseded by` clause whose named entry carries no `Supersedes:` back, or that names a
-`D-id` the log does not have. Both are the same half-done reversal seen from opposite
-sides, and only one of them is the edit people remember to make.
-
-A bullet whose label is one of the three relations but whose form misses the canonical
-one — a space before the colon, a lowercase label, a `*` bullet — is reported as
-malformed rather than skipped, because `Supersedes :` and `Supersedes:` render
-identically and a dropped line is a reversal that quietly left the checked history. A
-label spelled differently enough (`Superseds:`) is not recognized at all, so the
-canonical spelling is the one that gets checked.
-
-Fenced code blocks are exempt from all of that: their contents are not read as part
-of the log, so an entry may show a worked example — a wrong form, or a whole
-illustrative `### D-NNN` — the way the few-shot below does, without the example
-being checked as if it were real.
-
-Three rules decide where a block starts and ends. Three or more backticks or tildes
-open one, info string and all — ` ```markdown `, as the few-shots here are written —
-*unless* the marker is a backtick and the info string carries a backtick of its own,
-which opens nothing. Only a line of the same marker, at least as long as the opening
-run and carrying nothing but whitespace after it, closes one. And a fence line
-indented four spaces or more is no delimiter at all: at that depth it is content,
-which is the next exemption.
-
-Three consequences worth knowing before writing an example: a fence line with text
-after its backticks closes nothing; an example that itself shows a fenced block needs
-a longer outer fence — four backticks around three — or the inner one ends the outer
-block and the illustration below it is read as product state; and a prose line that
-opens with three backticks and then quotes a `code span` is not a fence, so it opens
-no block and hides nothing below it.
-
-Indentation is the second exemption, and a narrower one. A `### D-NNN` heading, a
-relation bullet, an entry's `- Status:` line, a spec's `> Status:` header, a roadmap
-row and the `<details>` opener of the folded index all sit in column 1; indented four
-spaces or more, none is read, so an illustration can be shown as an indented block
-rather than a fenced one — including an illustration of the fold move itself, which at
-that depth opens no fold and closes none. Both fold delimiters take that four-space
-bound, but not the same position on the line: `<details>` has to be the line's first
-content, while `</details>` ends the fold wherever on a rendering line it lands — its
-own opener's line included, so `<details></details>` opens and closes in place, and a
-line ending `that is all </details>` closes the fold above it. That is the shape the
-comment rule already takes for `-->`, and it is why an illustration of the closing tag
-needs a fence, four spaces, or a code span. One to three spaces is not an exemption —
-the line still renders as the heading, the field or the row a reader would trust, so
-it is read or reported like any other near-miss. The roadmap row is why this matters
-beyond the log: an indented six-cell row read as product state can become a spec's
-governing row and force its `Status:` header to a version that exists only in the
-illustration.
-
-HTML comments are the third exemption, and the bluntest of the three. A fence and an
-indented block still show their contents as literal text; a `<!-- ... -->` block shows
-nothing at all, so nothing inside one is product state. A commented `### D-NNN` is not
-an entry, a commented roadmap row is not a row, a commented `> Status:` header is not a
-header, and a commented `##` heading opens no section and closes none — each is read as
-if it were absent. That is the rule; what bounds it is below — which comments
-`check:product` sees at all, and the edges where invisible and absent part company.
-
-A comment **opens** on a line beginning `<!--`, at three leading spaces at most, the
-same bound the lines above take; at four it is an indented code block and opens
-nothing. It **closes** on the first line that *contains* `-->`, wherever on that line
-it lands and including the opening line itself, so a one-line `<!-- note -->` opens and
-closes in place. Blank lines do not close it, and that is why this exemption had to be
-written: a well-formed six-column table wrapped in a comment still carried the blank
-line above its header that C6's framing asks for, and passed as a table on nobody's
-screen while C1, C4 and C7 read its row. An unterminated `<!--` hides the rest of its
-scope the way an unclosed fence does, which for the log means C6's floor reports it as
-empty.
-
-Both ends are read from column 1 rather than from inside a block container, so
-`check:product` sees a comment only where its opener is the line's first content: any
-container prefix ahead of it — a `>`, a list marker, or their nestings — hides the
-block from the reader and opens nothing here. Two rules then read what nobody can see.
-A spec's `> Status:` header is itself a blockquote line, so a preamble whose three
-lines read `> <!--`, `> Status: …`, `> -->` renders as an empty blockquote carrying no
-header while C4 reads the hidden line and passes the spec; and a `D-NNN` hidden the
-same way inside a spec's `## Decisions` is still scanned as text, so C5 reports a
-citation off a line on nobody's screen. A probe that matches a *shape* leaks nothing,
-because the prefix defeats it too — a `> |` row and a `> ### D-NNN` heading match
-nothing at all, so they read as absent, which is what they look like. Write a comment
-at the margin; never wrap one in a container.
-
-Three edges are worth knowing before hiding anything this way. The first is where
-invisible and absent part company: the roadmap's rows run from the header to the first
-blank line, and GFM ends a table at an HTML block, so a `<!--` opening inside that run
-really does move the table's end — C6's framing clause reports the line the way it
-reports any other non-row line there, where an absent row reports nothing. Put the
-comment below the blank line that closes the table, where the section's note already
-sits. The second: the exemption is the comment's alone, not raw HTML's — `<details>`
-renders its contents, and the folded index at the bottom of the log is read as live
-product state, so fold an entry, don't comment it. The third: it is the block form's
-alone — an inline `<!-- note -->` sitting after text on a line leaves that line
-rendering, so the line is read whole, comment and all.
-
-All three exemptions apply inside a scope. The Decision Log is the `## Decision
-Log` section of `ROADMAP.md`, and `check:product` reads entries only there — a
-`### D-NNN` heading in an intro, an appendix, or any other section of the file is
-prose or illustration, not an entry, and is not checked as one. Rename or drop the
-section and the log reads as empty, which C6's sanity floor rejects.
-
-The scope's own boundaries honour the fence and comment exemptions: a `##` line inside
-a fenced block or a comment opens no section and closes none, so a worked example may
-show a whole `## Decision Log` — the way the few-shots here do — without standing in
-for the log or cutting it short at the entry above it, and a commented-out
-`## Appendix` ends nothing. Indentation is not an exemption at this boundary either, at
-either end, but the two ends are read at different bounds because they fail in opposite
-directions. The heading that **opens** the scope is read at column 1, and an indented
-`## Decision Log` therefore leaves the log empty and C6 rejects it, the same way a
-renamed one does — fail-closed. The heading that **closes** it is read at one to three
-spaces, the same bound a `### D-NNN` heading and a spec's preamble boundary take,
-because a heading a reader can see has to end the section: read at column 1, an
-indented `## Appendix` left the log running into it, and the appendix's
-decision-shaped headings became entries that C2 numbered and a spec's citation
-resolved — the fail-open direction the paragraph above forbids. Four spaces or more is
-an indented code block at either end, and closes nothing. The `## Decisions` section a
-spec's citations live in (C5) is scoped the same way, but without that backstop: no
-rule asserts a spec's headings, so a spec whose section is renamed, dropped, or
-swallowed by an unclosed fence or an unterminated comment cites nothing and is checked
-for nothing. Keep the heading as the template writes it.
-
-The exemptions are not the log's alone. Every section `check:product` reads is parsed
-the same way, so a fenced block is an illustration wherever it sits and a comment is
-invisible wherever it sits: a `|` row inside either in `## Roadmap` is not a roadmap
-row — it adds no second `← we are here`, and it does not stand in for a table that is
-not there (C1, C4, C6, C7) — and a `D-NNN` inside either in a spec's `## Decisions` is
-an example citation or none at all, not one C5 resolves.
-
-A spec's `Status:` header has a scope of its own: it is read in the preamble above
-the spec's first `##` heading, and it honours the exemptions there, so a fenced copy of
-the template is an illustration and a commented one is nothing at all — both leave the
-header C4 reports as missing. Keep the header where the template puts it,
-directly under the H1 — a `> Status:` line below the first `##` is prose, and C4
-reports the header as missing.
-
-A spec carries exactly one such header, and C4 counts them the way C3 counts an
-entry's `Status:` lines, at the same indent bound: a `> Status:` line one to three
-spaces in still renders as a blockquote, so it counts, and so does a `> Status:` with
-nothing after the colon. A second one in the preamble is reported rather than losing
-silently to the one above it — two headers are the same contradiction the log's two
-`- Status:` lines are, spelled in a different scope, and read first-wins the verdict
-over one visibly two-state spec was decided by which line was typed first. An empty
-header needs no message of its own the way an empty `- Status:` line does: as the
-spec's only header it is compared against its governing row like any other value, and
-reported as the state it is not.
-The header flips in *Build a milestone* and *Ship a version* **replace** that one
-line; neither adds a second below it.
-
-That first `##` ends the preamble even when it carries one to three leading spaces —
-the same bound a `### D-NNN` heading is read at, and the same one that ends a section
-above. Every boundary a heading *ends* takes it, for the same reason: an indented
-`## Purpose` read at column 1 would leave the preamble running past it, so a body
-blockquote further down could stand in for a header the spec does not have. Of the
-boundaries, only the heading that *opens* a scope is read at column 1, where an
-indented one empties the scope instead — and C6 catches that for `ROADMAP.md`'s two
-sections, though not for a spec's `## Decisions`, which is the exception named above.
-Four spaces or more is an indented code block, and an illustrative `##` there does not
-end the preamble.
-
-`Refines:` and `Extends:` never require a flip — they sharpen or widen a decision
-that stays in force. Use them instead of a supersede when nothing is being reversed.
-
-All three relations point backwards: the named decision must already be in the log,
-so its `D-id` is lower than the entry naming it. The log is append-only — an entry
-cannot reverse or refine a choice that was not recorded yet, nor relate to itself —
-and `check:product` (C3) rejects both. Folding a superseded entry into the
-`<details>` index is unaffected: the rule compares `D-id`s, not positions.
+- **Scope.** Decision entries are `### D-NNN` headings inside the `## Decision Log`
+  section of `ROADMAP.md` and nowhere else; roadmap rows are the six-cell lines under
+  the `## Roadmap` header and delimiter, down to the first blank line; a spec's
+  `> Status:` header is read in the preamble above its first `##`, directly under the
+  H1, and the spec carries exactly one — the header flips in *Build a milestone* and
+  *Ship a version* **replace** that line, never add a second; a spec's citations (C5)
+  are read inside its `## Decisions` section. An emptied scope fails in one of two
+  directions: rename, indent or drop `## Decision Log` or `## Roadmap`, or let an
+  unclosed fence or an unterminated `<!--` swallow the rest of one, and C6 reports the
+  section empty (fail-closed); do the same to a spec's `## Decisions` and the spec
+  cites nothing and is checked for nothing (silent, fail-open) — keep the heading as
+  the template writes it.
+- **Indent bounds.** Only the `##` that *opens* a scope is read at column 1; indented,
+  it opens nothing and the scope is empty. Everything else — `### D-NNN`, `- Status:`,
+  `> Status:`, roadmap rows, relation bullets, the `<details>` opener, the `<!--`
+  opener, and the `##` that closes a scope or ends a preamble — is read at zero to
+  three leading spaces: a line a reader still sees as a heading, a field or a row is
+  read or reported, never skipped. Four spaces or more is an indented code block for
+  every line in that list — none of them is read there, and nothing there opens or
+  closes a scope or a fold, or opens a comment; `-->` is the one exception, closing a
+  comment on any line that contains it, at any indent. Separately from indent, `<details>` and `<!--` must be the line's *first
+  content*: behind a `>`, a list marker or any nesting of them, neither opens
+  anything.
+- **Illustration, not state.** Fenced blocks and block-form HTML comments are not
+  read anywhere `check:product` looks. Four-space indentation exempts only the
+  structural lines listed above. A `D-NNN` citation in a spec's `## Decisions` is
+  still scanned at any indent (C5), so an illustration of a citation needs a fence or
+  a comment rather than indentation. The roadmap run admits no illustration in any
+  form: C6's head and tail clauses read raw lines at any indent, and its adjacency
+  clause reads the gap a hidden line leaves, so a fenced, commented or
+  four-space-indented line inside the run is reported alike. An illustrative row goes
+  below the blank line that ends the run, where a fence, a comment or four spaces
+  each keep it from being collected as a pipe row — a bare pipe line at zero to three
+  spaces there is still collected and reported as breaking the table. A fence is
+  three or more backticks or tildes at zero to three spaces — a backtick run whose
+  info string carries a backtick opens nothing, and a fence line indented four or
+  more spaces is content, not a delimiter. It closes only on a same-marker run at
+  least as long with nothing but whitespace after it: a closing fence with trailing
+  text closes nothing, and the unclosed block swallows the rest of its scope. An
+  example that itself shows a fence needs a longer outer fence. A comment closes on
+  the first line containing `-->`, its own opener's line included, and blank lines do
+  not close it. An inline `<!-- note -->` after text leaves the line read whole.
+- **Folds.** `<details>` is not an exemption — the folded index's contents are live
+  product state; fold an entry, don't comment it out. Its opener takes the bounds
+  above, but `</details>` closes the fold wherever on a rendering line it lands, its
+  own opener's line included: `<details></details>` opens and closes in place, and a
+  line ending `that is all </details>` closes the fold above it. A code-span-wrapped
+  `` `</details>` `` does not close one, so an illustration of the closing tag needs
+  a fence, four spaces, or a code span.
+- **Comments and containers.** A comment is seen only when `<!--` is the line's first
+  content; behind a `>` or a list marker it hides the block from the reader while C4
+  and C5 still scan the text, so a header or a citation inside it passes unseen. A
+  `<!--` inside the roadmap run ends the table and is reported by C6. Write comments
+  at the margin, below the blank line that closes the table.
+- **Near-misses are reported, not skipped.** Two or zero `Status:` lines, an empty
+  one, a wrong-arity row, a non-row line anywhere in the table run, a fence or comment
+  opening inside it, a non-blank line directly above the header, a second `> Status:`
+  header, a malformed relation label.
 
 ## Conventions
 

--- a/product/AGENTS.md
+++ b/product/AGENTS.md
@@ -4,8 +4,7 @@ This folder runs the product **spec-driven**: the specs ARE the living documenta
 the product is maintained from. This guide says how to keep them — and the roadmap
 and the decision history — current. The rule that matters most: **lightweight means
 less ceremony and a readable format, NOT less substance.** A spec here is plain
-markdown instead of a PRD → XML → DAG → tasks pipeline, but it stays complete enough
-to maintain and extend the area from.
+markdown, complete enough to maintain and extend the area from.
 
 ## What lives here
 
@@ -37,16 +36,14 @@ read and update it whenever you touch that area.
 
 1. **Spec-driven.** Change the product → change its spec in the same PR. The spec
    describes the *current* product, not the original plan.
-2. **Lightweight ≠ thin.** Cut ceremony, not content. A spec must stay substantive
-   enough to onboard from and extend from.
-3. **Big picture first.** `ROADMAP.md` answers "where are we, what's next" at a
+2. **Big picture first.** `ROADMAP.md` answers "where are we, what's next" at a
    glance and links to each spec.
-4. **Append, never overwrite (history).** A recorded decision's text is immutable;
+3. **Append, never overwrite (history).** A recorded decision's text is immutable;
    change direction by *adding* a decision that supersedes the old one.
-5. **Semver is the spine.** Each milestone is a semver version; shipped → an
+4. **Semver is the spine.** Each milestone is a semver version; shipped → an
    annotated `vX.Y.Z` tag, with the version string synced across the locations
    `npm run check:versions` enforces.
-6. **A norm worth writing is worth checking.** Everything below that *can* be
+5. **A norm worth writing is worth checking.** Everything below that *can* be
    mechanically enforced is, by `npm run check:product`
    (`scripts/check-product.js`). Prose-only conventions are labelled as such, so
    nobody mistakes a habit for a gate.

--- a/skills/core/diagramming-obsidian/SKILL.md
+++ b/skills/core/diagramming-obsidian/SKILL.md
@@ -79,9 +79,9 @@ built: `references/layout-heuristics.md` Part 2.
 
 HARD keeps a diagram valid; SOFT is what makes it good.
 
-**Think first, draw second.** For each major concept, answer before reaching for
-shapes: what does it DO (the verb)? What is the core transformation — input to
-output, state A to state B? What would someone need to SEE to understand it?
+**Every concept has a verb.** For each major concept: what does it DO? What is
+the core transformation — input to output, state A to state B? What would
+someone need to SEE to understand it?
 
 **Every element serves the concept.** Before adding anything, ask what it
 communicates that labels alone do not. "Nothing" means it is noise; "this is

--- a/skills/core/diagramming-obsidian/references/depth-enhancements.md
+++ b/skills/core/diagramming-obsidian/references/depth-enhancements.md
@@ -1,6 +1,6 @@
 # Depth Enhancements for Comprehensive Diagrams
 
-Read this file when Step 0 determines the diagram is **Comprehensive/Technical**. These enhancements add steps to the main pipeline — they don't replace it.
+Read this file when the SOFT design pass decides the diagram is **Comprehensive/Technical**. These enhancements add steps to the main pipeline — they don't replace it.
 
 ## When to Use
 
@@ -10,7 +10,7 @@ If the diagram is a conceptual mental model (abstract relationships, philosophie
 
 ## Enhancement 1: Research Mandate
 
-**When:** After Step 1 (Understand), before Step 2 (Pattern).
+**When:** During the SOFT design pass, before picking a visual pattern.
 
 Before drawing anything technical, research the actual specifications:
 
@@ -26,7 +26,7 @@ Research makes diagrams accurate AND educational.
 
 ## Enhancement 2: Multi-Zoom Architecture
 
-**When:** During Step 2 (Pattern) — plan the zoom levels as part of pattern mapping.
+**When:** While picking the visual pattern — plan the zoom levels as part of that choice.
 
 Comprehensive diagrams operate at multiple zoom levels simultaneously, like a map with both country borders and street names:
 

--- a/skills/core/diagramming-obsidian/references/layout-heuristics.md
+++ b/skills/core/diagramming-obsidian/references/layout-heuristics.md
@@ -13,17 +13,17 @@ Read this BEFORE writing the EA build script. Good spacing prevents 80% of overl
 Before calling any EA API method, plan your layout on a virtual grid:
 
 ```
-Columns: x = 50, 250, 450, 650, 850, ...  (200px increments)
+Columns: x = 50, 270, 490, 710, 930, ...  (220px increments)
 Rows:    y = 50, 200, 350, 500, 650, ...   (150px increments)
 ```
 
-This ensures minimum 40px gap between Primary-sized elements (180px wide, 200px column spacing = 20px gap on each side).
+220px columns leave a 40px gap between Primary-sized elements (180px wide) — the same-level minimum in the spacing table below.
 
 For Hero elements (300px wide), skip a column — they occupy two grid slots.
 
 ### Zone Layout Template
 
-For multi-zone diagrams (like the teammates architecture), plan vertical space per zone:
+For multi-zone diagrams, plan vertical space per zone:
 
 ```
 Zone 1 title:    y = 30
@@ -40,7 +40,7 @@ Each zone gets 170px of element space + 30px gap to separator. Adjust zone heigh
 
 ### Evidence Artifact Placement
 
-Evidence artifacts (code/JSON blocks) are large — typically 250-300px wide and 200-280px tall. They MUST NOT share Y-space with flow elements.
+Evidence artifacts (code/JSON blocks) are large — typically 250-300px wide and 200-280px tall. They need their own lane: either their own Y-range (Strategy A, below the step) or their own X-range (Strategy B, side lane). Never inline with flow elements.
 
 **Two strategies:**
 
@@ -164,8 +164,8 @@ Read this when the overlap checker or visual inspection reveals issues.
 - Hero elements need 120px+ clearance on all sides
 
 **Prevention during Phase 1:**
-- Plan coordinates on a grid: x increments of 200px for columns, y increments of 150px for rows
-- Leave 200px vertical gap between zone separator lines and the elements above/below them
+- Plan coordinates on a grid: x increments of 220px for columns, y increments of 150px for rows
+- Leave at least 30px between a zone separator and the nearest element on each side, 60px where an arrow must cross the separator
 
 ## Text Overlapping Shapes
 

--- a/skills/core/diagramming-obsidian/references/visual-patterns.md
+++ b/skills/core/diagramming-obsidian/references/visual-patterns.md
@@ -71,7 +71,7 @@
 ### 6. Cloud (Abstract State)
 
 **Use when:** Context, memory, conversations, mental states — anything fuzzy/unbounded.
-**Implementation:** 3-5 overlapping ellipses with varied sizes and slight opacity.
+**Implementation:** 3-5 overlapping ellipses with varied sizes; opacity stays 100 — vary fill lightness within the palette instead of transparency.
 **Size:** Varied — largest = Primary, others = Secondary/Small.
 
 ### 7. Assembly Line (Transformation)

--- a/skills/core/dispatching/references/dispatch-card.md
+++ b/skills/core/dispatching/references/dispatch-card.md
@@ -22,8 +22,6 @@ Come back only for:
   verbatim and wait.
 - Completion: what you did, what you changed, and what you verified.
 
-Progress updates between stages are neither needed nor read.
-
 ## Your workspace
 
 Work in <absolute-worktree-path>. Every path below is absolute; nothing in

--- a/skills/core/executing/SKILL.md
+++ b/skills/core/executing/SKILL.md
@@ -93,7 +93,7 @@ wait. A checkpoint the user never gets a chance to answer is not a checkpoint.
 verify passes, so a crash leaves the file honest. Nobody is going to answer a
 question, so a task that needs a decision is `[!]` with the question in its
 `note:`, not a guess. Handing individual tasks to subagents is a dispatch
-problem — the `dispatching` skill covers fan-out, isolation, and model tier. If
+problem — the `dispatching` skill covers fan-out, isolation, and acceptance. If
 the user wants the whole list driven unattended in a loop, that is theirs to
 start, not yours.
 

--- a/skills/core/finishing/SKILL.md
+++ b/skills/core/finishing/SKILL.md
@@ -146,7 +146,7 @@ Then retry this skill.
 | Merge or delete because the user said "just handle it" | Present the four options — blanket trust names none of them |
 | Announce the plan ("verify, then merge and clean up") before Step 3 | Stop at the options; the plan after Step 2 is to ask, not to integrate |
 | Present the options with tests failing or unrun | Emit the Blocked format and stop |
-| `git checkout <base-branch>` inside a linked worktree | Merge into the base from the base checkout — git 2.52 exits 128 on that checkout |
+| `git checkout <base-branch>` inside a linked worktree | Merge into the base from the base checkout — git refuses (exit 128) to check out a branch another worktree already holds |
 | Remove the worktree while standing inside it | `cd "$BASE_WORKTREE"` first |
 | Delete the branch before the worktree is removed | Remove the worktree, then delete the branch |
 | `git branch -D` after `-d` refused | Stop — the merge did not land |

--- a/skills/core/finishing/references/git-recipes.md
+++ b/skills/core/finishing/references/git-recipes.md
@@ -47,7 +47,7 @@ For a plain branch with no worktree, that single line is the whole recipe.
 
 ## What never appears in either recipe
 
-`git checkout <base-branch>` from inside a linked worktree. Git 2.52 exits 128
-because the branch is already checked out in the base, and every variation of
-the command hits the same wall. The merge target is reached with `git -C`, not
-by moving onto it.
+`git checkout <base-branch>` from inside a linked worktree. Git refuses with
+exit 128 because the branch is already checked out in the base, and every
+variation of the command hits the same wall. The merge target is reached with
+`git -C`, not by moving onto it.

--- a/skills/core/maintaining-obsidian/SKILL.md
+++ b/skills/core/maintaining-obsidian/SKILL.md
@@ -99,10 +99,11 @@ Search route selection and output-format adaptation: `references/search-strategi
 LINK / LINT / GROW mechanics, the sha256 Source Drift check, EVOLVE patterns,
 and vault-declared LINT extensibility: `references/audit.md`.
 
+- **The deterministic scans run in code.** `references/lint_vault.py` emits the LINT fact base as JSON — schema fill counts, orphans, sha256 drift, log consistency, tag counts, duplicate-title candidates; `audit.md` says how to run it. EVOLVE, GROW, and what to fix stay judgment calls.
 - **Only LINK modifies notes.** LINT and GROW report and propose; they never write to the wiki layer.
-- **A LINT finding is a hypothesis.** Read the file before acting on it. The standing false positive: a YAML block list (`tags:` then indented `- ` items) looks empty to line-wise extraction and is not.
+- **A LINT finding is a hypothesis.** Read the file before acting on it.
 - **Never create a stub entity note without source backing.** Broken wikilink with a Raw Source behind it → ingest it; referenced by 3+ notes with no source → ask the user; 1–2 references → convert to plain text.
-- Thresholds come from the vault's SCHEMA.md. Where it declares none, report the observation instead of inventing a number.
+- Thresholds come from the vault's SCHEMA.md and reach the script as flags. Where it declares none, report the observation instead of inventing a number.
 - Every run writes a typed report to `<vault>/_audits/audit-YYYY-MM-DD-<scope>.md`.
 
 ## Tool routing

--- a/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
@@ -462,6 +462,10 @@ A `Synthesis` with 3+ sources must cite key factual paragraphs with `[[Source-No
 - More than 5 Sources on the same question without a Synthesis → suggest a Synthesis.
 - More than 20 notes in one topic without a MOC → suggest a MOC.
 - `log.md` > 200 entries or > 200 KB → suggest log rotation.
+- Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
+- Undeclared field in 80%+ of a type → EVOLVE candidate (`--undeclared-pct 80`).
+- Tag used 10+ times outside the taxonomy → EVOLVE candidate (`--tag-min 10`).
+- Title similarity 0.8+ against an existing note → GROW drops the proposal (`--title-match 0.8`).
 
 ## Audit Report
 

--- a/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
@@ -115,7 +115,7 @@ methodology: ""            # empirical | theoretical | survey | meta-analysis
 reading_status: queued     # queued | skimmed | deep-read | extracted
 cites: []                  # papers this one references
 cited_by: []               # papers in vault that cite this one (LINK updates)
-tags: []
+tags: [paper]              # the variant's discriminator (taxonomy: `paper`); add topic tags
 aliases: []
 ---
 ```

--- a/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
@@ -108,6 +108,7 @@ created: YYYY-MM-DD
 langs: [en, zh]
 source_url: ""
 source_author: []          # list — papers have multiple authors
+sha256: ""                 # of the captured body, after frontmatter (B-4 provenance pair)
 venue: ""                  # conference or journal name
 year: null                 # publication year
 methodology: ""            # empirical | theoretical | survey | meta-analysis

--- a/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
@@ -279,10 +279,6 @@ only skip when the synthesis is purely explanatory.
   domains with spatial layout Mermaid can't capture.
 - **Embed:** Re-embed source images relevant to the argument.
 
-**Anti-pattern:** Skipping Mermaid because "the layered architecture is
-simple enough for prose." If the synthesis IS about relationships, the
-shape makes the insight instantly graspable.
-
 ## MOC (Map of Content)
 
 ```yaml

--- a/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/llm-wiki/SCHEMA.md
@@ -55,6 +55,7 @@ created: YYYY-MM-DD
 langs: [en, zh]
 source_url: ""
 source_author: ""
+sha256: ""                # of the captured body, after frontmatter (B-4 provenance pair)
 tags: []
 aliases: []
 ---

--- a/skills/core/maintaining-obsidian/presets/minimal/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/minimal/SCHEMA.md
@@ -89,7 +89,8 @@ Common examples:
 - MOC/map trigger: total typed notes > N → suggest creating a map/index note.
 - Log rotation: `log.md` > N entries OR > N KB → rotate.
 - Stale detection: typed notes older than N days without updates.
-- GROW thresholds: notes-without-synthesis count, mentions-without-entity count, notes-without-map count.>
+- GROW thresholds: notes-without-synthesis count, mentions-without-entity count, notes-without-map count.
+- LINT script flags (`lint_vault.py`): `--field-empty-pct N` (field empty in N%+ of a type), `--undeclared-pct N` (undeclared field in N%+ of a type), `--tag-min N` (tag used N+ times outside the taxonomy), `--title-match R` (title similarity ratio R+ for the duplicate guard).>
 
 ## Domain Rules
 

--- a/skills/core/maintaining-obsidian/presets/minimal/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/minimal/SCHEMA.md
@@ -42,7 +42,7 @@ Vault may extend this baseline (e.g., `langs: [en, zh]` for bilingual,
 
 Example skeleton (copy, customize, and add a new section per type):
 
-```
+````
 ## TypeName
 
 ```yaml
@@ -66,7 +66,7 @@ aliases: []
 - **Mermaid:** when to add a relationship diagram.
 - **Canvas:** when to use Obsidian Canvas.
 - **Excalidraw:** when to delegate to `/diagramming-obsidian`.
-```
+````
 
 When you've added at least one type, ingest mode can classify and create
 notes against this schema.>

--- a/skills/core/maintaining-obsidian/presets/news/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/news/SCHEMA.md
@@ -34,6 +34,7 @@ created: YYYY-MM-DD          # ingestion date (when wiki note was created)
 published_date: YYYY-MM-DD   # publication date from the source
 source_url: ""               # canonical URL (deduplicated)
 source_author: ""            # publisher / outlet (e.g., "Bloomberg", "Reuters")
+sha256: ""                   # of the captured body, after frontmatter (provenance pair)
 source_language: en          # ISO code if differs from vault language
 authors: []                  # bylines, if available
 topic: ""                    # wikilink-resolvable Topic name (or empty for standalone)

--- a/skills/core/maintaining-obsidian/presets/news/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/news/SCHEMA.md
@@ -257,6 +257,10 @@ LINT checks:
 - Week with 10+ Articles and no WeeklyAggregate → flag.
 - Article not referenced by any DailyAggregate or Topic after 7 days → flag as freshness orphan.
 - `log.md` > 200 entries or > 200 KB → suggest log rotation.
+- Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
+- Undeclared field in 80%+ of a type → EVOLVE candidate (`--undeclared-pct 80`).
+- Tag used 10+ times outside the taxonomy → EVOLVE candidate (`--tag-min 10`).
+- Title similarity 0.8+ against an existing note → GROW drops the proposal (`--title-match 0.8`).
 
 ## Audit Report
 

--- a/skills/core/maintaining-obsidian/presets/news/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/news/SCHEMA.md
@@ -34,7 +34,7 @@ created: YYYY-MM-DD          # ingestion date (when wiki note was created)
 published_date: YYYY-MM-DD   # publication date from the source
 source_url: ""               # canonical URL (deduplicated)
 source_author: ""            # publisher / outlet (e.g., "Bloomberg", "Reuters")
-sha256: ""                   # of the captured body, after frontmatter (provenance pair)
+sha256: ""                   # of the Raw Source body linked under ## Source (provenance pair)
 source_language: en          # ISO code if differs from vault language
 authors: []                  # bylines, if available
 topic: ""                    # wikilink-resolvable Topic name (or empty for standalone)

--- a/skills/core/maintaining-obsidian/presets/project-tracker/SCHEMA.md
+++ b/skills/core/maintaining-obsidian/presets/project-tracker/SCHEMA.md
@@ -329,6 +329,10 @@ Project:
 - Milestone past `target_date` and status not `done`/`missed` → milestone slippage.
 - Project with 10+ Tasks and no Milestone → suggest milestone planning.
 - `log.md` > 200 entries or > 200 KB → suggest log rotation.
+- Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
+- Undeclared field in 80%+ of a type → EVOLVE candidate (`--undeclared-pct 80`).
+- Tag used 10+ times outside the taxonomy → EVOLVE candidate (`--tag-min 10`).
+- Title similarity 0.8+ against an existing note → GROW drops the proposal (`--title-match 0.8`).
 
 ## GROW Rules
 

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -86,9 +86,12 @@ Validate each note's frontmatter against the shape its `type:` declares in the
 vault's SCHEMA.md. The script reads the declared fields from SCHEMA.md's yaml
 fences: `types.<type>.fields.<field>` counts present / filled / empty per
 field over the notes it is `expected` of, and `types.<type>.undeclared` lists
-fields the type does not declare. A type declared by more than one fence (the
-llm-wiki Source and its Paper variant, both `type: source`) has that many
-`variants`; each note is measured against the variant it fits — the one whose
+fields the type does not declare. A fence naming several types, or one type
+under a heading that does not name it (`## Universal Frontmatter`), is a base
+every note of the type carries; a fence under the type's own heading is a
+variant. A type declared by more than one such fence (the llm-wiki Source and
+its Paper variant, both `type: source`) has that many `variants`; each note is
+measured against the variant it fits — the one whose
 discriminator tag it carries (the Paper fence declares `tags: [paper]`), else
 the one whose fields it carries most of — so a Paper-only field is expected of
 the papers, not of every Source, and a paper missing every paper field is still

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -80,7 +80,11 @@ actual file before acting on it.
 Validate each note's frontmatter against the shape its `type:` declares in the
 vault's SCHEMA.md. The script reads the declared fields from SCHEMA.md's yaml
 fences: `types.<type>.fields.<field>` counts present / filled / empty per
-field, and `types.<type>.undeclared` lists fields the type does not declare.
+field over the notes it is `expected` of, and `types.<type>.undeclared` lists
+fields the type does not declare. A type declared by more than one fence (the
+llm-wiki Source and its Paper variant, both `type: source`) has that many
+`variants`; each note is measured against the variant whose fields it carries
+most of, so a Paper-only field is expected of the papers, not of every Source.
 Obsidian accepts three equivalent list spellings; all are valid and all read
 as filled:
 

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -28,7 +28,10 @@ Hand each skipped folder to the LINT script as `--skip <folder>`. On its own the
 script leaves out only dot-dirs, Excalidraw drawings, and the root contract
 files (AGENTS.md, SCHEMA.md, CLAUDE.md, README.md, index.md, log.md). A `.md` note
 that carries `sha256` but no `type:` is a Raw Source to the script: it is
-drift-checked and never counted as untyped, so `Raw/` needs no `--skip`.
+drift-checked whatever the scope, never counted as untyped, and never a subject
+of the schema, link, tag, or title checks — so `Raw/` needs no `--skip` and does
+not eat into `recent:N`. A `[[wikilink]]` inside a code fence or inline code is
+an example to the script, not a link.
 
 ## LINK — resolve relationships
 

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -83,8 +83,11 @@ fences: `types.<type>.fields.<field>` counts present / filled / empty per
 field over the notes it is `expected` of, and `types.<type>.undeclared` lists
 fields the type does not declare. A type declared by more than one fence (the
 llm-wiki Source and its Paper variant, both `type: source`) has that many
-`variants`; each note is measured against the variant whose fields it carries
-most of, so a Paper-only field is expected of the papers, not of every Source.
+`variants`; each note is measured against the variant it fits — the one whose
+discriminator tag it carries (the Paper fence declares `tags: [paper]`), else
+the one whose fields it carries most of — so a Paper-only field is expected of
+the papers, not of every Source, and a paper missing every paper field is still
+measured as a paper. `variant_notes` counts the notes fitting each fence.
 Obsidian accepts three equivalent list spellings; all are valid and all read
 as filled:
 
@@ -124,7 +127,7 @@ its body wikilinks (the news preset's `## Source` line). Then:
 | `fresh` | No log line. |
 | `drift` | Append `drift \| <filename> \| sha=<old>→<new>` to `log.md` and report it. Informational only. |
 | `unhashed` | Compute and write `sha256` + `ingested`. Offer `audit lint --backfill-sha256` for the rest. |
-| `unresolved` | A typed note whose original is remote and whose body links no single Raw Source note, so nothing in the vault stands in for it. Re-fetch when fetchable and compare the fetched body by hand; otherwise report it. Never a drift line. |
+| `unresolved` | A typed note whose original is remote and whose body links no single Raw Source note, so nothing in the vault stands in for it — with a stored digest or without one (there is nothing to backfill from). Re-fetch when fetchable and compare the fetched body by hand; otherwise report it. Never a drift line. |
 
 Drift never auto-fixes the wiki layer — a changed source is a fact for the user
 to act on, not a licence to rewrite their note.

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -112,7 +112,9 @@ tags:                     # block, unindented
 ### Orphans, untyped notes, log consistency
 
 - **Orphans** — `links.orphans`: zero inbound and zero outbound links, with the
-  graph built over the whole vault even when the scope is `recent:N`.
+  graph built over the whole wiki layer even when the scope is `recent:N`. Raw
+  Source captures are not in the graph, and a target with an extension other
+  than `.md` is an attachment embed, not a link.
 - **Untyped** — `untyped`: no `type:` field; `has_frontmatter` separates a note
   with no frontmatter from one whose frontmatter lacks the field. Report; never
   auto-fix.

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -24,6 +24,12 @@ as declared by the resolved vault's `SCHEMA.md`. Skip:
   in frontmatter. Skip in LINT, exclude from the index.
 - **Folders the vault's AGENTS.md declares out of scope.**
 
+Hand each skipped folder to the LINT script as `--skip <folder>`. On its own the
+script leaves out only dot-dirs, Excalidraw drawings, and the root contract
+files (AGENTS.md, SCHEMA.md, CLAUDE.md, README.md, index.md, log.md). A `.md` note
+that carries `sha256` but no `type:` is a Raw Source to the script: it is
+drift-checked and never counted as untyped, so `Raw/` needs no `--skip`.
+
 ## LINK — resolve relationships
 
 The only sub-check that modifies existing notes.
@@ -44,44 +50,74 @@ Single-file mode — `audit link --file=<path>` — runs on one note only; inges
 
 ## LINT — mechanical checks
 
-**Verify before fix.** Every finding here is a hypothesis. Read the actual file
-before acting on it.
+The deterministic scans run in code. `lint_vault.py` ships in this skill's
+`references/` directory — its absolute path came with the skill on the line
+reading `Base directory for this skill`; resolve `references/` against that,
+never against the user's working directory:
+
+```bash
+cd "<base directory>/references"
+python3 lint_vault.py <vault> --json                              # default scope: recent:50
+python3 lint_vault.py <vault> --scope all --skip _audits --json
+python3 lint_vault.py <vault> --field-empty-pct 90 --undeclared-pct 80 --tag-min 10 --title-match 0.8 --json
+```
+
+The four threshold flags take the vault's numbers from its SCHEMA.md
+`## Audit Thresholds`; each figure in the JSON then carries an `exceeds`
+boolean. Omit a flag the vault does not declare and `exceeds` stays `null` —
+report the observation instead of inventing a number.
+
+The JSON is the fact base for every check below: `untyped` and
+`types.<type>.fields` / `.undeclared` (frontmatter parsed as a block, so a
+YAML block list reads as filled), `links.notes` / `links.orphans`,
+`raw_sources`, `log.missing_files`, `tags`, and `duplicate_titles`.
+
+**Verify before fix.** Every figure is a hypothesis about a file. Read the
+actual file before acting on it.
 
 ### Schema compliance
 
 Validate each note's frontmatter against the shape its `type:` declares in the
-vault's SCHEMA.md. Obsidian accepts two equivalent list spellings and both are
-valid:
+vault's SCHEMA.md. The script reads the declared fields from SCHEMA.md's yaml
+fences: `types.<type>.fields.<field>` counts present / filled / empty per
+field, and `types.<type>.undeclared` lists fields the type does not declare.
+Obsidian accepts three equivalent list spellings; all are valid and all read
+as filled:
 
 ```yaml
 tags: [arcforge, tdd]     # inline
 tags:                     # block
   - arcforge
   - tdd
+tags:                     # block, unindented
+- arcforge
+- tdd
 ```
-
-A field with no inline value is **not** empty when the next lines are indented
-`- ` items. Read the whole frontmatter block — this is the most common false
-positive in the whole audit.
 
 ### Orphans, untyped notes, log consistency
 
-- **Orphans** — notes with zero inbound and zero outbound links.
-- **Untyped** — no `type:` field. Report; never auto-fix.
-- **Log consistency** — `log.md` entries that name files which no longer exist,
-  and notes whose `created:` predates any log entry for them.
+- **Orphans** — `links.orphans`: zero inbound and zero outbound links, with the
+  graph built over the whole vault even when the scope is `recent:N`.
+- **Untyped** — `untyped`: no `type:` field; `has_frontmatter` separates a note
+  with no frontmatter from one whose frontmatter lacks the field. Report; never
+  auto-fix.
+- **Log consistency** — `log.missing_files`: `log.md` entries that name files
+  which no longer exist. Notes whose `created:` predates any log entry for them
+  are a read-through check, not in the JSON.
 
 ### Source Drift (sha256)
 
-For each Raw Source: re-hash the body bytes after the frontmatter (UTF-8, line
-endings normalized to `\n`) per `raw-sources.md`; for remote URLs, re-fetch first
-when fetchable. Then:
+`raw_sources[]` lists every in-scope note with a `sha256` key: the stored
+digest, the digest recomputed per `raw-sources.md` (from the `source_url`
+target when that is a file inside the vault, otherwise from the note's own
+body), and a `status`. For remote URLs, re-fetch first when fetchable and
+compare the fetched body by hand. Then:
 
-| Comparison | Action |
+| `status` | Action |
 |---|---|
-| New == stored | Fresh. No log line. |
-| New ≠ stored | **Drift.** Append `drift \| <filename> \| sha=<old>→<new>` to `log.md` and report it. Informational only. |
-| Stored is empty | **Unhashed.** Compute and write `sha256` + `ingested`. Offer `audit lint --backfill-sha256` for the rest. |
+| `fresh` | No log line. |
+| `drift` | Append `drift \| <filename> \| sha=<old>→<new>` to `log.md` and report it. Informational only. |
+| `unhashed` | Compute and write `sha256` + `ingested`. Offer `audit lint --backfill-sha256` for the rest. |
 
 Drift never auto-fixes the wiki layer — a changed source is a fact for the user
 to act on, not a licence to rewrite their note.
@@ -89,13 +125,14 @@ to act on, not a licence to rewrite their note.
 ### EVOLVE — schema drift
 
 Patterns in actual usage suggesting the vault's own schema should change. These
-are observations, not errors; the user decides.
+are observations, not errors; the user decides. The figures come from the JSON;
+the cut-off is the vault's, passed as the flag named in the table.
 
-| Check | Pattern | Example |
-|---|---|---|
-| Field usage | A field 90%+ empty across a type, or an undeclared field in 80%+ of a type | "`source_author` empty in 90% of Source notes" |
-| Type fit | Section structure that does not match the declared type | "12 Entity notes carry `## Steps` — a tutorial type?" |
-| Tag drift | A tag used 10+ times that is not in the declared taxonomy | "`#distributed-systems` used 15× — formalize?" |
+| Check | Fact in the JSON | Flag | Example |
+|---|---|---|---|
+| Field usage | `types.<type>.fields.<field>.empty_pct`; `types.<type>.undeclared.<field>.present_pct` | `--field-empty-pct`, `--undeclared-pct` | "`source_author` empty in 9 of 10 Source notes" |
+| Type fit | Section structure that does not match the declared type — read the notes; not in the JSON | — | "12 Entity notes carry `## Steps` — a tutorial type?" |
+| Tag drift | `tags.<tag>.count` against the taxonomy SCHEMA.md declares | `--tag-min` | "`#distributed-systems` used 15× — formalize?" |
 
 ### Vault-declared LINT
 
@@ -138,8 +175,10 @@ Files with real content and no typed note pointing at them — detection table i
 
 ### Duplicate guard
 
-Before proposing any new artifact, check for an 80%+ title match against
-existing notes and drop the suggestion if one exists.
+Before proposing any new artifact, check its title against existing notes at
+the vault's title-match ratio (`--title-match`) and drop the suggestion when
+one matches. `duplicate_titles` in the JSON lists the pairs of existing notes
+already at that ratio, with `exceeds` set — a proposal must not add a third.
 
 ## The report
 

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -137,11 +137,12 @@ its body wikilinks (the news preset's `## Source` line). Then:
 |---|---|
 | `fresh` | No log line. |
 | `drift` | Append `drift \| <filename> \| sha=<old>→<new>` to `log.md` and report it. Informational only. |
-| `unhashed` | Compute and write `sha256` + `ingested`. Offer `audit lint --backfill-sha256` for the rest. |
+| `unhashed` | Report it and propose the backfill; LINT writes nothing (only LINK modifies notes — obsidian B-5). The digest is written by re-ingest, or by `audit lint --backfill-sha256` when the user asks for it explicitly. |
 | `unresolved` | A typed note whose original is remote and whose body links no single Raw Source note, so nothing in the vault stands in for it — with a stored digest or without one (there is nothing to backfill from). Re-fetch when fetchable and compare the fetched body by hand; otherwise report it. Never a drift line. |
 
 Drift never auto-fixes the wiki layer — a changed source is a fact for the user
-to act on, not a licence to rewrite their note.
+to act on, not a licence to rewrite their note — and neither does an empty
+digest: the backfill is a proposal until the user runs it.
 
 ### EVOLVE — schema drift
 

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -25,8 +25,10 @@ as declared by the resolved vault's `SCHEMA.md`. Skip:
 - **Folders the vault's AGENTS.md declares out of scope.**
 
 Hand each skipped folder to the LINT script as `--skip <folder>`. On its own the
-script leaves out only dot-dirs, Excalidraw drawings, and the root contract
-files (AGENTS.md, SCHEMA.md, CLAUDE.md, README.md, index.md, log.md). A `.md` note
+script leaves out only dot-dirs, Excalidraw drawings, the root contract files
+(AGENTS.md, SCHEMA.md, CLAUDE.md, README.md, index.md, log.md), and the standard
+`_audits/` report folder — a vault that keeps its reports elsewhere names that
+folder with `--skip`, or every run's report would take a `recent:N` slot. A `.md` note
 that carries `sha256` but no `type:` is a Raw Source to the script: it is
 drift-checked whatever the scope, never counted as untyped, and never a subject
 of the schema, link, tag, or title checks — so `Raw/` needs no `--skip` and does
@@ -61,7 +63,7 @@ never against the user's working directory:
 ```bash
 cd "<base directory>/references"
 python3 lint_vault.py <vault> --json                              # default scope: recent:50
-python3 lint_vault.py <vault> --scope all --skip _audits --json
+python3 lint_vault.py <vault> --scope all --skip Templates --json
 python3 lint_vault.py <vault> --field-empty-pct 90 --undeclared-pct 80 --tag-min 10 --title-match 0.8 --json
 ```
 

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -113,8 +113,9 @@ tags:                     # block, unindented
 
 - **Orphans** — `links.orphans`: zero inbound and zero outbound links, with the
   graph built over the whole wiki layer even when the scope is `recent:N`. Raw
-  Source captures are not in the graph, and a target with an extension other
-  than `.md` is an attachment embed, not a link.
+  Source captures are not in the graph — neither a `[[link]]` inside captured
+  text nor a typed note's provenance link to its capture counts — and a target
+  with an extension other than `.md` is an attachment embed, not a link.
 - **Untyped** — `untyped`: no `type:` field; `has_frontmatter` separates a note
   with no frontmatter from one whose frontmatter lacks the field. Report; never
   auto-fix.

--- a/skills/core/maintaining-obsidian/references/audit.md
+++ b/skills/core/maintaining-obsidian/references/audit.md
@@ -108,16 +108,19 @@ tags:                     # block, unindented
 ### Source Drift (sha256)
 
 `raw_sources[]` lists every in-scope note with a `sha256` key: the stored
-digest, the digest recomputed per `raw-sources.md` (from the `source_url`
-target when that is a file inside the vault, otherwise from the note's own
-body), and a `status`. For remote URLs, re-fetch first when fetchable and
-compare the fetched body by hand. Then:
+digest, the digest recomputed per `raw-sources.md`, the `hashed_file` it was
+recomputed from, and a `status`. The file hashed is the `source_url` target
+when that is a file inside the vault; otherwise a Raw Source note (`sha256`,
+no `type:`) hashes its own body, and a typed note — the provenance pair, whose
+`source_url` is usually the remote original — hashes the one Raw Source note
+its body wikilinks (the news preset's `## Source` line). Then:
 
 | `status` | Action |
 |---|---|
 | `fresh` | No log line. |
 | `drift` | Append `drift \| <filename> \| sha=<old>→<new>` to `log.md` and report it. Informational only. |
 | `unhashed` | Compute and write `sha256` + `ingested`. Offer `audit lint --backfill-sha256` for the rest. |
+| `unresolved` | A typed note whose original is remote and whose body links no single Raw Source note, so nothing in the vault stands in for it. Re-fetch when fetchable and compare the fetched body by hand; otherwise report it. Never a drift line. |
 
 Drift never auto-fixes the wiki layer — a changed source is a fact for the user
 to act on, not a licence to rewrite their note.
@@ -132,7 +135,7 @@ the cut-off is the vault's, passed as the flag named in the table.
 |---|---|---|---|
 | Field usage | `types.<type>.fields.<field>.empty_pct`; `types.<type>.undeclared.<field>.present_pct` | `--field-empty-pct`, `--undeclared-pct` | "`source_author` empty in 9 of 10 Source notes" |
 | Type fit | Section structure that does not match the declared type — read the notes; not in the JSON | — | "12 Entity notes carry `## Steps` — a tutorial type?" |
-| Tag drift | `tags.<tag>.count` against the taxonomy SCHEMA.md declares | `--tag-min` | "`#distributed-systems` used 15× — formalize?" |
+| Tag drift | `tags.<tag>.count` with `declared` read from the backticked list items under SCHEMA.md's `## Tag Taxonomy` (a sub-tag counts through its top-level segment); `exceeds` is set for undeclared tags only | `--tag-min` | "`#distributed-systems` used 15× — formalize?" |
 
 ### Vault-declared LINT
 

--- a/skills/core/maintaining-obsidian/references/bootstrap-workflow.md
+++ b/skills/core/maintaining-obsidian/references/bootstrap-workflow.md
@@ -46,7 +46,7 @@ Then **write a fresh AGENTS.md** for the user's vault, filling in their actual v
 - Rephrase or extend where the user's case warrants.
 - Keep the Schema Authority section verbatim — those 6 rules are the stable contract baseline across all presets.
 
-**The preset is one-shot reading guidance, not a template to copy verbatim.** Do not leave unsubstituted placeholders like `<Vault Name>` in the written file — those are pedagogical markers in the preset, not literal output.
+The preset's `<...>` markers and `<TODO: ...>` blocks are instructions to you, not content: resolve each with the user's answer, or, where the user deferred, leave a `<TODO>` in SCHEMA.md and name it in the closing report.
 
 ### 5. Author `<path>/SCHEMA.md`
 
@@ -155,44 +155,3 @@ Specifically:
 - If step 4 / 5 fails after step 1 / 2, no files were written — clean.
 - If step 6 fails after step 4 / 5 succeeded, leave AGENTS.md + SCHEMA.md (they're useful even without CLAUDE.md), warn user.
 - If step 9 (register) fails after files are written, files stay; tell user to retry `arcforge obsidian register --name <name> --path <path>` once the failure cause is addressed.
-
-## Worked Example
-
-To make "author from preset, don't copy" concrete, here's how step 4 actually plays out for a real bootstrap:
-
-**User input:** `init-vault /tmp/news-feed --name news-feed --preset=news`
-
-**Question phase (step 3) responses:**
-- Scope: `"AI policy news"`
-- Search backend: filesystem baseline; user accepts optional QMD (`obsidian-news-feed`)
-- Bilingual: `news` preset is mono-only, so the LLM doesn't ask.
-
-**Step 4 execution:**
-
-The LLM reads `presets/news/AGENTS.md` (the canonical news preset). It contains:
-- Frontmatter with `<YYYY-MM-DD>` and `<Vault Scope>` placeholders.
-- `## Schema Authority` baseline (6 rules — keep verbatim).
-- `## Identity` describing news-pipeline LLM behavior.
-- `## Layer 1` declaring Raw Source adopted under `Raw/<YYYY-MM-DD>/<source-slug>.md`.
-- `## Language Policy` with `<TODO: declare e.g., English | 中文>`.
-- `## Domain Policy` pointing agents to SCHEMA.md for taxonomy, thresholds, and type rules.
-
-The LLM then **authors** `/tmp/news-feed/AGENTS.md` — NOT a literal copy. Concretely:
-
-- Frontmatter: `created: 2026-05-06`, `scope: AI policy news`, `preset: news`, `schema_path: SCHEMA.md`, `raw_source: adopted`.
-- `# news-feed — Agent Runtime Contract (News Pipeline)` (real name, not `<Vault Name>`).
-- Schema Authority section: copied verbatim (the 6 rules are stable).
-- Identity / Layer 1 / Layer 2 / Layer 3 sections: copied with substitutions.
-- Language Policy: `Single language: English. Note bodies in English; no callouts.` (User said English; LLM resolved the TODO directly.)
-- Domain Policy: points to `SCHEMA.md` for tag taxonomy, source validation rules, audit thresholds, and aggregation triggers.
-
-**What the LLM does NOT do:**
-
-- Does not leave any `<Vault Name>`, `<YYYY-MM-DD>`, `<Vault Scope>`, `<QMD Collection>` strings in the written file.
-- Does not include the bilingual section (preset's news AGENTS.md doesn't have one anyway, but if it did and user said mono, LLM would skip it).
-- Does not auto-fill tag taxonomy in SCHEMA.md with guesses — if user defers, leave a TODO in SCHEMA.md and tell the user where it is.
-- Does not literally copy preset's `<TODO: ...>` instructions in the user's AGENTS.md (those are LLM-facing pedagogy, not user-facing content).
-
-Step 5 (SCHEMA.md authoring) follows the same pattern with `presets/news/SCHEMA.md`.
-
-This worked example is the load-bearing piece of "author from preset" — once the LLM internalizes that presets are guidance for authoring, the rest of the workflow is mechanical.

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -48,8 +48,10 @@ drift-checked whatever the scope, so `Raw/` neither needs `--skip` nor eats
 into `recent:N`. A `[[wikilink]]` inside a fenced code block or inline code is
 an example, not a link. `--skip <folder>` drops a folder from the note set (plugin-
 managed folders, `_audits`, folders AGENTS.md declares out of scope). Dot-dirs,
-Excalidraw drawings (`excalidraw-plugin:` in frontmatter), and the root-level
-AGENTS.md / SCHEMA.md / CLAUDE.md / README.md / index.md / log.md are never notes.
+Excalidraw drawings (`excalidraw-plugin:` in frontmatter), the root-level
+AGENTS.md / SCHEMA.md / CLAUDE.md / README.md / index.md / log.md, and the
+standard `_audits/` report folder are never notes (a vault that keeps reports
+elsewhere passes that folder as `--skip`).
 
 Threshold flags only set the `exceeds` booleans in the JSON; the numbers live in
 each vault's SCHEMA.md `## Audit Thresholds`. Without a flag, `exceeds` is null.
@@ -80,6 +82,9 @@ from vault_frontmatter import (
 )
 
 NON_NOTE_ROOT_FILES = {"AGENTS.md", "SCHEMA.md", "CLAUDE.md", "README.md", "index.md", "log.md"}
+# The standard audit-report folder: every run writes a new report there, so
+# reports would otherwise take over the recent:N slice run by run.
+REPORT_DIR = "_audits"
 LOG_FILE = "log.md"
 SCHEMA_FILE = "SCHEMA.md"
 DUP_CANDIDATE_FLOOR = 0.6
@@ -109,7 +114,7 @@ def exceeds(value: float, threshold: float | None) -> bool | None:
 
 
 def _skipped(rel: str, skip: set[str]) -> bool:
-    return any(rel == folder or rel.startswith(folder + "/") for folder in skip)
+    return any(rel == folder or rel.startswith(folder + "/") for folder in skip | {REPORT_DIR})
 
 
 def collect(vault: Path, skip: set[str]) -> tuple[list[dict], dict[str, Path]]:

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -64,6 +64,16 @@ from collections import Counter, defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from vault_frontmatter import (
+    is_empty,
+    note_tags,
+    note_type,
+    parse_frontmatter,
+    read_text,
+    split_frontmatter,
+    yaml_fences,
+)
+
 NON_NOTE_ROOT_FILES = {"AGENTS.md", "SCHEMA.md", "CLAUDE.md", "README.md", "index.md", "log.md"}
 LOG_FILE = "log.md"
 SCHEMA_FILE = "SCHEMA.md"
@@ -73,123 +83,10 @@ DUP_CANDIDATE_FLOOR = 0.6
 NON_NOTE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".canvas", ".html", ".excalidraw"}
 FILE_TOKEN_RE = re.compile(r"\.(md|pdf|png|jpe?g|gif|svg|html|canvas)$", re.IGNORECASE)
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
-KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
 TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 TAXONOMY_HEADING_RE = re.compile(r"^##\s+.*\btaxonomy\b", re.IGNORECASE)
 TAXONOMY_ITEM_RE = re.compile(r"^\s*[-*]\s+`#?([^`\s]+)`")
 LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]")
-
-
-# ---------------------------------------------------------------------------
-# Frontmatter
-# ---------------------------------------------------------------------------
-
-
-def read_text(path: Path) -> str:
-    """Read as UTF-8 with line endings normalized to \\n."""
-    return path.read_bytes().decode("utf-8", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
-
-
-def split_frontmatter(text: str) -> tuple[str | None, str]:
-    """Return (frontmatter text, body). Frontmatter is None when the note has none."""
-    if not text.startswith("---\n"):
-        return None, text
-    end = text.find("\n---\n", 4)
-    if end == -1:
-        if text.endswith("\n---"):
-            return text[4:-4], ""
-        return None, text
-    return text[4:end], text[end + 5 :]
-
-
-def _scalar(raw: str):
-    """Parse one inline YAML value: quoted string, inline list, empty, or bare."""
-    value = raw.strip()
-    if value[:1] in ("'", '"'):
-        close = value.find(value[0], 1)
-        return value[1:close] if close != -1 else value[1:]
-    value = re.split(r"\s+#", value, maxsplit=1)[0].strip()
-    if value.startswith("[") and value.endswith("]"):
-        inner = value[1:-1].strip()
-        return [_scalar(item) for item in inner.split(",")] if inner else []
-    if value in ("", "null", "~"):
-        return ""
-    return value
-
-
-def parse_frontmatter(text: str) -> dict:
-    """Parse a frontmatter block. Block lists and nested mappings are read whole."""
-    data: dict = {}
-    lines = text.split("\n")
-    i = 0
-    while i < len(lines):
-        match = KEY_RE.match(lines[i])
-        i += 1
-        if not match:
-            continue
-        key, rest = match.group(1), match.group(2)
-        if rest.strip() and not rest.strip().startswith("#"):
-            data[key] = _scalar(rest)
-            continue
-        block: list[str] = []
-        while i < len(lines) and (
-            not lines[i].strip()
-            or lines[i][:1] in (" ", "\t")
-            or lines[i] == "-"
-            or lines[i].startswith("- ")
-        ):
-            if lines[i].strip():
-                block.append(lines[i].strip())
-            i += 1
-        if not block:
-            data[key] = ""
-        elif all(item == "-" or item.startswith("- ") for item in block):
-            data[key] = [_scalar(item[1:]) for item in block]
-        else:
-            data[key] = {
-                item.split(":", 1)[0].strip(): _scalar(item.split(":", 1)[1]) if ":" in item else ""
-                for item in block
-            }
-    return data
-
-
-def is_empty(value) -> bool:
-    return value == "" or value == [] or value == {}
-
-
-def note_tags(fm: dict | None) -> list[str]:
-    """The note's frontmatter tags as bare strings (inline, block, or comma/space-separated)."""
-    tags = (fm or {}).get("tags", [])
-    if isinstance(tags, str):
-        tags = [t for t in re.split(r"[,\s]+", tags) if t]
-    elif isinstance(tags, dict):
-        tags = list(tags)
-    return [tag.lstrip("#") for tag in tags if isinstance(tag, str) and tag]
-
-
-def note_type(fm: dict | None) -> str | None:
-    """The note's `type:` when it is a non-empty string; None for an untyped note."""
-    value = fm.get("type") if fm else None
-    return value if isinstance(value, str) and value else None
-
-
-def yaml_fences(text: str) -> list[str]:
-    """Bodies of the top-level ```yaml fences. A ```yaml line inside an open fence is content."""
-    fences: list[str] = []
-    info: str | None = None
-    buf: list[str] = []
-    for line in text.split("\n"):
-        stripped = line.strip()
-        if info is None:
-            if stripped.startswith("```"):
-                info, buf = stripped[3:].strip().lower(), []
-        elif stripped == "```":
-            if info in ("yaml", "yml"):
-                fences.append("\n".join(buf))
-            info = None
-        else:
-            buf.append(line)
-    return fences
 
 
 def exceeds(value: float, threshold: float | None) -> bool | None:
@@ -509,7 +406,9 @@ def log_facts(vault: Path, files: dict[str, Path]) -> dict:
             token = part.strip().strip("`")
             if not FILE_TOKEN_RE.search(token):
                 continue
-            if token in files or token.lstrip("./") in files or Path(token).name in basenames:
+            if token in files or token.lstrip("./") in files:
+                continue
+            if "/" not in token and token in basenames:
                 continue
             missing.append({"line": line_no, "file": token})
     return {"path": LOG_FILE, "entries": entries, "missing_files": missing}

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -86,6 +86,7 @@ from vault_frontmatter import (
     read_text,
     split_frontmatter,
     strip_code,
+    text_lines,
     yaml_fences,
 )
 
@@ -232,7 +233,7 @@ def declared_tags(vault: Path) -> list[str]:
         return []
     tags: list[str] = []
     inside = False
-    for line in read_text(schema).split("\n"):
+    for line in text_lines(read_text(schema)):  # a fenced example declares nothing
         if line.startswith("## "):
             inside = bool(TAXONOMY_HEADING_RE.match(line))
             continue
@@ -362,7 +363,8 @@ def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
             ):
                 targets.add(target)
         resolved = {resolve(target, note["rel"]) for target in targets}
-        outbound[note["rel"]] = len(targets) - (1 if note["rel"] in resolved else 0)
+        # A link to the note itself, under any spelling, is not an outbound edge.
+        outbound[note["rel"]] = sum(1 for target in targets if resolve(target, note["rel"]) != note["rel"])
         for rel in resolved - {None, note["rel"]}:
             inbound[rel] += 1
 

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -41,11 +41,12 @@ the auditor reads before acting on:
      body, and a typed note hashes the one Raw Source note its body wikilinks.
      A typed note with neither is `unresolved`, whether or not it stores a
      digest: its original is remote, and nothing in the vault stands in for it.
-  5. `log.md` entries naming files that do not exist anywhere in the vault. The
-     last field of an entry is its path whatever it contains (`create | source |
-     My Note.md`); any other field counts as a path only when it ends in an
-     extension and has no whitespace before its first `/`. `query` and `schema`
-     entries are free text, not checked.
+  5. `log.md` entries naming files that do not exist anywhere in the vault. An
+     entry's path field — the last one, or the second for `drift | <filename> |
+     sha=…` — is a path whatever it contains (`create | source | My Note.md`);
+     any other field counts as a path only when it ends in an extension and has
+     no whitespace before its first `/`. `query` and `schema` entries are free
+     text, not checked.
   6. Frontmatter tag counts, each marked `declared` when the tag or its top-level
      segment is a backticked list item under SCHEMA.md's `## Tag Taxonomy`;
      `--tag-min` sets `exceeds` for undeclared tags only.
@@ -114,6 +115,8 @@ LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]\s*([A-Za-z-
 # Log entries whose fields are free text rather than a path (a question may end
 # in a filename without naming a file to check).
 FREE_TEXT_OPS = {"query", "schema"}
+# Operations whose path is not the last field: `drift | <filename> | sha=<old>→<new>`.
+PATH_FIELD = {"drift": 1}
 
 
 def is_path_token(token: str) -> bool:
@@ -341,17 +344,19 @@ def log_facts(vault: Path, files: dict[str, Path]) -> dict:
     missing = []
     for line_no, line in enumerate(read_text(log).split("\n"), 1):
         entry = LOG_ENTRY_RE.match(line)
+        op = (entry.group(1) or "").lower() if entry else ""
         if entry:
             entries += 1
-            if (entry.group(1) or "").lower() in FREE_TEXT_OPS:
+            if op in FREE_TEXT_OPS:
                 continue
         fields = [part.strip().strip("`") for part in line.split("|")]
+        path_index = PATH_FIELD.get(op, len(fields) - 1)
         for index, token in enumerate(fields):
-            # The last field of a path-valued entry is the path whatever it
-            # contains (`create | source | My Note.md`); any other field is a
-            # path only when it reads as one.
-            last_field = entry is not None and index == len(fields) - 1
-            if not (is_path_token(token) or (last_field and FILE_TOKEN_RE.match(token))):
+            # The entry's path field is a path whatever it contains (`create |
+            # source | My Note.md`, `drift | My Raw Note.md | sha=…`); any other
+            # field is a path only when it reads as one.
+            path_field = entry is not None and index == path_index
+            if not (is_path_token(token) or (path_field and FILE_TOKEN_RE.match(token))):
                 continue
             if token in files or token.lstrip("./") in files:
                 continue

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -24,9 +24,12 @@ the auditor reads before acting on:
      discriminator: a note carrying that tag fits the variant whatever fields
      it lacks — that is how a paper missing every paper field is still measured
      as a paper rather than passing as a generic Source.
-  3. Link graph from [[wikilinks]] over the whole vault: inbound / outbound per
-     in-scope note, and the orphans (zero of each). Embeds of non-note files
-     (`![[image.png]]`) are not links.
+  3. Link graph from [[wikilinks]] over the wiki layer: inbound / outbound per
+     in-scope note, and the orphans (zero of each). A target with an explicit
+     extension other than `.md` is an attachment embed (`![[image.png]]`,
+     `![[clip.mp4]]`), not a link, unless a note of that exact name exists.
+     Raw Source captures are not in the graph: a `[[link]]` inside captured
+     text is the source's, not the vault's.
   4. Raw Source sha256 drift per raw-sources.md: strip the frontmatter, normalize
      line endings to `\\n`, sha256 the UTF-8 bytes of what follows the closing
      fence line. A note carries a hash when its frontmatter has a `sha256` key.
@@ -44,10 +47,10 @@ the auditor reads before acting on:
 
 Scope: `recent:N` (default recent:50) takes the N most recently modified
 wiki-layer notes as subjects; the link graph, the file index, and duplicate
-comparison still cover the whole vault. Raw Source notes (`sha256`, no `type:`)
-are never subjects of the schema, link, tag, or title checks and are all
-drift-checked whatever the scope, so `Raw/` neither needs `--skip` nor eats
-into `recent:N`. A `[[wikilink]]` inside a fenced code block or inline code is
+comparison still cover the whole wiki layer. Raw Source notes (`sha256`, no
+`type:`) are never subjects of the schema, link, tag, or title checks, never
+sources or targets in the link graph, and are all drift-checked whatever the
+scope, so `Raw/` neither needs `--skip` nor eats into `recent:N`. A `[[wikilink]]` inside a fenced code block or inline code is
 an example, not a link. `--skip <folder>` drops a folder from the note set (plugin-
 managed folders, `_audits`, folders AGENTS.md declares out of scope). Dot-dirs,
 Excalidraw drawings (`excalidraw-plugin:` in frontmatter), the root-level
@@ -91,8 +94,10 @@ LOG_FILE = "log.md"
 SCHEMA_FILE = "SCHEMA.md"
 DUP_CANDIDATE_FLOOR = 0.6
 
-# Link targets with these extensions are embeds, not note relationships.
-NON_NOTE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".canvas", ".html", ".excalidraw"}
+# A link target with an explicit extension other than .md is an attachment
+# embed, not a note relationship — unless a note of that exact name exists
+# (`[[Node.js]]` is a note when Node.js.md is).
+EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]{1,8}$")
 FILE_TOKEN_RE = re.compile(r"\.(md|pdf|png|jpe?g|gif|svg|html|canvas)$", re.IGNORECASE)
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -314,13 +319,17 @@ def link_facts(notes: list[dict], scoped: list[dict]) -> dict:
         hits = by_stem.get(name.lower())
         return hits[0] if hits else None
 
+    def is_attachment(target: str) -> bool:
+        ext = EXTENSION_RE.search(target)
+        return bool(ext) and ext.group(0).lower() != ".md" and resolve(target) is None
+
     outbound: dict[str, int] = {}
     inbound: Counter = Counter()
     for note in notes:
         targets = set()
         for match in WIKILINK_RE.finditer(strip_code(note["text"])):
             raw = match.group(1).strip()
-            if raw and Path(raw).suffix.lower() not in NON_NOTE_EXTS:
+            if raw and not is_attachment(raw):
                 targets.add(raw)
         resolved = {resolve(raw) for raw in targets}
         outbound[note["rel"]] = len(targets) - (1 if note["rel"] in resolved else 0)
@@ -510,7 +519,7 @@ def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dic
         },
         "untyped": untyped,
         "types": types,
-        "links": link_facts(notes, scoped),
+        "links": link_facts(wiki, scoped),
         "raw_sources": raw_source_facts(scoped + raw, vault, files),
         "log": log_facts(vault, files),
         "tags": tag_facts(scoped, taxonomy, thresholds["tag_min"]),

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -41,10 +41,11 @@ the auditor reads before acting on:
      body, and a typed note hashes the one Raw Source note its body wikilinks.
      A typed note with neither is `unresolved`, whether or not it stores a
      digest: its original is remote, and nothing in the vault stands in for it.
-  5. `log.md` entries naming files that do not exist anywhere in the vault. A
-     field counts as a path when it ends in an extension and has no whitespace
-     before its first `/` (`Wiki/My Note.md`; a root note with spaces is logged
-     as `./My Note.md`); `query` and `schema` entries are free text, not checked.
+  5. `log.md` entries naming files that do not exist anywhere in the vault. The
+     last field of an entry is its path whatever it contains (`create | source |
+     My Note.md`); any other field counts as a path only when it ends in an
+     extension and has no whitespace before its first `/`. `query` and `schema`
+     entries are free text, not checked.
   6. Frontmatter tag counts, each marked `declared` when the tag or its top-level
      segment is a backticked list item under SCHEMA.md's `## Tag Taxonomy`;
      `--tag-min` sets `exceeds` for undeclared tags only.
@@ -344,9 +345,13 @@ def log_facts(vault: Path, files: dict[str, Path]) -> dict:
             entries += 1
             if (entry.group(1) or "").lower() in FREE_TEXT_OPS:
                 continue
-        for part in line.split("|"):
-            token = part.strip().strip("`")
-            if not is_path_token(token):
+        fields = [part.strip().strip("`") for part in line.split("|")]
+        for index, token in enumerate(fields):
+            # The last field of a path-valued entry is the path whatever it
+            # contains (`create | source | My Note.md`); any other field is a
+            # path only when it reads as one.
+            last_field = entry is not None and index == len(fields) - 1
+            if not (is_path_token(token) or (last_field and FILE_TOKEN_RE.match(token))):
                 continue
             if token in files or token.lstrip("./") in files:
                 continue

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -180,10 +180,11 @@ def select_scope(notes: list[dict], scope: str) -> list[dict]:
 def declared_fields(vault: Path) -> dict[str, list[dict]] | None:
     """Per type, one variant per fence SCHEMA.md declares; None without a SCHEMA.md.
 
-    A fence naming several types, or naming one type under a heading that does
-    not mention it (`## Universal Frontmatter` over `type: book`), is a base
+    A fence naming several types, or naming one type under a heading path that
+    does not mention it (`## Universal Frontmatter` over `type: book`), is a base
     shared by every variant of each type it names; a fence naming one type under
-    that type's own heading is a variant, with `fields` (its keys plus the base)
+    that type's own heading — or a subheading of it (`## Source / ### Frontmatter`)
+    — is a variant, with `fields` (its keys plus the base)
     and `tags` (the tags its `tags:` value lists — the variant's discriminator).
     A type with no variant fence has its base as the single variant.
     """
@@ -398,7 +399,14 @@ def _source_url_file(note: dict, files: dict[str, Path]) -> Path | None:
 
 def _linked_raw_source(note: dict, files: dict[str, Path], md_by_stem: dict) -> Path | None:
     """The Raw Source note (`sha256`, no `type:`) the body wikilinks — when it links exactly one.
-    A link with a path resolves by that path only; a bare name by basename."""
+    A link with a path resolves by that path only; a bare name by basename, and only
+    when every note of that name is a capture (a wiki note of the same name makes
+    the link a wiki relationship, not provenance)."""
+
+    def frontmatter_of(rel: str) -> dict | None:
+        fm_text, _ = split_frontmatter(read_text(files[rel]))
+        return parse_frontmatter(fm_text) if fm_text is not None else None
+
     hits: set[Path] = set()
     for match in WIKILINK_RE.finditer(strip_code(note["body"])):
         target = match.group(1).strip()
@@ -407,9 +415,10 @@ def _linked_raw_source(note: dict, files: dict[str, Path], md_by_stem: dict) -> 
             rels = [f"{name}.md"] if f"{name}.md" in files else []
         else:
             rels = md_by_stem.get(name.lower(), [])
+            if not all(is_raw_source(frontmatter_of(rel)) for rel in rels):
+                continue
         for rel in rels:
-            fm_text, _ = split_frontmatter(read_text(files[rel]))
-            if is_raw_source(parse_frontmatter(fm_text) if fm_text is not None else None):
+            if is_raw_source(frontmatter_of(rel)):
                 hits.add(files[rel])
     return hits.pop() if len(hits) == 1 else None
 

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -54,8 +54,9 @@ comparison still cover the whole wiki layer. Raw Source notes (`sha256`, no
 `type:`) are never subjects of the schema, link, tag, or title checks, never
 sources or targets in the link graph, and are all drift-checked whatever the
 scope, so `Raw/` neither needs `--skip` nor eats into `recent:N`. A `[[wikilink]]` inside a fenced code block or inline code is
-an example, not a link. `--skip <folder>` drops a folder from the note set (plugin-
-managed folders, `_audits`, folders AGENTS.md declares out of scope). Dot-dirs,
+an example, not a link. `--skip <folder>` drops a folder from the wiki note set (plugin-
+managed folders, folders AGENTS.md declares out of scope); a Raw Source note in
+a skipped folder keeps its identity. Dot-dirs,
 Excalidraw drawings (`excalidraw-plugin:` in frontmatter), the root-level
 AGENTS.md / SCHEMA.md / CLAUDE.md / README.md / index.md / log.md, and the
 standard `_audits/` report folder are never notes (a vault that keeps reports
@@ -143,7 +144,7 @@ def collect(vault: Path, skip: set[str]) -> tuple[list[dict], dict[str, Path]]:
             continue
         rel_posix = rel.as_posix()
         files[rel_posix] = path
-        if path.suffix != ".md" or _skipped(rel_posix, skip):
+        if path.suffix != ".md":
             continue
         if len(rel.parts) == 1 and path.name in NON_NOTE_ROOT_FILES:
             continue
@@ -162,6 +163,9 @@ def collect(vault: Path, skip: set[str]) -> tuple[list[dict], dict[str, Path]]:
                 "body": body,
                 "title": title if isinstance(title, str) and title else path.stem,
                 "mtime": path.stat().st_mtime,
+                # A skipped folder leaves the wiki note set; a Raw Source note in
+                # it keeps its identity (drift-checked, a provenance target).
+                "skipped": _skipped(rel_posix, skip),
             }
         )
     return notes, files
@@ -202,9 +206,8 @@ def declared_fields(vault: Path) -> dict[str, list[dict]] | None:
         if not isinstance(type_value, str):
             continue
         names = [n for n in (part.strip() for part in type_value.split("|")) if TYPE_NAME_RE.match(n)]
-        heading_key = re.sub(r"[^a-z0-9]", "", heading.lower())
         for name in names:
-            own_section = re.sub(r"[^a-z0-9]", "", name.lower()) in heading_key
+            own_section = _heading_names(heading, name)
             if len(names) == 1 and own_section:
                 variants[name].append({"fields": set(fm.keys()), "tags": set(note_tags(fm))})
             else:
@@ -214,6 +217,17 @@ def declared_fields(vault: Path) -> dict[str, list[dict]] | None:
         or [{"fields": base[name], "tags": set()}]
         for name in sorted(set(base) | set(variants))
     }
+
+
+def _heading_names(heading: str, type_name: str) -> bool:
+    """Whether the heading path names the type as whole words — `Source — Paper
+    Variant / Frontmatter` names `source`, `Daily Aggregate` names
+    `daily-aggregate`, `Catalog defaults` does not name `log`."""
+    tokens = re.findall(r"[a-z0-9]+", heading.lower())
+    key = re.sub(r"[^a-z0-9]", "", type_name.lower())
+    return any(
+        key == "".join(tokens[i:j]) for i in range(len(tokens)) for j in range(i + 1, len(tokens) + 1)
+    )
 
 
 def _fit(fm: dict, variants: list[dict]) -> int:
@@ -539,7 +553,7 @@ def duplicate_title_facts(notes: list[dict], scoped: list[dict], title_match) ->
 def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dict:
     notes, files = collect(vault, skip)
     raw = [note for note in notes if is_raw_source(note["fm"])]
-    wiki = [note for note in notes if not is_raw_source(note["fm"])]
+    wiki = [note for note in notes if not is_raw_source(note["fm"]) and not note["skipped"]]
     scoped = select_scope(wiki, scope)
     declared = declared_fields(vault)
     taxonomy = declared_tags(vault)

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -12,10 +12,12 @@ the auditor reads before acting on:
   2. `type:` presence; per-type field fill counts and undeclared-field counts.
      Declared fields come from the top-level yaml fences in `<vault>/SCHEMA.md`
      (a fence nested inside another fence is an illustration). A fence whose
-     `type:` lists several names (`source | entity`) is a base every note of
-     those types carries; each fence naming one type is a variant of it (the
-     llm-wiki Source and its Paper variant), and a placeholder name (`<one of
-     the types declared below>`) declares nothing. A note is measured against
+     `type:` lists several names (`source | entity`), or whose section heading
+     does not name its one type (`## Universal Frontmatter` over `type: book`),
+     is a base every note of those types carries; a fence naming one type under
+     that type's own heading is a variant of it (the llm-wiki Source and its
+     Paper variant), and a placeholder name (`<one of the types declared
+     below>`) declares nothing. A note is measured against
      the variant whose fields it carries most of, so a field only one variant
      declares is `expected` of the notes fitting that variant, not of every
      note of the type. A variant fence that declares a `tags:` value names its
@@ -168,25 +170,29 @@ def select_scope(notes: list[dict], scope: str) -> list[dict]:
 def declared_fields(vault: Path) -> dict[str, list[dict]] | None:
     """Per type, one variant per fence SCHEMA.md declares; None without a SCHEMA.md.
 
-    A fence naming several types is a base shared by every variant of each; a
-    fence naming one type is a variant, with `fields` (its keys plus the base)
+    A fence naming several types, or naming one type under a heading that does
+    not mention it (`## Universal Frontmatter` over `type: book`), is a base
+    shared by every variant of each type it names; a fence naming one type under
+    that type's own heading is a variant, with `fields` (its keys plus the base)
     and `tags` (the tags its `tags:` value lists — the variant's discriminator).
-    A type with no fence of its own has its base as the single variant.
+    A type with no variant fence has its base as the single variant.
     """
     schema = vault / SCHEMA_FILE
     if not schema.is_file():
         return None
     base: dict[str, set[str]] = defaultdict(set)
     variants: dict[str, list[dict]] = defaultdict(list)
-    for fence in yaml_fences(read_text(schema)):
+    for heading, fence in yaml_fences(read_text(schema)):
         lines = [line for line in fence.split("\n") if line.strip() != "---"]
         fm = parse_frontmatter("\n".join(lines))
         type_value = fm.get("type")
         if not isinstance(type_value, str):
             continue
         names = [n for n in (part.strip() for part in type_value.split("|")) if TYPE_NAME_RE.match(n)]
+        heading_key = re.sub(r"[^a-z0-9]", "", heading.lower())
         for name in names:
-            if len(names) == 1:
+            own_section = re.sub(r"[^a-z0-9]", "", name.lower()) in heading_key
+            if len(names) == 1 and own_section:
                 variants[name].append({"fields": set(fm.keys()), "tags": set(note_tags(fm))})
             else:
                 base[name].update(fm.keys())
@@ -301,10 +307,11 @@ def link_facts(notes: list[dict], scoped: list[dict]) -> dict:
         by_stem[Path(note["rel"]).stem.lower()].append(note["rel"])
 
     def resolve(target: str) -> str | None:
+        # A link with a path resolves by that path only; a bare name by basename.
         name = target[:-3] if target.endswith(".md") else target
-        if "/" in name and f"{name}.md" in by_rel:
-            return f"{name}.md"
-        hits = by_stem.get(Path(name).name.lower())
+        if "/" in name:
+            return f"{name}.md" if f"{name}.md" in by_rel else None
+        hits = by_stem.get(name.lower())
         return hits[0] if hits else None
 
     outbound: dict[str, int] = {}
@@ -353,12 +360,16 @@ def _source_url_file(note: dict, files: dict[str, Path]) -> Path | None:
 
 
 def _linked_raw_source(note: dict, files: dict[str, Path], md_by_stem: dict) -> Path | None:
-    """The Raw Source note (`sha256`, no `type:`) the body wikilinks — when it links exactly one."""
+    """The Raw Source note (`sha256`, no `type:`) the body wikilinks — when it links exactly one.
+    A link with a path resolves by that path only; a bare name by basename."""
     hits: set[Path] = set()
     for match in WIKILINK_RE.finditer(strip_code(note["body"])):
         target = match.group(1).strip()
         name = target[:-3] if target.endswith(".md") else target
-        rels = [f"{name}.md"] if f"{name}.md" in files else md_by_stem.get(Path(name).name.lower(), [])
+        if "/" in name:
+            rels = [f"{name}.md"] if f"{name}.md" in files else []
+        else:
+            rels = md_by_stem.get(name.lower(), [])
         for rel in rels:
             fm_text, _ = split_frontmatter(read_text(files[rel]))
             if is_raw_source(parse_frontmatter(fm_text) if fm_text is not None else None):

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -10,18 +10,25 @@ the auditor reads before acting on:
   1. Frontmatter per note, parsed as a block. A YAML block list (`tags:` then
      indented `- ` items) reads as filled, never as empty.
   2. `type:` presence; per-type field fill counts and undeclared-field counts.
-     Declared fields come from the yaml fences in `<vault>/SCHEMA.md`; a fence
-     whose `type:` lists several names (`source | entity`) declares for each.
+     Declared fields come from the top-level yaml fences in `<vault>/SCHEMA.md`
+     (a fence nested inside another fence is an illustration). A fence whose
+     `type:` lists several names (`source | entity`) declares for each; a
+     placeholder name (`<one of the types declared below>`) declares nothing.
   3. Link graph from [[wikilinks]] over the whole vault: inbound / outbound per
      in-scope note, and the orphans (zero of each). Embeds of non-note files
      (`![[image.png]]`) are not links.
   4. Raw Source sha256 drift per raw-sources.md: strip the frontmatter, normalize
      line endings to `\\n`, sha256 the UTF-8 bytes of what follows the closing
-     fence line. A note carries a Raw Source hash when its frontmatter has a
-     `sha256` key; when its `source_url` resolves to a file inside the vault,
-     that file's body is the one hashed.
+     fence line. A note carries a hash when its frontmatter has a `sha256` key.
+     The file hashed is the `source_url` target when that is a file inside the
+     vault; otherwise a Raw Source note (`sha256`, no `type:`) hashes its own
+     body, and a typed note hashes the one Raw Source note its body wikilinks.
+     A typed note with neither is `unresolved`: its original is remote, and
+     nothing in the vault stands in for it.
   5. `log.md` entries naming files that do not exist anywhere in the vault.
-  6. Frontmatter tag counts.
+  6. Frontmatter tag counts, each marked `declared` when the tag or its top-level
+     segment is a backticked list item under SCHEMA.md's `## Tag Taxonomy`;
+     `--tag-min` sets `exceeds` for undeclared tags only.
   7. Duplicate-title candidates (difflib ratio >= 0.6, or the --title-match
      value when lower) between in-scope notes and every other note.
 
@@ -58,8 +65,10 @@ DUP_CANDIDATE_FLOOR = 0.6
 NON_NOTE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".canvas", ".html", ".excalidraw"}
 FILE_TOKEN_RE = re.compile(r"\.(md|pdf|png|jpe?g|gif|svg|html|canvas)$", re.IGNORECASE)
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
-FENCE_RE = re.compile(r"```ya?ml\n(.*?)\n```", re.DOTALL)
 KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
+TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+TAXONOMY_HEADING_RE = re.compile(r"^##\s+.*\btaxonomy\b", re.IGNORECASE)
+TAXONOMY_ITEM_RE = re.compile(r"^\s*[-*]\s+`#?([^`\s]+)`")
 LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]")
 
 
@@ -140,6 +149,31 @@ def is_empty(value) -> bool:
     return value == "" or value == [] or value == {}
 
 
+def note_type(fm: dict | None) -> str | None:
+    """The note's `type:` when it is a non-empty string; None for an untyped note."""
+    value = fm.get("type") if fm else None
+    return value if isinstance(value, str) and value else None
+
+
+def yaml_fences(text: str) -> list[str]:
+    """Bodies of the top-level ```yaml fences. A ```yaml line inside an open fence is content."""
+    fences: list[str] = []
+    info: str | None = None
+    buf: list[str] = []
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if info is None:
+            if stripped.startswith("```"):
+                info, buf = stripped[3:].strip().lower(), []
+        elif stripped == "```":
+            if info in ("yaml", "yml"):
+                fences.append("\n".join(buf))
+            info = None
+        else:
+            buf.append(line)
+    return fences
+
+
 def exceeds(value: float, threshold: float | None) -> bool | None:
     return None if threshold is None else value >= threshold
 
@@ -207,16 +241,33 @@ def declared_fields(vault: Path) -> dict[str, set[str]] | None:
     if not schema.is_file():
         return None
     declared: dict[str, set[str]] = defaultdict(set)
-    for fence in FENCE_RE.findall(read_text(schema)):
+    for fence in yaml_fences(read_text(schema)):
         lines = [line for line in fence.split("\n") if line.strip() != "---"]
         fm = parse_frontmatter("\n".join(lines))
         type_value = fm.get("type")
-        if not isinstance(type_value, str) or not type_value:
+        if not isinstance(type_value, str):
             continue
-        for name in type_value.split("|"):
-            if name.strip():
-                declared[name.strip()].update(fm.keys())
+        for name in (part.strip() for part in type_value.split("|")):
+            if TYPE_NAME_RE.match(name):
+                declared[name].update(fm.keys())
     return dict(declared)
+
+
+def declared_tags(vault: Path) -> list[str]:
+    """Top-level tags listed under SCHEMA.md's taxonomy heading, as `- `tag` — ...` items."""
+    schema = vault / SCHEMA_FILE
+    if not schema.is_file():
+        return []
+    tags: list[str] = []
+    inside = False
+    for line in read_text(schema).split("\n"):
+        if line.startswith("## "):
+            inside = bool(TAXONOMY_HEADING_RE.match(line))
+            continue
+        match = TAXONOMY_ITEM_RE.match(line) if inside else None
+        if match and match.group(1) not in tags:
+            tags.append(match.group(1))
+    return tags
 
 
 def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) -> tuple[dict, list]:
@@ -224,8 +275,8 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
     untyped = []
     for note in scoped:
         fm = note["fm"]
-        type_value = fm.get("type") if fm else None
-        if not isinstance(type_value, str) or not type_value:
+        type_value = note_type(fm)
+        if type_value is None:
             if fm is not None and "sha256" in fm:
                 # A Raw Source note: audit.md keeps it under the drift check
                 # (raw_source_facts) and out of schema compliance.
@@ -312,26 +363,67 @@ def sha256_body(body: str) -> str:
     return hashlib.sha256(body.encode("utf-8")).hexdigest()
 
 
+def sha256_file(path: Path) -> str:
+    """A note's body digest per raw-sources.md; a non-note file's raw bytes."""
+    if path.suffix == ".md":
+        return sha256_body(split_frontmatter(read_text(path))[1])
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_url_file(note: dict, files: dict[str, Path]) -> Path | None:
+    """The vault file `source_url` names, when it names one (not a URL, not the note itself)."""
+    source_url = note["fm"].get("source_url")
+    if not isinstance(source_url, str) or not source_url or "://" in source_url:
+        return None
+    candidate = files.get(source_url.lstrip("/")) or files.get(
+        (Path(note["rel"]).parent / source_url).as_posix()
+    )
+    return candidate if candidate is not None and candidate != note["path"] else None
+
+
+def _linked_raw_source(note: dict, files: dict[str, Path], md_by_stem: dict) -> Path | None:
+    """The Raw Source note (`sha256`, no `type:`) the body wikilinks — when it links exactly one."""
+    hits: set[Path] = set()
+    for match in WIKILINK_RE.finditer(note["body"]):
+        target = match.group(1).strip()
+        name = target[:-3] if target.endswith(".md") else target
+        rels = [f"{name}.md"] if f"{name}.md" in files else md_by_stem.get(Path(name).name.lower(), [])
+        for rel in rels:
+            fm_text, _ = split_frontmatter(read_text(files[rel]))
+            fm = parse_frontmatter(fm_text) if fm_text is not None else None
+            if fm is not None and "sha256" in fm and note_type(fm) is None:
+                hits.add(files[rel])
+    return hits.pop() if len(hits) == 1 else None
+
+
 def raw_source_facts(scoped: list[dict], vault: Path, files: dict[str, Path]) -> list[dict]:
+    md_by_stem: dict[str, list[str]] = defaultdict(list)
+    for rel in files:
+        if rel.endswith(".md"):
+            md_by_stem[Path(rel).stem.lower()].append(rel)
     out = []
     for note in scoped:
         fm = note["fm"]
         if fm is None or "sha256" not in fm:
             continue
         stored = fm["sha256"] if isinstance(fm["sha256"], str) else ""
-        hashed_file, recomputed = note["rel"], sha256_body(note["body"])
-        source_url = fm.get("source_url")
-        if isinstance(source_url, str) and source_url and "://" not in source_url:
-            candidate = files.get(source_url.lstrip("/")) or files.get(
-                (Path(note["rel"]).parent / source_url).as_posix()
-            )
-            if candidate is not None and candidate != note["path"]:
-                hashed_file = candidate.relative_to(vault).as_posix()
-                if candidate.suffix == ".md":
-                    recomputed = sha256_body(split_frontmatter(read_text(candidate))[1])
-                else:
-                    recomputed = hashlib.sha256(candidate.read_bytes()).hexdigest()
-        status = "unhashed" if not stored else ("fresh" if stored == recomputed else "drift")
+        # The provenance pair: a typed note's digest is of the Raw Source it was
+        # ingested from, never of its own synthesized body.
+        target = _source_url_file(note, files)
+        if target is None and note_type(fm) is not None:
+            target = _linked_raw_source(note, files, md_by_stem)
+        if target is not None:
+            hashed_file, recomputed = target.relative_to(vault).as_posix(), sha256_file(target)
+        elif note_type(fm) is None:
+            hashed_file, recomputed = note["rel"], sha256_body(note["body"])
+        else:
+            hashed_file, recomputed = None, None
+        if not stored:
+            status = "unhashed"
+        elif recomputed is None:
+            status = "unresolved"
+        else:
+            status = "fresh" if stored == recomputed else "drift"
         out.append(
             {
                 "path": note["rel"],
@@ -364,7 +456,8 @@ def log_facts(vault: Path, files: dict[str, Path]) -> dict:
     return {"path": LOG_FILE, "entries": entries, "missing_files": missing}
 
 
-def tag_facts(scoped: list[dict], tag_min) -> dict:
+def tag_facts(scoped: list[dict], declared: list[str], tag_min) -> dict:
+    """Tag counts; `exceeds` only for a tag outside the taxonomy (top-level segment undeclared)."""
     counts: Counter = Counter()
     for note in scoped:
         tags = (note["fm"] or {}).get("tags", [])
@@ -375,7 +468,15 @@ def tag_facts(scoped: list[dict], tag_min) -> dict:
         for tag in tags:
             if isinstance(tag, str) and tag:
                 counts[tag.lstrip("#")] += 1
-    return {tag: {"count": n, "exceeds": exceeds(n, tag_min)} for tag, n in sorted(counts.items())}
+    out = {}
+    for tag, n in sorted(counts.items()):
+        is_declared = tag in declared or tag.split("/", 1)[0] in declared
+        out[tag] = {
+            "count": n,
+            "declared": is_declared,
+            "exceeds": None if tag_min is None else (not is_declared and n >= tag_min),
+        }
+    return out
 
 
 def normalize_title(title: str) -> str:
@@ -414,6 +515,7 @@ def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dic
     notes, files = collect(vault, skip)
     scoped = select_scope(notes, scope)
     declared = declared_fields(vault)
+    taxonomy = declared_tags(vault)
     types, untyped = type_facts(
         scoped, declared, thresholds["field_empty_pct"], thresholds["undeclared_pct"]
     )
@@ -426,13 +528,14 @@ def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dic
         "schema": {
             "path": SCHEMA_FILE if declared is not None else None,
             "declared_types": sorted(declared) if declared else [],
+            "declared_tags": taxonomy,
         },
         "untyped": untyped,
         "types": types,
         "links": link_facts(notes, scoped),
         "raw_sources": raw_source_facts(scoped, vault, files),
         "log": log_facts(vault, files),
-        "tags": tag_facts(scoped, thresholds["tag_min"]),
+        "tags": tag_facts(scoped, taxonomy, thresholds["tag_min"]),
         "duplicate_titles": duplicate_title_facts(notes, scoped, thresholds["title_match"]),
     }
 
@@ -469,7 +572,8 @@ def print_summary(report: dict) -> None:
     by_status = Counter(item["status"] for item in report["raw_sources"])
     print(
         f"Raw Sources: {len(report['raw_sources'])} (fresh {by_status['fresh']}, "
-        f"drift {by_status['drift']}, unhashed {by_status['unhashed']})"
+        f"drift {by_status['drift']}, unhashed {by_status['unhashed']}, "
+        f"unresolved {by_status['unresolved']})"
     )
     for item in report["raw_sources"]:
         if item["status"] != "fresh":
@@ -478,7 +582,8 @@ def print_summary(report: dict) -> None:
     print(f"Log: {log['entries']} entries, {len(log['missing_files'])} naming missing files")
     for item in log["missing_files"]:
         print(f"  line {item['line']}: {item['file']}")
-    print(f"Tags: {len(report['tags'])} distinct")
+    outside = sum(1 for facts in report["tags"].values() if not facts["declared"])
+    print(f"Tags: {len(report['tags'])} distinct, {outside} outside the taxonomy")
     print(f"Duplicate-title candidates: {len(report['duplicate_titles'])}")
     for item in report["duplicate_titles"]:
         print(f"  {item['ratio']:.3f}  {item['a']}  ~  {item['b']}")

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -1,0 +1,549 @@
+"""Emit the deterministic LINT facts for an Obsidian vault.
+
+Usage:
+    cd <this skill's references/ directory>
+    python3 lint_vault.py <vault> [--scope recent:50|all] [--skip <folder>]... [--json]
+                          [--field-empty-pct N] [--undeclared-pct N] [--tag-min N] [--title-match R]
+
+Reports facts, not verdicts — every figure is a hypothesis about a file that
+the auditor reads before acting on:
+  1. Frontmatter per note, parsed as a block. A YAML block list (`tags:` then
+     indented `- ` items) reads as filled, never as empty.
+  2. `type:` presence; per-type field fill counts and undeclared-field counts.
+     Declared fields come from the yaml fences in `<vault>/SCHEMA.md`; a fence
+     whose `type:` lists several names (`source | entity`) declares for each.
+  3. Link graph from [[wikilinks]] over the whole vault: inbound / outbound per
+     in-scope note, and the orphans (zero of each). Embeds of non-note files
+     (`![[image.png]]`) are not links.
+  4. Raw Source sha256 drift per raw-sources.md: strip the frontmatter, normalize
+     line endings to `\\n`, sha256 the UTF-8 bytes of what follows the closing
+     fence line. A note carries a Raw Source hash when its frontmatter has a
+     `sha256` key; when its `source_url` resolves to a file inside the vault,
+     that file's body is the one hashed.
+  5. `log.md` entries naming files that do not exist anywhere in the vault.
+  6. Frontmatter tag counts.
+  7. Duplicate-title candidates (difflib ratio >= 0.6, or the --title-match
+     value when lower) between in-scope notes and every other note.
+
+Scope: `recent:N` (default recent:50) takes the N most recently modified notes as
+subjects; the link graph, the file index, and duplicate comparison still cover
+the whole vault. `--skip <folder>` drops a folder from the note set (plugin-
+managed folders, `_audits`, folders AGENTS.md declares out of scope). Dot-dirs,
+Excalidraw drawings (`excalidraw-plugin:` in frontmatter), and the root-level
+AGENTS.md / SCHEMA.md / CLAUDE.md / README.md / index.md / log.md are never notes.
+
+Threshold flags only set the `exceeds` booleans in the JSON; the numbers live in
+each vault's SCHEMA.md `## Audit Thresholds`. Without a flag, `exceeds` is null.
+
+Output: JSON (--json) or a short text summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from difflib import SequenceMatcher
+from pathlib import Path
+
+NON_NOTE_ROOT_FILES = {"AGENTS.md", "SCHEMA.md", "CLAUDE.md", "README.md", "index.md", "log.md"}
+LOG_FILE = "log.md"
+SCHEMA_FILE = "SCHEMA.md"
+DUP_CANDIDATE_FLOOR = 0.6
+
+# Link targets with these extensions are embeds, not note relationships.
+NON_NOTE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".canvas", ".html", ".excalidraw"}
+FILE_TOKEN_RE = re.compile(r"\.(md|pdf|png|jpe?g|gif|svg|html|canvas)$", re.IGNORECASE)
+WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
+FENCE_RE = re.compile(r"```ya?ml\n(.*?)\n```", re.DOTALL)
+KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
+LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]")
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter
+# ---------------------------------------------------------------------------
+
+
+def read_text(path: Path) -> str:
+    """Read as UTF-8 with line endings normalized to \\n."""
+    return path.read_bytes().decode("utf-8", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+
+
+def split_frontmatter(text: str) -> tuple[str | None, str]:
+    """Return (frontmatter text, body). Frontmatter is None when the note has none."""
+    if not text.startswith("---\n"):
+        return None, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        if text.endswith("\n---"):
+            return text[4:-4], ""
+        return None, text
+    return text[4:end], text[end + 5 :]
+
+
+def _scalar(raw: str):
+    """Parse one inline YAML value: quoted string, inline list, empty, or bare."""
+    value = raw.strip()
+    if value[:1] in ("'", '"'):
+        close = value.find(value[0], 1)
+        return value[1:close] if close != -1 else value[1:]
+    value = re.split(r"\s+#", value, maxsplit=1)[0].strip()
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        return [_scalar(item) for item in inner.split(",")] if inner else []
+    if value in ("", "null", "~"):
+        return ""
+    return value
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Parse a frontmatter block. Block lists and nested mappings are read whole."""
+    data: dict = {}
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines):
+        match = KEY_RE.match(lines[i])
+        i += 1
+        if not match:
+            continue
+        key, rest = match.group(1), match.group(2)
+        if rest.strip() and not rest.strip().startswith("#"):
+            data[key] = _scalar(rest)
+            continue
+        block: list[str] = []
+        while i < len(lines) and (
+            not lines[i].strip()
+            or lines[i][:1] in (" ", "\t")
+            or lines[i] == "-"
+            or lines[i].startswith("- ")
+        ):
+            if lines[i].strip():
+                block.append(lines[i].strip())
+            i += 1
+        if not block:
+            data[key] = ""
+        elif all(item == "-" or item.startswith("- ") for item in block):
+            data[key] = [_scalar(item[1:]) for item in block]
+        else:
+            data[key] = {
+                item.split(":", 1)[0].strip(): _scalar(item.split(":", 1)[1]) if ":" in item else ""
+                for item in block
+            }
+    return data
+
+
+def is_empty(value) -> bool:
+    return value == "" or value == [] or value == {}
+
+
+def exceeds(value: float, threshold: float | None) -> bool | None:
+    return None if threshold is None else value >= threshold
+
+
+# ---------------------------------------------------------------------------
+# Vault walk
+# ---------------------------------------------------------------------------
+
+
+def _skipped(rel: str, skip: set[str]) -> bool:
+    return any(rel == folder or rel.startswith(folder + "/") for folder in skip)
+
+
+def collect(vault: Path, skip: set[str]) -> tuple[list[dict], dict[str, Path]]:
+    """Every file in the vault (by relative posix path) and the notes among them."""
+    files: dict[str, Path] = {}
+    notes: list[dict] = []
+    for path in sorted(vault.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(vault)
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        rel_posix = rel.as_posix()
+        files[rel_posix] = path
+        if path.suffix != ".md" or _skipped(rel_posix, skip):
+            continue
+        if len(rel.parts) == 1 and path.name in NON_NOTE_ROOT_FILES:
+            continue
+        text = read_text(path)
+        fm_text, body = split_frontmatter(text)
+        fm = parse_frontmatter(fm_text) if fm_text is not None else None
+        if fm and "excalidraw-plugin" in fm:
+            continue
+        title = fm.get("title") if fm else None
+        notes.append(
+            {
+                "rel": rel_posix,
+                "path": path,
+                "fm": fm,
+                "text": text,
+                "body": body,
+                "title": title if isinstance(title, str) and title else path.stem,
+                "mtime": path.stat().st_mtime,
+            }
+        )
+    return notes, files
+
+
+def select_scope(notes: list[dict], scope: str) -> list[dict]:
+    if scope == "all":
+        return notes
+    limit = int(scope.split(":", 1)[1])
+    return sorted(notes, key=lambda n: n["mtime"], reverse=True)[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Facts
+# ---------------------------------------------------------------------------
+
+
+def declared_fields(vault: Path) -> dict[str, set[str]] | None:
+    """Fields each type declares in SCHEMA.md's yaml fences; None without a SCHEMA.md."""
+    schema = vault / SCHEMA_FILE
+    if not schema.is_file():
+        return None
+    declared: dict[str, set[str]] = defaultdict(set)
+    for fence in FENCE_RE.findall(read_text(schema)):
+        lines = [line for line in fence.split("\n") if line.strip() != "---"]
+        fm = parse_frontmatter("\n".join(lines))
+        type_value = fm.get("type")
+        if not isinstance(type_value, str) or not type_value:
+            continue
+        for name in type_value.split("|"):
+            if name.strip():
+                declared[name.strip()].update(fm.keys())
+    return dict(declared)
+
+
+def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) -> tuple[dict, list]:
+    by_type: dict[str, list[dict]] = defaultdict(list)
+    untyped = []
+    for note in scoped:
+        fm = note["fm"]
+        type_value = fm.get("type") if fm else None
+        if not isinstance(type_value, str) or not type_value:
+            if fm is not None and "sha256" in fm:
+                # A Raw Source note: audit.md keeps it under the drift check
+                # (raw_source_facts) and out of schema compliance.
+                continue
+            untyped.append({"path": note["rel"], "has_frontmatter": fm is not None})
+            continue
+        by_type[type_value].append(fm)
+
+    types = {}
+    for type_name, fms in sorted(by_type.items()):
+        total = len(fms)
+        decl = declared.get(type_name) if declared is not None else None
+        observed = set().union(*(fm.keys() for fm in fms))
+        fields = {}
+        for field in sorted(observed | (decl or set())):
+            present = sum(1 for fm in fms if field in fm)
+            filled = sum(1 for fm in fms if field in fm and not is_empty(fm[field]))
+            empty = total - filled
+            pct = round(100.0 * empty / total, 1)
+            fields[field] = {
+                "present": present,
+                "filled": filled,
+                "empty": empty,
+                "empty_pct": pct,
+                "exceeds": exceeds(pct, field_empty_pct),
+            }
+        undeclared = None
+        if decl is not None:
+            undeclared = {}
+            for field in sorted(observed - decl):
+                present = sum(1 for fm in fms if field in fm)
+                pct = round(100.0 * present / total, 1)
+                undeclared[field] = {
+                    "present": present,
+                    "present_pct": pct,
+                    "exceeds": exceeds(pct, undeclared_pct),
+                }
+        types[type_name] = {
+            "notes": total,
+            "declared": sorted(decl) if decl is not None else None,
+            "fields": fields,
+            "undeclared": undeclared,
+        }
+    return types, untyped
+
+
+def link_facts(notes: list[dict], scoped: list[dict]) -> dict:
+    by_rel = {note["rel"] for note in notes}
+    by_stem: dict[str, list[str]] = defaultdict(list)
+    for note in notes:
+        by_stem[Path(note["rel"]).stem.lower()].append(note["rel"])
+
+    def resolve(target: str) -> str | None:
+        name = target[:-3] if target.endswith(".md") else target
+        if "/" in name and f"{name}.md" in by_rel:
+            return f"{name}.md"
+        hits = by_stem.get(Path(name).name.lower())
+        return hits[0] if hits else None
+
+    outbound: dict[str, int] = {}
+    inbound: Counter = Counter()
+    for note in notes:
+        targets = set()
+        for match in WIKILINK_RE.finditer(note["text"]):
+            raw = match.group(1).strip()
+            if raw and Path(raw).suffix.lower() not in NON_NOTE_EXTS:
+                targets.add(raw)
+        resolved = {resolve(raw) for raw in targets}
+        outbound[note["rel"]] = len(targets) - (1 if note["rel"] in resolved else 0)
+        for rel in resolved - {None, note["rel"]}:
+            inbound[rel] += 1
+
+    per_note = {
+        note["rel"]: {"inbound": inbound[note["rel"]], "outbound": outbound[note["rel"]]}
+        for note in scoped
+    }
+    orphans = sorted(
+        rel for rel, counts in per_note.items() if not counts["inbound"] and not counts["outbound"]
+    )
+    return {"orphans": orphans, "notes": per_note}
+
+
+def sha256_body(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def raw_source_facts(scoped: list[dict], vault: Path, files: dict[str, Path]) -> list[dict]:
+    out = []
+    for note in scoped:
+        fm = note["fm"]
+        if fm is None or "sha256" not in fm:
+            continue
+        stored = fm["sha256"] if isinstance(fm["sha256"], str) else ""
+        hashed_file, recomputed = note["rel"], sha256_body(note["body"])
+        source_url = fm.get("source_url")
+        if isinstance(source_url, str) and source_url and "://" not in source_url:
+            candidate = files.get(source_url.lstrip("/")) or files.get(
+                (Path(note["rel"]).parent / source_url).as_posix()
+            )
+            if candidate is not None and candidate != note["path"]:
+                hashed_file = candidate.relative_to(vault).as_posix()
+                if candidate.suffix == ".md":
+                    recomputed = sha256_body(split_frontmatter(read_text(candidate))[1])
+                else:
+                    recomputed = hashlib.sha256(candidate.read_bytes()).hexdigest()
+        status = "unhashed" if not stored else ("fresh" if stored == recomputed else "drift")
+        out.append(
+            {
+                "path": note["rel"],
+                "hashed_file": hashed_file,
+                "status": status,
+                "stored": stored,
+                "recomputed": recomputed,
+            }
+        )
+    return out
+
+
+def log_facts(vault: Path, files: dict[str, Path]) -> dict:
+    log = vault / LOG_FILE
+    if not log.is_file():
+        return {"path": None, "entries": 0, "missing_files": []}
+    basenames = {Path(rel).name for rel in files}
+    entries = 0
+    missing = []
+    for line_no, line in enumerate(read_text(log).split("\n"), 1):
+        if LOG_ENTRY_RE.match(line):
+            entries += 1
+        for part in line.split("|"):
+            token = part.strip().strip("`")
+            if not FILE_TOKEN_RE.search(token):
+                continue
+            if token in files or token.lstrip("./") in files or Path(token).name in basenames:
+                continue
+            missing.append({"line": line_no, "file": token})
+    return {"path": LOG_FILE, "entries": entries, "missing_files": missing}
+
+
+def tag_facts(scoped: list[dict], tag_min) -> dict:
+    counts: Counter = Counter()
+    for note in scoped:
+        tags = (note["fm"] or {}).get("tags", [])
+        if isinstance(tags, str):
+            tags = [t for t in re.split(r"[,\s]+", tags) if t]
+        elif isinstance(tags, dict):
+            tags = list(tags)
+        for tag in tags:
+            if isinstance(tag, str) and tag:
+                counts[tag.lstrip("#")] += 1
+    return {tag: {"count": n, "exceeds": exceeds(n, tag_min)} for tag, n in sorted(counts.items())}
+
+
+def normalize_title(title: str) -> str:
+    return re.sub(r"[\W_]+", " ", title.lower()).strip()
+
+
+def duplicate_title_facts(notes: list[dict], scoped: list[dict], title_match) -> list[dict]:
+    floor = DUP_CANDIDATE_FLOOR if title_match is None else min(DUP_CANDIDATE_FLOOR, title_match)
+    normalized = {note["rel"]: normalize_title(note["title"]) for note in notes}
+    seen: set[tuple[str, str]] = set()
+    out = []
+    for subject in scoped:
+        if not normalized[subject["rel"]]:
+            continue
+        matcher = SequenceMatcher()
+        matcher.set_seq2(normalized[subject["rel"]])
+        for other in notes:
+            if other["rel"] == subject["rel"] or not normalized[other["rel"]]:
+                continue
+            pair = tuple(sorted((subject["rel"], other["rel"])))
+            if pair in seen:
+                continue
+            seen.add(pair)
+            matcher.set_seq1(normalized[other["rel"]])
+            if matcher.real_quick_ratio() < floor or matcher.quick_ratio() < floor:
+                continue
+            ratio = round(matcher.ratio(), 3)
+            if ratio < floor:
+                continue
+            out.append({"a": pair[0], "b": pair[1], "ratio": ratio, "exceeds": exceeds(ratio, title_match)})
+    out.sort(key=lambda item: (-item["ratio"], item["a"], item["b"]))
+    return out
+
+
+def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dict:
+    notes, files = collect(vault, skip)
+    scoped = select_scope(notes, scope)
+    declared = declared_fields(vault)
+    types, untyped = type_facts(
+        scoped, declared, thresholds["field_empty_pct"], thresholds["undeclared_pct"]
+    )
+    return {
+        "vault": str(vault),
+        "scope": scope,
+        "skipped": sorted(skip),
+        "thresholds": thresholds,
+        "notes": {"total": len(notes), "in_scope": len(scoped)},
+        "schema": {
+            "path": SCHEMA_FILE if declared is not None else None,
+            "declared_types": sorted(declared) if declared else [],
+        },
+        "untyped": untyped,
+        "types": types,
+        "links": link_facts(notes, scoped),
+        "raw_sources": raw_source_facts(scoped, vault, files),
+        "log": log_facts(vault, files),
+        "tags": tag_facts(scoped, thresholds["tag_min"]),
+        "duplicate_titles": duplicate_title_facts(notes, scoped, thresholds["title_match"]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_scope(value: str) -> str:
+    if value == "all" or re.fullmatch(r"recent:[1-9]\d*", value):
+        return value
+    raise argparse.ArgumentTypeError(f"scope must be 'all' or 'recent:<N>', got {value!r}")
+
+
+def print_summary(report: dict) -> None:
+    notes = report["notes"]
+    schema = report["schema"]
+    print(
+        f"Vault: {report['vault']}  scope: {report['scope']} "
+        f"({notes['in_scope']} of {notes['total']} notes)"
+    )
+    print(f"Schema: {schema['path'] or 'none'}  types: {', '.join(schema['declared_types']) or '-'}")
+    for name, facts in report["types"].items():
+        undeclared = facts["undeclared"]
+        extra = f", undeclared fields: {', '.join(undeclared)}" if undeclared else ""
+        print(f"  {name}: {facts['notes']} notes{extra}")
+    print(f"Untyped: {len(report['untyped'])}")
+    for item in report["untyped"]:
+        print(f"  {item['path']} (frontmatter: {'yes' if item['has_frontmatter'] else 'no'})")
+    print(f"Orphans: {len(report['links']['orphans'])}")
+    for rel in report["links"]["orphans"]:
+        print(f"  {rel}")
+    by_status = Counter(item["status"] for item in report["raw_sources"])
+    print(
+        f"Raw Sources: {len(report['raw_sources'])} (fresh {by_status['fresh']}, "
+        f"drift {by_status['drift']}, unhashed {by_status['unhashed']})"
+    )
+    for item in report["raw_sources"]:
+        if item["status"] != "fresh":
+            print(f"  {item['status']}: {item['path']}")
+    log = report["log"]
+    print(f"Log: {log['entries']} entries, {len(log['missing_files'])} naming missing files")
+    for item in log["missing_files"]:
+        print(f"  line {item['line']}: {item['file']}")
+    print(f"Tags: {len(report['tags'])} distinct")
+    print(f"Duplicate-title candidates: {len(report['duplicate_titles'])}")
+    for item in report["duplicate_titles"]:
+        print(f"  {item['ratio']:.3f}  {item['a']}  ~  {item['b']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Emit the deterministic LINT facts for an Obsidian vault"
+    )
+    parser.add_argument("vault", type=Path, help="Path to the vault root")
+    parser.add_argument(
+        "--scope", type=parse_scope, default="recent:50", help="recent:<N> (default recent:50) or all"
+    )
+    parser.add_argument(
+        "--skip",
+        action="append",
+        default=[],
+        metavar="FOLDER",
+        help="Vault-relative folder to leave out of the note set (repeatable)",
+    )
+    parser.add_argument(
+        "--field-empty-pct",
+        type=float,
+        default=None,
+        help="Field empty in this %% of a type or more sets exceeds",
+    )
+    parser.add_argument(
+        "--undeclared-pct",
+        type=float,
+        default=None,
+        help="Undeclared field present in this %% of a type or more sets exceeds",
+    )
+    parser.add_argument(
+        "--tag-min", type=int, default=None, help="Tag used this many times or more sets exceeds"
+    )
+    parser.add_argument(
+        "--title-match",
+        type=float,
+        default=None,
+        help="Title similarity ratio (0-1) at or above which a pair sets exceeds",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Output raw JSON instead of the text summary"
+    )
+    args = parser.parse_args()
+
+    vault = args.vault.resolve()
+    if not vault.is_dir():
+        print(f"ERROR: vault directory not found: {args.vault}", file=sys.stderr)
+        sys.exit(1)
+
+    thresholds = {
+        "field_empty_pct": args.field_empty_pct,
+        "undeclared_pct": args.undeclared_pct,
+        "tag_min": args.tag_min,
+        "title_match": args.title_match,
+    }
+    skip = {folder.strip("/") for folder in args.skip if folder.strip("/")}
+    report = lint_vault(vault, args.scope, skip, thresholds)
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return
+    print_summary(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -101,9 +101,10 @@ DUP_CANDIDATE_FLOOR = 0.6
 # embed, not a note relationship — unless a note of that exact name exists
 # (`[[Node.js]]` is a note when Node.js.md is).
 EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]+$")
-# A log token names a file when it has no whitespace and ends in an extension
-# that starts with a letter (`Raw/recording.mp3`, `note.md`; not `v1.2`).
-FILE_TOKEN_RE = re.compile(r"^\S+\.[A-Za-z][A-Za-z0-9]{0,9}$")
+# A log token (one pipe-delimited field) names a file when it ends in an
+# extension that starts with a letter (`Raw/recording.mp3`, `Wiki/My Note.md`;
+# not `bump to v1.2`).
+FILE_TOKEN_RE = re.compile(r"^\S.*\.[A-Za-z][A-Za-z0-9]{0,9}$")
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 TAXONOMY_HEADING_RE = re.compile(r"^##\s+.*\btaxonomy\b", re.IGNORECASE)

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -18,7 +18,10 @@ the auditor reads before acting on:
      the types declared below>`) declares nothing. A note is measured against
      the variant whose fields it carries most of, so a field only one variant
      declares is `expected` of the notes fitting that variant, not of every
-     note of the type.
+     note of the type. A variant fence that declares a `tags:` value names its
+     discriminator: a note carrying that tag fits the variant whatever fields
+     it lacks — that is how a paper missing every paper field is still measured
+     as a paper rather than passing as a generic Source.
   3. Link graph from [[wikilinks]] over the whole vault: inbound / outbound per
      in-scope note, and the orphans (zero of each). Embeds of non-note files
      (`![[image.png]]`) are not links.
@@ -28,8 +31,8 @@ the auditor reads before acting on:
      The file hashed is the `source_url` target when that is a file inside the
      vault; otherwise a Raw Source note (`sha256`, no `type:`) hashes its own
      body, and a typed note hashes the one Raw Source note its body wikilinks.
-     A typed note with neither is `unresolved`: its original is remote, and
-     nothing in the vault stands in for it.
+     A typed note with neither is `unresolved`, whether or not it stores a
+     digest: its original is remote, and nothing in the vault stands in for it.
   5. `log.md` entries naming files that do not exist anywhere in the vault.
   6. Frontmatter tag counts, each marked `declared` when the tag or its top-level
      segment is a backticked list item under SCHEMA.md's `## Tag Taxonomy`;
@@ -154,6 +157,16 @@ def is_empty(value) -> bool:
     return value == "" or value == [] or value == {}
 
 
+def note_tags(fm: dict | None) -> list[str]:
+    """The note's frontmatter tags as bare strings (inline, block, or comma/space-separated)."""
+    tags = (fm or {}).get("tags", [])
+    if isinstance(tags, str):
+        tags = [t for t in re.split(r"[,\s]+", tags) if t]
+    elif isinstance(tags, dict):
+        tags = list(tags)
+    return [tag.lstrip("#") for tag in tags if isinstance(tag, str) and tag]
+
+
 def note_type(fm: dict | None) -> str | None:
     """The note's `type:` when it is a non-empty string; None for an untyped note."""
     value = fm.get("type") if fm else None
@@ -240,18 +253,19 @@ def select_scope(notes: list[dict], scope: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def declared_fields(vault: Path) -> dict[str, list[set[str]]] | None:
-    """Per type, one field set per variant SCHEMA.md declares; None without a SCHEMA.md.
+def declared_fields(vault: Path) -> dict[str, list[dict]] | None:
+    """Per type, one variant per fence SCHEMA.md declares; None without a SCHEMA.md.
 
     A fence naming several types is a base shared by every variant of each; a
-    fence naming one type is a variant. A type with no fence of its own has its
-    base as the single variant.
+    fence naming one type is a variant, with `fields` (its keys plus the base)
+    and `tags` (the tags its `tags:` value lists — the variant's discriminator).
+    A type with no fence of its own has its base as the single variant.
     """
     schema = vault / SCHEMA_FILE
     if not schema.is_file():
         return None
     base: dict[str, set[str]] = defaultdict(set)
-    variants: dict[str, list[set[str]]] = defaultdict(list)
+    variants: dict[str, list[dict]] = defaultdict(list)
     for fence in yaml_fences(read_text(schema)):
         lines = [line for line in fence.split("\n") if line.strip() != "---"]
         fm = parse_frontmatter("\n".join(lines))
@@ -261,13 +275,24 @@ def declared_fields(vault: Path) -> dict[str, list[set[str]]] | None:
         names = [n for n in (part.strip() for part in type_value.split("|")) if TYPE_NAME_RE.match(n)]
         for name in names:
             if len(names) == 1:
-                variants[name].append(set(fm.keys()))
+                variants[name].append({"fields": set(fm.keys()), "tags": set(note_tags(fm))})
             else:
                 base[name].update(fm.keys())
     return {
-        name: [base[name] | fields for fields in variants[name]] or [base[name]]
+        name: [{"fields": base[name] | v["fields"], "tags": v["tags"]} for v in variants[name]]
+        or [{"fields": base[name], "tags": set()}]
         for name in sorted(set(base) | set(variants))
     }
+
+
+def _fit(fm: dict, variants: list[dict]) -> int:
+    """Index of the variant a note fits: a discriminator tag it carries wins, then the most
+    declared fields it carries, then the earlier (generic) fence."""
+    tags = set(note_tags(fm)) | {tag.rsplit("/", 1)[-1] for tag in note_tags(fm)}
+    return max(
+        range(len(variants)),
+        key=lambda i: (bool(variants[i]["tags"] & tags), len(variants[i]["fields"] & fm.keys()), -i),
+    )
 
 
 def declared_tags(vault: Path) -> list[str]:
@@ -306,21 +331,19 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
     for type_name, fms in sorted(by_type.items()):
         total = len(fms)
         variants = declared.get(type_name) if declared is not None else None
-        decl = set().union(*variants) if variants else None
+        decl = set().union(*(v["fields"] for v in variants)) if variants else None
         observed = set().union(*(fm.keys() for fm in fms))
-        # Each note is measured against the variant whose fields it carries most
-        # of (ties go to the earlier fence, the generic one). A field every
+        # Each note is measured against the variant it fits (_fit). A field every
         # variant declares — or none — is expected of every note; a field only
         # some variants declare is expected of the notes fitting them, plus any
         # note carrying it anyway.
-        fits = [
-            max(range(len(variants)), key=lambda i, fm=fm: (len(variants[i] & fm.keys()), -i))
-            for fm in fms
-        ] if variants else []
+        fits = [_fit(fm, variants) for fm in fms] if variants else []
         fields = {}
         for field in sorted(observed | (decl or set())):
-            if variants and any(field not in v for v in variants) and field in decl:
-                expected = [fm for i, fm in zip(fits, fms) if field in variants[i] or field in fm]
+            if variants and any(field not in v["fields"] for v in variants) and field in decl:
+                expected = [
+                    fm for i, fm in zip(fits, fms) if field in variants[i]["fields"] or field in fm
+                ]
             else:
                 expected = fms
             if not expected:
@@ -352,6 +375,7 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
             "notes": total,
             "declared": sorted(decl) if decl is not None else None,
             "variants": len(variants) if variants else 0,
+            "variant_notes": [fits.count(i) for i in range(len(variants))] if variants else [],
             "fields": fields,
             "undeclared": undeclared,
         }
@@ -453,10 +477,10 @@ def raw_source_facts(scoped: list[dict], vault: Path, files: dict[str, Path]) ->
             hashed_file, recomputed = note["rel"], sha256_body(note["body"])
         else:
             hashed_file, recomputed = None, None
-        if not stored:
-            status = "unhashed"
-        elif recomputed is None:
+        if recomputed is None:
             status = "unresolved"
+        elif not stored:
+            status = "unhashed"
         else:
             status = "fresh" if stored == recomputed else "drift"
         out.append(
@@ -495,14 +519,7 @@ def tag_facts(scoped: list[dict], declared: list[str], tag_min) -> dict:
     """Tag counts; `exceeds` only for a tag outside the taxonomy (top-level segment undeclared)."""
     counts: Counter = Counter()
     for note in scoped:
-        tags = (note["fm"] or {}).get("tags", [])
-        if isinstance(tags, str):
-            tags = [t for t in re.split(r"[,\s]+", tags) if t]
-        elif isinstance(tags, dict):
-            tags = list(tags)
-        for tag in tags:
-            if isinstance(tag, str) and tag:
-                counts[tag.lstrip("#")] += 1
+        counts.update(note_tags(note["fm"]))
     out = {}
     for tag, n in sorted(counts.items()):
         is_declared = tag in declared or tag.split("/", 1)[0] in declared

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -29,7 +29,8 @@ the auditor reads before acting on:
      extension other than `.md` is an attachment embed (`![[image.png]]`,
      `![[clip.mp4]]`), not a link, unless a note of that exact name exists.
      Raw Source captures are not in the graph: a `[[link]]` inside captured
-     text is the source's, not the vault's.
+     text is the source's, not the vault's, and a typed note's provenance link
+     to its capture (`[[Raw/...]]`) is not a wiki relationship.
   4. Raw Source sha256 drift per raw-sources.md: strip the frontmatter, normalize
      line endings to `\\n`, sha256 the UTF-8 bytes of what follows the closing
      fence line. A note carries a hash when its frontmatter has a `sha256` key.
@@ -97,7 +98,7 @@ DUP_CANDIDATE_FLOOR = 0.6
 # A link target with an explicit extension other than .md is an attachment
 # embed, not a note relationship — unless a note of that exact name exists
 # (`[[Node.js]]` is a note when Node.js.md is).
-EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]{1,8}$")
+EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]+$")
 FILE_TOKEN_RE = re.compile(r"\.(md|pdf|png|jpe?g|gif|svg|html|canvas)$", re.IGNORECASE)
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -305,11 +306,15 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
     return types, untyped
 
 
-def link_facts(notes: list[dict], scoped: list[dict]) -> dict:
+def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
+    """Link graph over the wiki-layer `notes`; a link to one of the `raw` captures is
+    provenance, not a relationship, and counts for neither side."""
     by_rel = {note["rel"] for note in notes}
     by_stem: dict[str, list[str]] = defaultdict(list)
     for note in notes:
         by_stem[Path(note["rel"]).stem.lower()].append(note["rel"])
+    raw_rels = {note["rel"] for note in raw}
+    raw_stems = {Path(note["rel"]).stem.lower() for note in raw}
 
     def resolve(target: str) -> str | None:
         # A link with a path resolves by that path only; a bare name by basename.
@@ -323,14 +328,20 @@ def link_facts(notes: list[dict], scoped: list[dict]) -> dict:
         ext = EXTENSION_RE.search(target)
         return bool(ext) and ext.group(0).lower() != ".md" and resolve(target) is None
 
+    def is_raw_capture(target: str) -> bool:
+        name = target[:-3] if target.endswith(".md") else target
+        if "/" in name:
+            return f"{name}.md" in raw_rels
+        return name.lower() in raw_stems and resolve(target) is None
+
     outbound: dict[str, int] = {}
     inbound: Counter = Counter()
     for note in notes:
         targets = set()
         for match in WIKILINK_RE.finditer(strip_code(note["text"])):
-            raw = match.group(1).strip()
-            if raw and not is_attachment(raw):
-                targets.add(raw)
+            target = match.group(1).strip()
+            if target and not is_attachment(target) and not is_raw_capture(target):
+                targets.add(target)
         resolved = {resolve(raw) for raw in targets}
         outbound[note["rel"]] = len(targets) - (1 if note["rel"] in resolved else 0)
         for rel in resolved - {None, note["rel"]}:
@@ -519,7 +530,7 @@ def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dic
         },
         "untyped": untyped,
         "types": types,
-        "links": link_facts(wiki, scoped),
+        "links": link_facts(wiki, scoped, raw),
         "raw_sources": raw_source_facts(scoped + raw, vault, files),
         "log": log_facts(vault, files),
         "tags": tag_facts(scoped, taxonomy, thresholds["tag_min"]),

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -25,7 +25,9 @@ the auditor reads before acting on:
      it lacks — that is how a paper missing every paper field is still measured
      as a paper rather than passing as a generic Source.
   3. Link graph from [[wikilinks]] over the wiki layer: inbound / outbound per
-     in-scope note, and the orphans (zero of each). A target with an explicit
+     in-scope note, and the orphans (zero of each). A bare `[[name]]` shared by
+     several notes resolves to the one in the linking note's folder, else stays
+     unresolved (it still counts as outbound). A target with an explicit
      extension other than `.md` is an attachment embed (`![[image.png]]`,
      `![[clip.mp4]]`), not a link, unless a note of that exact name exists.
      Raw Source captures are not in the graph: a `[[link]]` inside captured
@@ -316,13 +318,20 @@ def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
     raw_rels = {note["rel"] for note in raw}
     raw_stems = {Path(note["rel"]).stem.lower() for note in raw}
 
-    def resolve(target: str) -> str | None:
-        # A link with a path resolves by that path only; a bare name by basename.
+    def resolve(target: str, source: str = "") -> str | None:
+        # A link with a path resolves by that path only. A bare name resolves by
+        # basename; when several notes share it, the one in the source note's
+        # own folder wins, and otherwise the link stays unresolved rather than
+        # being handed to whichever note sorts first (search-strategies.md:
+        # an ambiguous match is left unresolved).
         name = target[:-3] if target.endswith(".md") else target
         if "/" in name:
             return f"{name}.md" if f"{name}.md" in by_rel else None
-        hits = by_stem.get(name.lower())
-        return hits[0] if hits else None
+        hits = by_stem.get(name.lower(), [])
+        if len(hits) == 1:
+            return hits[0]
+        same_folder = [rel for rel in hits if Path(rel).parent == Path(source).parent]
+        return same_folder[0] if len(same_folder) == 1 else None
 
     def is_attachment(target: str) -> bool:
         ext = EXTENSION_RE.search(target)
@@ -342,7 +351,7 @@ def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
             target = match.group(1).strip()
             if target and not is_attachment(target) and not is_raw_capture(target):
                 targets.add(target)
-        resolved = {resolve(raw) for raw in targets}
+        resolved = {resolve(target, note["rel"]) for target in targets}
         outbound[note["rel"]] = len(targets) - (1 if note["rel"] in resolved else 0)
         for rel in resolved - {None, note["rel"]}:
             inbound[rel] += 1

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -340,10 +340,12 @@ def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
         return bool(ext) and ext.group(0).lower() != ".md" and resolve(target, source) is None
 
     def is_raw_capture(target: str, source: str) -> bool:
+        # Provenance is a link that can only mean a capture: by path, or by a
+        # bare name no wiki note has. An ambiguous wiki name stays a wiki link.
         name = target[:-3] if target.endswith(".md") else target
         if "/" in name:
             return f"{name}.md" in raw_rels
-        return name.lower() in raw_stems and resolve(target, source) is None
+        return name.lower() in raw_stems and name.lower() not in by_stem
 
     outbound: dict[str, int] = {}
     inbound: Counter = Counter()

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -12,8 +12,13 @@ the auditor reads before acting on:
   2. `type:` presence; per-type field fill counts and undeclared-field counts.
      Declared fields come from the top-level yaml fences in `<vault>/SCHEMA.md`
      (a fence nested inside another fence is an illustration). A fence whose
-     `type:` lists several names (`source | entity`) declares for each; a
-     placeholder name (`<one of the types declared below>`) declares nothing.
+     `type:` lists several names (`source | entity`) is a base every note of
+     those types carries; each fence naming one type is a variant of it (the
+     llm-wiki Source and its Paper variant), and a placeholder name (`<one of
+     the types declared below>`) declares nothing. A note is measured against
+     the variant whose fields it carries most of, so a field only one variant
+     declares is `expected` of the notes fitting that variant, not of every
+     note of the type.
   3. Link graph from [[wikilinks]] over the whole vault: inbound / outbound per
      in-scope note, and the orphans (zero of each). Embeds of non-note files
      (`![[image.png]]`) are not links.
@@ -235,22 +240,34 @@ def select_scope(notes: list[dict], scope: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def declared_fields(vault: Path) -> dict[str, set[str]] | None:
-    """Fields each type declares in SCHEMA.md's yaml fences; None without a SCHEMA.md."""
+def declared_fields(vault: Path) -> dict[str, list[set[str]]] | None:
+    """Per type, one field set per variant SCHEMA.md declares; None without a SCHEMA.md.
+
+    A fence naming several types is a base shared by every variant of each; a
+    fence naming one type is a variant. A type with no fence of its own has its
+    base as the single variant.
+    """
     schema = vault / SCHEMA_FILE
     if not schema.is_file():
         return None
-    declared: dict[str, set[str]] = defaultdict(set)
+    base: dict[str, set[str]] = defaultdict(set)
+    variants: dict[str, list[set[str]]] = defaultdict(list)
     for fence in yaml_fences(read_text(schema)):
         lines = [line for line in fence.split("\n") if line.strip() != "---"]
         fm = parse_frontmatter("\n".join(lines))
         type_value = fm.get("type")
         if not isinstance(type_value, str):
             continue
-        for name in (part.strip() for part in type_value.split("|")):
-            if TYPE_NAME_RE.match(name):
-                declared[name].update(fm.keys())
-    return dict(declared)
+        names = [n for n in (part.strip() for part in type_value.split("|")) if TYPE_NAME_RE.match(n)]
+        for name in names:
+            if len(names) == 1:
+                variants[name].append(set(fm.keys()))
+            else:
+                base[name].update(fm.keys())
+    return {
+        name: [base[name] | fields for fields in variants[name]] or [base[name]]
+        for name in sorted(set(base) | set(variants))
+    }
 
 
 def declared_tags(vault: Path) -> list[str]:
@@ -288,15 +305,32 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
     types = {}
     for type_name, fms in sorted(by_type.items()):
         total = len(fms)
-        decl = declared.get(type_name) if declared is not None else None
+        variants = declared.get(type_name) if declared is not None else None
+        decl = set().union(*variants) if variants else None
         observed = set().union(*(fm.keys() for fm in fms))
+        # Each note is measured against the variant whose fields it carries most
+        # of (ties go to the earlier fence, the generic one). A field every
+        # variant declares — or none — is expected of every note; a field only
+        # some variants declare is expected of the notes fitting them, plus any
+        # note carrying it anyway.
+        fits = [
+            max(range(len(variants)), key=lambda i, fm=fm: (len(variants[i] & fm.keys()), -i))
+            for fm in fms
+        ] if variants else []
         fields = {}
         for field in sorted(observed | (decl or set())):
-            present = sum(1 for fm in fms if field in fm)
-            filled = sum(1 for fm in fms if field in fm and not is_empty(fm[field]))
-            empty = total - filled
-            pct = round(100.0 * empty / total, 1)
+            if variants and any(field not in v for v in variants) and field in decl:
+                expected = [fm for i, fm in zip(fits, fms) if field in variants[i] or field in fm]
+            else:
+                expected = fms
+            if not expected:
+                continue
+            present = sum(1 for fm in expected if field in fm)
+            filled = sum(1 for fm in expected if field in fm and not is_empty(fm[field]))
+            empty = len(expected) - filled
+            pct = round(100.0 * empty / len(expected), 1)
             fields[field] = {
+                "expected": len(expected),
                 "present": present,
                 "filled": filled,
                 "empty": empty,
@@ -317,6 +351,7 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
         types[type_name] = {
             "notes": total,
             "declared": sorted(decl) if decl is not None else None,
+            "variants": len(variants) if variants else 0,
             "fields": fields,
             "undeclared": undeclared,
         }

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -40,9 +40,13 @@ the auditor reads before acting on:
   7. Duplicate-title candidates (difflib ratio >= 0.6, or the --title-match
      value when lower) between in-scope notes and every other note.
 
-Scope: `recent:N` (default recent:50) takes the N most recently modified notes as
-subjects; the link graph, the file index, and duplicate comparison still cover
-the whole vault. `--skip <folder>` drops a folder from the note set (plugin-
+Scope: `recent:N` (default recent:50) takes the N most recently modified
+wiki-layer notes as subjects; the link graph, the file index, and duplicate
+comparison still cover the whole vault. Raw Source notes (`sha256`, no `type:`)
+are never subjects of the schema, link, tag, or title checks and are all
+drift-checked whatever the scope, so `Raw/` neither needs `--skip` nor eats
+into `recent:N`. A `[[wikilink]]` inside a fenced code block or inline code is
+an example, not a link. `--skip <folder>` drops a folder from the note set (plugin-
 managed folders, `_audits`, folders AGENTS.md declares out of scope). Dot-dirs,
 Excalidraw drawings (`excalidraw-plugin:` in frontmatter), and the root-level
 AGENTS.md / SCHEMA.md / CLAUDE.md / README.md / index.md / log.md are never notes.
@@ -71,6 +75,7 @@ from vault_frontmatter import (
     parse_frontmatter,
     read_text,
     split_frontmatter,
+    strip_code,
     yaml_fences,
 )
 
@@ -87,6 +92,11 @@ TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 TAXONOMY_HEADING_RE = re.compile(r"^##\s+.*\btaxonomy\b", re.IGNORECASE)
 TAXONOMY_ITEM_RE = re.compile(r"^\s*[-*]\s+`#?([^`\s]+)`")
 LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]")
+
+
+def is_raw_source(fm: dict | None) -> bool:
+    """A Raw Source note to the script: carries `sha256` and no `type:`."""
+    return fm is not None and "sha256" in fm and note_type(fm) is None
 
 
 def exceeds(value: float, threshold: float | None) -> bool | None:
@@ -216,7 +226,7 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
         fm = note["fm"]
         type_value = note_type(fm)
         if type_value is None:
-            if fm is not None and "sha256" in fm:
+            if is_raw_source(fm):
                 # A Raw Source note: audit.md keeps it under the drift check
                 # (raw_source_facts) and out of schema compliance.
                 continue
@@ -296,7 +306,7 @@ def link_facts(notes: list[dict], scoped: list[dict]) -> dict:
     inbound: Counter = Counter()
     for note in notes:
         targets = set()
-        for match in WIKILINK_RE.finditer(note["text"]):
+        for match in WIKILINK_RE.finditer(strip_code(note["text"])):
             raw = match.group(1).strip()
             if raw and Path(raw).suffix.lower() not in NON_NOTE_EXTS:
                 targets.add(raw)
@@ -340,14 +350,13 @@ def _source_url_file(note: dict, files: dict[str, Path]) -> Path | None:
 def _linked_raw_source(note: dict, files: dict[str, Path], md_by_stem: dict) -> Path | None:
     """The Raw Source note (`sha256`, no `type:`) the body wikilinks — when it links exactly one."""
     hits: set[Path] = set()
-    for match in WIKILINK_RE.finditer(note["body"]):
+    for match in WIKILINK_RE.finditer(strip_code(note["body"])):
         target = match.group(1).strip()
         name = target[:-3] if target.endswith(".md") else target
         rels = [f"{name}.md"] if f"{name}.md" in files else md_by_stem.get(Path(name).name.lower(), [])
         for rel in rels:
             fm_text, _ = split_frontmatter(read_text(files[rel]))
-            fm = parse_frontmatter(fm_text) if fm_text is not None else None
-            if fm is not None and "sha256" in fm and note_type(fm) is None:
+            if is_raw_source(parse_frontmatter(fm_text) if fm_text is not None else None):
                 hits.add(files[rel])
     return hits.pop() if len(hits) == 1 else None
 
@@ -464,7 +473,9 @@ def duplicate_title_facts(notes: list[dict], scoped: list[dict], title_match) ->
 
 def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dict:
     notes, files = collect(vault, skip)
-    scoped = select_scope(notes, scope)
+    raw = [note for note in notes if is_raw_source(note["fm"])]
+    wiki = [note for note in notes if not is_raw_source(note["fm"])]
+    scoped = select_scope(wiki, scope)
     declared = declared_fields(vault)
     taxonomy = declared_tags(vault)
     types, untyped = type_facts(
@@ -475,7 +486,7 @@ def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dic
         "scope": scope,
         "skipped": sorted(skip),
         "thresholds": thresholds,
-        "notes": {"total": len(notes), "in_scope": len(scoped)},
+        "notes": {"total": len(wiki), "raw_sources": len(raw), "in_scope": len(scoped)},
         "schema": {
             "path": SCHEMA_FILE if declared is not None else None,
             "declared_types": sorted(declared) if declared else [],
@@ -484,10 +495,10 @@ def lint_vault(vault: Path, scope: str, skip: set[str], thresholds: dict) -> dic
         "untyped": untyped,
         "types": types,
         "links": link_facts(notes, scoped),
-        "raw_sources": raw_source_facts(scoped, vault, files),
+        "raw_sources": raw_source_facts(scoped + raw, vault, files),
         "log": log_facts(vault, files),
         "tags": tag_facts(scoped, taxonomy, thresholds["tag_min"]),
-        "duplicate_titles": duplicate_title_facts(notes, scoped, thresholds["title_match"]),
+        "duplicate_titles": duplicate_title_facts(wiki, scoped, thresholds["title_match"]),
     }
 
 
@@ -507,7 +518,7 @@ def print_summary(report: dict) -> None:
     schema = report["schema"]
     print(
         f"Vault: {report['vault']}  scope: {report['scope']} "
-        f"({notes['in_scope']} of {notes['total']} notes)"
+        f"({notes['in_scope']} of {notes['total']} wiki notes, {notes['raw_sources']} Raw Sources)"
     )
     print(f"Schema: {schema['path'] or 'none'}  types: {', '.join(schema['declared_types']) or '-'}")
     for name, facts in report["types"].items():

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -101,7 +101,9 @@ DUP_CANDIDATE_FLOOR = 0.6
 # embed, not a note relationship — unless a note of that exact name exists
 # (`[[Node.js]]` is a note when Node.js.md is).
 EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]+$")
-FILE_TOKEN_RE = re.compile(r"\.(md|pdf|png|jpe?g|gif|svg|html|canvas)$", re.IGNORECASE)
+# A log token names a file when it has no whitespace and ends in an extension
+# that starts with a letter (`Raw/recording.mp3`, `note.md`; not `v1.2`).
+FILE_TOKEN_RE = re.compile(r"^\S+\.[A-Za-z][A-Za-z0-9]{0,9}$")
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 TAXONOMY_HEADING_RE = re.compile(r"^##\s+.*\btaxonomy\b", re.IGNORECASE)
@@ -333,15 +335,15 @@ def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
         same_folder = [rel for rel in hits if Path(rel).parent == Path(source).parent]
         return same_folder[0] if len(same_folder) == 1 else None
 
-    def is_attachment(target: str) -> bool:
+    def is_attachment(target: str, source: str) -> bool:
         ext = EXTENSION_RE.search(target)
-        return bool(ext) and ext.group(0).lower() != ".md" and resolve(target) is None
+        return bool(ext) and ext.group(0).lower() != ".md" and resolve(target, source) is None
 
-    def is_raw_capture(target: str) -> bool:
+    def is_raw_capture(target: str, source: str) -> bool:
         name = target[:-3] if target.endswith(".md") else target
         if "/" in name:
             return f"{name}.md" in raw_rels
-        return name.lower() in raw_stems and resolve(target) is None
+        return name.lower() in raw_stems and resolve(target, source) is None
 
     outbound: dict[str, int] = {}
     inbound: Counter = Counter()
@@ -349,7 +351,11 @@ def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
         targets = set()
         for match in WIKILINK_RE.finditer(strip_code(note["text"])):
             target = match.group(1).strip()
-            if target and not is_attachment(target) and not is_raw_capture(target):
+            if (
+                target
+                and not is_attachment(target, note["rel"])
+                and not is_raw_capture(target, note["rel"])
+            ):
                 targets.add(target)
         resolved = {resolve(target, note["rel"]) for target in targets}
         outbound[note["rel"]] = len(targets) - (1 if note["rel"] in resolved else 0)
@@ -458,7 +464,7 @@ def log_facts(vault: Path, files: dict[str, Path]) -> dict:
             entries += 1
         for part in line.split("|"):
             token = part.strip().strip("`")
-            if not FILE_TOKEN_RE.search(token):
+            if not FILE_TOKEN_RE.match(token):
                 continue
             if token in files or token.lstrip("./") in files:
                 continue

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -41,8 +41,10 @@ the auditor reads before acting on:
      body, and a typed note hashes the one Raw Source note its body wikilinks.
      A typed note with neither is `unresolved`, whether or not it stores a
      digest: its original is remote, and nothing in the vault stands in for it.
-  5. `log.md` entries naming files that do not exist anywhere in the vault
-     (a `query` entry's fields are a question, not a path, and are not checked).
+  5. `log.md` entries naming files that do not exist anywhere in the vault. A
+     field counts as a path when it ends in an extension and has no whitespace
+     before its first `/` (`Wiki/My Note.md`; a root note with spaces is logged
+     as `./My Note.md`); `query` and `schema` entries are free text, not checked.
   6. Frontmatter tag counts, each marked `declared` when the tag or its top-level
      segment is a backticked list item under SCHEMA.md's `## Tag Taxonomy`;
      `--tag-min` sets `exceeds` for undeclared tags only.
@@ -72,7 +74,6 @@ Output: JSON (--json) or a short text summary.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import re
 import sys
@@ -82,15 +83,16 @@ from pathlib import Path
 
 from vault_frontmatter import (
     is_empty,
+    is_raw_source,
     note_tags,
     note_type,
     parse_frontmatter,
     read_text,
     split_frontmatter,
-    strip_code,
     text_lines,
     yaml_fences,
 )
+from vault_links import link_facts, raw_source_facts
 
 NON_NOTE_ROOT_FILES = {"AGENTS.md", "SCHEMA.md", "CLAUDE.md", "README.md", "index.md", "log.md"}
 # The standard audit-report folder: every run writes a new report there, so
@@ -100,27 +102,25 @@ LOG_FILE = "log.md"
 SCHEMA_FILE = "SCHEMA.md"
 DUP_CANDIDATE_FLOOR = 0.6
 
-# A link target with an explicit extension other than .md is an attachment
-# embed, not a note relationship — unless a note of that exact name exists
-# (`[[Node.js]]` is a note when Node.js.md is).
-EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]+$")
-# A log token (one pipe-delimited field) names a file when it ends in an
-# extension that starts with a letter (`Raw/recording.mp3`, `Wiki/My Note.md`;
-# not `bump to v1.2`).
+# A log field names a file when it ends in a letter-led extension and reads as
+# a path: no whitespace at all, or none before its first `/` (`Raw/recording.mp3`,
+# `Wiki/My Note.md`; not `bump to v1.2`, not `updated SCHEMA.md`).
 FILE_TOKEN_RE = re.compile(r"^\S.*\.[A-Za-z][A-Za-z0-9]{0,9}$")
-WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 TAXONOMY_HEADING_RE = re.compile(r"^##\s+.*\btaxonomy\b", re.IGNORECASE)
 TAXONOMY_ITEM_RE = re.compile(r"^\s*[-*]\s+`#?([^`\s]+)`")
 LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]\s*([A-Za-z-]+)?")
 # Log entries whose fields are free text rather than a path (a question may end
 # in a filename without naming a file to check).
-FREE_TEXT_OPS = {"query"}
+FREE_TEXT_OPS = {"query", "schema"}
 
 
-def is_raw_source(fm: dict | None) -> bool:
-    """A Raw Source note to the script: carries `sha256` and no `type:`."""
-    return fm is not None and "sha256" in fm and note_type(fm) is None
+def is_path_token(token: str) -> bool:
+    """See FILE_TOKEN_RE: a letter-led extension, and no whitespace before the first `/`."""
+    if not FILE_TOKEN_RE.match(token):
+        return False
+    head = token.split("/", 1)[0] if "/" in token else token
+    return re.search(r"\s", head) is None
 
 
 def exceeds(value: float, threshold: float | None) -> bool | None:
@@ -331,177 +331,6 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
     return types, untyped
 
 
-def _frontmatter_values(value) -> list[str]:
-    """Every string inside a parsed frontmatter value (scalar, list, or mapping)."""
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [s for item in value for s in _frontmatter_values(item)]
-    if isinstance(value, dict):
-        return [s for item in value.values() for s in _frontmatter_values(item)]
-    return []
-
-
-def link_text(note: dict) -> str:
-    """What the graph scans: the body outside code, plus the parsed frontmatter
-    values — a `[[link]]` in a YAML comment is not a link."""
-    values = _frontmatter_values(note["fm"] or {})
-    return strip_code(note["body"]) + "\n" + "\n".join(values)
-
-
-def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
-    """Link graph over the wiki-layer `notes`; a link to one of the `raw` captures is
-    provenance, not a relationship, and counts for neither side."""
-    by_rel = {note["rel"] for note in notes}
-    by_stem: dict[str, list[str]] = defaultdict(list)
-    for note in notes:
-        by_stem[Path(note["rel"]).stem.lower()].append(note["rel"])
-    raw_rels = {note["rel"] for note in raw}
-    raw_stems = {Path(note["rel"]).stem.lower() for note in raw}
-
-    def resolve(target: str, source: str = "") -> str | None:
-        # A link with a path resolves by that path only. A bare name resolves by
-        # basename; when several notes share it, the one in the source note's
-        # own folder wins, and otherwise the link stays unresolved rather than
-        # being handed to whichever note sorts first (search-strategies.md:
-        # an ambiguous match is left unresolved).
-        name = target[:-3] if target.endswith(".md") else target
-        if "/" in name:
-            return f"{name}.md" if f"{name}.md" in by_rel else None
-        hits = by_stem.get(name.lower(), [])
-        if len(hits) == 1:
-            return hits[0]
-        same_folder = [rel for rel in hits if Path(rel).parent == Path(source).parent]
-        return same_folder[0] if len(same_folder) == 1 else None
-
-    def is_attachment(target: str, source: str) -> bool:
-        ext = EXTENSION_RE.search(target)
-        return bool(ext) and ext.group(0).lower() != ".md" and resolve(target, source) is None
-
-    def is_raw_capture(target: str, source: str) -> bool:
-        # Provenance is a link that can only mean a capture: by path, or by a
-        # bare name no wiki note has. An ambiguous wiki name stays a wiki link.
-        name = target[:-3] if target.endswith(".md") else target
-        if "/" in name:
-            return f"{name}.md" in raw_rels
-        return name.lower() in raw_stems and name.lower() not in by_stem
-
-    outbound: dict[str, int] = {}
-    inbound: Counter = Counter()
-    for note in notes:
-        targets = set()
-        for match in WIKILINK_RE.finditer(link_text(note)):
-            target = match.group(1).strip()
-            if (
-                target
-                and not is_attachment(target, note["rel"])
-                and not is_raw_capture(target, note["rel"])
-            ):
-                targets.add(target)
-        resolved = {resolve(target, note["rel"]) for target in targets}
-        # A link to the note itself, under any spelling, is not an outbound edge.
-        outbound[note["rel"]] = sum(1 for target in targets if resolve(target, note["rel"]) != note["rel"])
-        for rel in resolved - {None, note["rel"]}:
-            inbound[rel] += 1
-
-    per_note = {
-        note["rel"]: {"inbound": inbound[note["rel"]], "outbound": outbound[note["rel"]]}
-        for note in scoped
-    }
-    orphans = sorted(
-        rel for rel, counts in per_note.items() if not counts["inbound"] and not counts["outbound"]
-    )
-    return {"orphans": orphans, "notes": per_note}
-
-
-def sha256_body(body: str) -> str:
-    return hashlib.sha256(body.encode("utf-8")).hexdigest()
-
-
-def sha256_file(path: Path) -> str:
-    """A note's body digest per raw-sources.md; a non-note file's raw bytes."""
-    if path.suffix == ".md":
-        return sha256_body(split_frontmatter(read_text(path))[1])
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _source_url_file(note: dict, files: dict[str, Path]) -> Path | None:
-    """The vault file `source_url` names, when it names one (not a URL, not the note itself)."""
-    source_url = note["fm"].get("source_url")
-    if not isinstance(source_url, str) or not source_url or "://" in source_url:
-        return None
-    candidate = files.get(source_url.lstrip("/")) or files.get(
-        (Path(note["rel"]).parent / source_url).as_posix()
-    )
-    return candidate if candidate is not None and candidate != note["path"] else None
-
-
-def _linked_raw_source(note: dict, files: dict[str, Path], md_by_stem: dict) -> Path | None:
-    """The Raw Source note (`sha256`, no `type:`) the body wikilinks — when it links exactly one.
-    A link with a path resolves by that path only; a bare name by basename, and only
-    when every note of that name is a capture (a wiki note of the same name makes
-    the link a wiki relationship, not provenance)."""
-
-    def frontmatter_of(rel: str) -> dict | None:
-        fm_text, _ = split_frontmatter(read_text(files[rel]))
-        return parse_frontmatter(fm_text) if fm_text is not None else None
-
-    hits: set[Path] = set()
-    for match in WIKILINK_RE.finditer(strip_code(note["body"])):
-        target = match.group(1).strip()
-        name = target[:-3] if target.endswith(".md") else target
-        if "/" in name:
-            rels = [f"{name}.md"] if f"{name}.md" in files else []
-        else:
-            rels = md_by_stem.get(name.lower(), [])
-            if not all(is_raw_source(frontmatter_of(rel)) for rel in rels):
-                continue
-        for rel in rels:
-            if is_raw_source(frontmatter_of(rel)):
-                hits.add(files[rel])
-    return hits.pop() if len(hits) == 1 else None
-
-
-def raw_source_facts(scoped: list[dict], vault: Path, files: dict[str, Path]) -> list[dict]:
-    md_by_stem: dict[str, list[str]] = defaultdict(list)
-    for rel in files:
-        if rel.endswith(".md"):
-            md_by_stem[Path(rel).stem.lower()].append(rel)
-    out = []
-    for note in scoped:
-        fm = note["fm"]
-        if fm is None or "sha256" not in fm:
-            continue
-        stored = fm["sha256"] if isinstance(fm["sha256"], str) else ""
-        # The provenance pair: a typed note's digest is of the Raw Source it was
-        # ingested from, never of its own synthesized body.
-        target = _source_url_file(note, files)
-        if target is None and note_type(fm) is not None:
-            target = _linked_raw_source(note, files, md_by_stem)
-        if target is not None:
-            hashed_file, recomputed = target.relative_to(vault).as_posix(), sha256_file(target)
-        elif note_type(fm) is None:
-            hashed_file, recomputed = note["rel"], sha256_body(note["body"])
-        else:
-            hashed_file, recomputed = None, None
-        if recomputed is None:
-            status = "unresolved"
-        elif not stored:
-            status = "unhashed"
-        else:
-            status = "fresh" if stored == recomputed else "drift"
-        out.append(
-            {
-                "path": note["rel"],
-                "hashed_file": hashed_file,
-                "status": status,
-                "stored": stored,
-                "recomputed": recomputed,
-            }
-        )
-    return out
-
-
 def log_facts(vault: Path, files: dict[str, Path]) -> dict:
     log = vault / LOG_FILE
     if not log.is_file():
@@ -517,7 +346,7 @@ def log_facts(vault: Path, files: dict[str, Path]) -> dict:
                 continue
         for part in line.split("|"):
             token = part.strip().strip("`")
-            if not FILE_TOKEN_RE.match(token):
+            if not is_path_token(token):
                 continue
             if token in files or token.lstrip("./") in files:
                 continue

--- a/skills/core/maintaining-obsidian/references/lint_vault.py
+++ b/skills/core/maintaining-obsidian/references/lint_vault.py
@@ -41,7 +41,8 @@ the auditor reads before acting on:
      body, and a typed note hashes the one Raw Source note its body wikilinks.
      A typed note with neither is `unresolved`, whether or not it stores a
      digest: its original is remote, and nothing in the vault stands in for it.
-  5. `log.md` entries naming files that do not exist anywhere in the vault.
+  5. `log.md` entries naming files that do not exist anywhere in the vault
+     (a `query` entry's fields are a question, not a path, and are not checked).
   6. Frontmatter tag counts, each marked `declared` when the tag or its top-level
      segment is a backticked list item under SCHEMA.md's `## Tag Taxonomy`;
      `--tag-min` sets `exceeds` for undeclared tags only.
@@ -111,7 +112,10 @@ WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 TAXONOMY_HEADING_RE = re.compile(r"^##\s+.*\btaxonomy\b", re.IGNORECASE)
 TAXONOMY_ITEM_RE = re.compile(r"^\s*[-*]\s+`#?([^`\s]+)`")
-LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]")
+LOG_ENTRY_RE = re.compile(r"^\s*(?:#+\s*|-\s*)?\[\d{4}-\d{2}-\d{2}\]\s*([A-Za-z-]+)?")
+# Log entries whose fields are free text rather than a path (a question may end
+# in a filename without naming a file to check).
+FREE_TEXT_OPS = {"query"}
 
 
 def is_raw_source(fm: dict | None) -> bool:
@@ -327,6 +331,24 @@ def type_facts(scoped: list[dict], declared, field_empty_pct, undeclared_pct) ->
     return types, untyped
 
 
+def _frontmatter_values(value) -> list[str]:
+    """Every string inside a parsed frontmatter value (scalar, list, or mapping)."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [s for item in value for s in _frontmatter_values(item)]
+    if isinstance(value, dict):
+        return [s for item in value.values() for s in _frontmatter_values(item)]
+    return []
+
+
+def link_text(note: dict) -> str:
+    """What the graph scans: the body outside code, plus the parsed frontmatter
+    values — a `[[link]]` in a YAML comment is not a link."""
+    values = _frontmatter_values(note["fm"] or {})
+    return strip_code(note["body"]) + "\n" + "\n".join(values)
+
+
 def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
     """Link graph over the wiki-layer `notes`; a link to one of the `raw` captures is
     provenance, not a relationship, and counts for neither side."""
@@ -368,7 +390,7 @@ def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
     inbound: Counter = Counter()
     for note in notes:
         targets = set()
-        for match in WIKILINK_RE.finditer(strip_code(note["text"])):
+        for match in WIKILINK_RE.finditer(link_text(note)):
             target = match.group(1).strip()
             if (
                 target
@@ -488,8 +510,11 @@ def log_facts(vault: Path, files: dict[str, Path]) -> dict:
     entries = 0
     missing = []
     for line_no, line in enumerate(read_text(log).split("\n"), 1):
-        if LOG_ENTRY_RE.match(line):
+        entry = LOG_ENTRY_RE.match(line)
+        if entry:
             entries += 1
+            if (entry.group(1) or "").lower() in FREE_TEXT_OPS:
+                continue
         for part in line.split("|"):
             token = part.strip().strip("`")
             if not FILE_TOKEN_RE.match(token):

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -14,6 +14,7 @@ import re
 from pathlib import Path
 
 KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
+HEADING_RE = re.compile(r"^#{1,6}\s+(.*\S)")
 # A fence delimiter may be indented by at most three spaces (CommonMark); four
 # is an indented code block whose backticks are literal text.
 FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(\S*)")
@@ -135,17 +136,23 @@ def _walk_fences(text: str):
             yield "body", info, line
 
 
-def yaml_fences(text: str) -> list[str]:
-    """Bodies of the top-level ```yaml fences (see _walk_fences for nesting)."""
-    fences: list[str] = []
+def yaml_fences(text: str) -> list[tuple[str, str]]:
+    """(heading, body) per top-level ```yaml fence — the heading is the nearest one
+    above the fence, "" before any (see _walk_fences for nesting)."""
+    fences: list[tuple[str, str]] = []
+    heading = ""
     buf: list[str] = []
     for state, info, line in _walk_fences(text):
-        if state == "open":
+        if state == "text":
+            match = HEADING_RE.match(line)
+            if match:
+                heading = match.group(1)
+        elif state == "open":
             buf = []
         elif state == "body":
             buf.append(line)
         elif state == "close" and info in ("yaml", "yml"):
-            fences.append("\n".join(buf))
+            fences.append((heading, "\n".join(buf)))
     return fences
 
 

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -1,0 +1,122 @@
+"""Frontmatter and YAML-fence parsing for lint_vault.py.
+
+Reads a note as UTF-8 with line endings normalized, splits its frontmatter from
+its body, and parses the frontmatter as a block: inline values, inline lists,
+block lists (indented or at column 0), and one-level nested mappings. Also
+extracts the top-level ```yaml fences of a SCHEMA.md. Stdlib only; imported by
+lint_vault.py in this directory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
+
+
+def read_text(path: Path) -> str:
+    """Read as UTF-8 with line endings normalized to \\n."""
+    return path.read_bytes().decode("utf-8", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+
+
+def split_frontmatter(text: str) -> tuple[str | None, str]:
+    """Return (frontmatter text, body). Frontmatter is None when the note has none."""
+    if not text.startswith("---\n"):
+        return None, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        if text.endswith("\n---"):
+            return text[4:-4], ""
+        return None, text
+    return text[4:end], text[end + 5 :]
+
+
+def _scalar(raw: str):
+    """Parse one inline YAML value: quoted string, inline list, empty, or bare."""
+    value = raw.strip()
+    if value[:1] in ("'", '"'):
+        close = value.find(value[0], 1)
+        return value[1:close] if close != -1 else value[1:]
+    value = re.split(r"\s+#", value, maxsplit=1)[0].strip()
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        return [_scalar(item) for item in inner.split(",")] if inner else []
+    if value in ("", "null", "~"):
+        return ""
+    return value
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Parse a frontmatter block. Block lists and nested mappings are read whole."""
+    data: dict = {}
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines):
+        match = KEY_RE.match(lines[i])
+        i += 1
+        if not match:
+            continue
+        key, rest = match.group(1), match.group(2)
+        if rest.strip() and not rest.strip().startswith("#"):
+            data[key] = _scalar(rest)
+            continue
+        block: list[str] = []
+        while i < len(lines) and (
+            not lines[i].strip()
+            or lines[i][:1] in (" ", "\t")
+            or lines[i] == "-"
+            or lines[i].startswith("- ")
+        ):
+            if lines[i].strip():
+                block.append(lines[i].strip())
+            i += 1
+        if not block:
+            data[key] = ""
+        elif all(item == "-" or item.startswith("- ") for item in block):
+            data[key] = [_scalar(item[1:]) for item in block]
+        else:
+            data[key] = {
+                item.split(":", 1)[0].strip(): _scalar(item.split(":", 1)[1]) if ":" in item else ""
+                for item in block
+            }
+    return data
+
+
+def is_empty(value) -> bool:
+    return value == "" or value == [] or value == {}
+
+
+def note_tags(fm: dict | None) -> list[str]:
+    """The note's frontmatter tags as bare strings (inline, block, or comma/space-separated)."""
+    tags = (fm or {}).get("tags", [])
+    if isinstance(tags, str):
+        tags = [t for t in re.split(r"[,\s]+", tags) if t]
+    elif isinstance(tags, dict):
+        tags = list(tags)
+    return [tag.lstrip("#") for tag in tags if isinstance(tag, str) and tag]
+
+
+def note_type(fm: dict | None) -> str | None:
+    """The note's `type:` when it is a non-empty string; None for an untyped note."""
+    value = fm.get("type") if fm else None
+    return value if isinstance(value, str) and value else None
+
+
+def yaml_fences(text: str) -> list[str]:
+    """Bodies of the top-level ```yaml fences. A ```yaml line inside an open fence is content."""
+    fences: list[str] = []
+    info: str | None = None
+    buf: list[str] = []
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if info is None:
+            if stripped.startswith("```"):
+                info, buf = stripped[3:].strip().lower(), []
+        elif stripped == "```":
+            if info in ("yaml", "yml"):
+                fences.append("\n".join(buf))
+            info = None
+        else:
+            buf.append(line)
+    return fences

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -4,8 +4,9 @@ Reads a note as UTF-8 with line endings normalized, splits its frontmatter from
 its body, and parses the frontmatter as a block: inline values, inline lists,
 block lists (indented or at column 0), and one-level nested mappings. Also
 extracts the top-level ```yaml fences of a SCHEMA.md, and masks fenced code
-blocks and inline code so a literal `[[link]]` shown as an example is not a
-link. Stdlib only; imported by lint_vault.py in this directory.
+blocks, inline code, and Obsidian / HTML comments so a literal `[[link]]` shown
+as an example or hidden in a comment is not a link. Stdlib only; imported by
+lint_vault.py in this directory.
 """
 
 from __future__ import annotations
@@ -24,6 +25,9 @@ FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(\S*)")
 # length: `a`, ``a ` b``, ```a``` — never a run of another length. It may cross
 # a line break but not a blank line (a paragraph end).
 INLINE_CODE_RE = re.compile(r"(?<!`)(`+)(?!`)((?:(?!\n\n)[\s\S])+?)(?<!`)\1(?!`)")
+# Obsidian comments (`%% hidden %%`) and HTML comments are not rendered, so a
+# [[link]] inside one is not a link.
+COMMENT_RE = re.compile(r"%%.*?%%|<!--.*?-->", re.DOTALL)
 
 
 def read_text(path: Path) -> str:
@@ -201,5 +205,6 @@ def text_lines(text: str) -> list[str]:
 
 
 def strip_code(text: str) -> str:
-    """The text with fenced code blocks and inline code spans removed."""
-    return INLINE_CODE_RE.sub("", "\n".join(text_lines(text)))
+    """The text with fenced code blocks, inline code spans, and Obsidian / HTML
+    comments removed."""
+    return COMMENT_RE.sub("", INLINE_CODE_RE.sub("", "\n".join(text_lines(text))))

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -79,7 +79,8 @@ def parse_frontmatter(text: str) -> dict:
             or lines[i] == "-"
             or lines[i].startswith("- ")
         ):
-            if lines[i].strip():
+            # A comment-only line is neither a list item nor a mapping entry.
+            if lines[i].strip() and not lines[i].strip().startswith("#"):
                 block.append(lines[i].strip())
             i += 1
         if not block:
@@ -139,7 +140,13 @@ def _walk_fences(text: str):
             else:
                 yield "text", "", line, False
             continue
-        inner = line[len(prefix):] if line.startswith(prefix) else line
+        # Inside a quoted fence each line carries its own `>` run; strip that
+        # line's prefix, not the opener's (`> ```yaml` may close as `>```` `).
+        if prefix:
+            quoted = QUOTE_PREFIX_RE.match(line)
+            inner = line[quoted.end():] if quoted else line
+        else:
+            inner = line
         if re.fullmatch(rf" {{0,3}}{re.escape(marker[0])}{{{len(marker)},}}\s*", inner):
             yield "close", info, line, bool(prefix)
             marker = None

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -19,8 +19,9 @@ HEADING_RE = re.compile(r"^#{1,6}\s+(.*\S)")
 # is an indented code block whose backticks are literal text.
 FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(\S*)")
 # A code span opens with a run of backticks and closes with a run of the same
-# length: `a`, ``a ` b``, ```a``` — never a run of another length.
-INLINE_CODE_RE = re.compile(r"(?<!`)(`+)(?!`)([^\n]+?)(?<!`)\1(?!`)")
+# length: `a`, ``a ` b``, ```a``` — never a run of another length. It may cross
+# a line break but not a blank line (a paragraph end).
+INLINE_CODE_RE = re.compile(r"(?<!`)(`+)(?!`)((?:(?!\n\n)[\s\S])+?)(?<!`)\1(?!`)")
 
 
 def read_text(path: Path) -> str:

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -14,7 +14,7 @@ import re
 from pathlib import Path
 
 KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
-HEADING_RE = re.compile(r"^#{1,6}\s+(.*\S)")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*\S)")
 # A fence delimiter may be indented by at most three spaces (CommonMark); four
 # is an indented code block whose backticks are literal text. A fence inside a
 # blockquote or Obsidian callout carries the container's `> ` prefix.
@@ -115,8 +115,9 @@ def note_type(fm: dict | None) -> str | None:
 
 
 def _walk_fences(text: str):
-    """Yield (state, info, line) per line: `text` outside any fence; `open`, `body`,
-    `close` inside one. A fence closes only at a delimiter of its own character and
+    """Yield (state, info, line, quoted) per line: `text` outside any fence; `open`,
+    `body`, `close` inside one; `quoted` when the fence sits in a blockquote or
+    callout. A fence closes only at a delimiter of its own character and
     at least its own length (CommonMark), so a ```yaml inside a ```` illustration
     fence is body, the illustration's closer does not open a new fence, and a
     ``` fence closed by ```` ends where the longer delimiter is. A delimiter
@@ -134,39 +135,44 @@ def _walk_fences(text: str):
             match = FENCE_OPEN_RE.match(line[len(prefix):].rstrip())
             if match:
                 marker, info = match.group(1), match.group(2).lower()
-                yield "open", info, line
+                yield "open", info, line, bool(prefix)
             else:
-                yield "text", "", line
+                yield "text", "", line, False
             continue
         inner = line[len(prefix):] if line.startswith(prefix) else line
         if re.fullmatch(rf" {{0,3}}{re.escape(marker[0])}{{{len(marker)},}}\s*", inner):
-            yield "close", info, line
+            yield "close", info, line, bool(prefix)
             marker = None
         else:
-            yield "body", info, inner
+            yield "body", info, inner, bool(prefix)
 
 
 def yaml_fences(text: str) -> list[tuple[str, str]]:
-    """(heading, body) per top-level ```yaml fence — the heading is the nearest one
-    above the fence, "" before any (see _walk_fences for nesting)."""
+    """(headings, body) per top-level ```yaml fence. `headings` is the enclosing
+    heading path joined with " / " (`Source / Frontmatter`), "" before any. A
+    fence inside a blockquote or callout is an illustration and is not returned
+    (see _walk_fences for nesting)."""
     fences: list[tuple[str, str]] = []
-    heading = ""
+    stack: list[str] = []
     buf: list[str] = []
-    for state, info, line in _walk_fences(text):
+    for state, info, line, quoted in _walk_fences(text):
         if state == "text":
             match = HEADING_RE.match(line)
             if match:
-                heading = match.group(1)
+                level = len(match.group(1))
+                del stack[level - 1 :]
+                stack.extend([""] * (level - 1 - len(stack)))
+                stack.append(match.group(2))
         elif state == "open":
             buf = []
         elif state == "body":
             buf.append(line)
-        elif state == "close" and info in ("yaml", "yml"):
-            fences.append((heading, "\n".join(buf)))
+        elif state == "close" and info in ("yaml", "yml") and not quoted:
+            fences.append((" / ".join(h for h in stack if h), "\n".join(buf)))
     return fences
 
 
 def strip_code(text: str) -> str:
     """The text with fenced code blocks and inline code spans removed."""
-    kept = [line for state, _, line in _walk_fences(text) if state == "text"]
+    kept = [line for state, _, line, _ in _walk_fences(text) if state == "text"]
     return INLINE_CODE_RE.sub("", "\n".join(kept))

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -14,8 +14,12 @@ import re
 from pathlib import Path
 
 KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
-FENCE_OPEN_RE = re.compile(r"^(`{3,}|~{3,})\s*(\S*)")
-INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+# A fence delimiter may be indented by at most three spaces (CommonMark); four
+# is an indented code block whose backticks are literal text.
+FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(\S*)")
+# A code span opens with a run of backticks and closes with a run of the same
+# length: `a`, ``a ` b``, ```a``` — never a run of another length.
+INLINE_CODE_RE = re.compile(r"(?<!`)(`+)(?!`)([^\n]+?)(?<!`)\1(?!`)")
 
 
 def read_text(path: Path) -> str:
@@ -111,20 +115,20 @@ def _walk_fences(text: str):
     `close` inside one. A fence closes only at a delimiter of its own character and
     at least its own length (CommonMark), so a ```yaml inside a ```` illustration
     fence is body, the illustration's closer does not open a new fence, and a
-    ``` fence closed by ```` ends where the longer delimiter is.
+    ``` fence closed by ```` ends where the longer delimiter is. A delimiter
+    indented four spaces or more is literal text, not a fence.
     """
     marker: str | None = None
     info = ""
     for line in text.split("\n"):
-        stripped = line.strip()
         if marker is None:
-            match = FENCE_OPEN_RE.match(stripped)
+            match = FENCE_OPEN_RE.match(line.rstrip())
             if match:
                 marker, info = match.group(1), match.group(2).lower()
                 yield "open", info, line
             else:
                 yield "text", "", line
-        elif re.fullmatch(rf"{re.escape(marker[0])}{{{len(marker)},}}", stripped):
+        elif re.fullmatch(rf" {{0,3}}{re.escape(marker[0])}{{{len(marker)},}}\s*", line):
             yield "close", info, line
             marker = None
         else:

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -179,7 +179,11 @@ def yaml_fences(text: str) -> list[tuple[str, str]]:
     return fences
 
 
+def text_lines(text: str) -> list[str]:
+    """The lines outside every fence, inline code left in place."""
+    return [line for state, _, line, _ in _walk_fences(text) if state == "text"]
+
+
 def strip_code(text: str) -> str:
     """The text with fenced code blocks and inline code spans removed."""
-    kept = [line for state, _, line, _ in _walk_fences(text) if state == "text"]
-    return INLINE_CODE_RE.sub("", "\n".join(kept))
+    return INLINE_CODE_RE.sub("", "\n".join(text_lines(text)))

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -55,8 +55,10 @@ def _scalar(raw: str):
         return value[1:close] if close != -1 else value[1:]
     value = re.split(r"\s+#", value, maxsplit=1)[0].strip()
     if value.startswith("[") and value.endswith("]"):
+        # Flow list: a quoted item keeps its commas (`["[[Smith, John]]", b]`).
         inner = value[1:-1].strip()
-        return [_scalar(item) for item in inner.split(",")] if inner else []
+        items = re.findall(r"\"[^\"]*\"|'[^']*'|[^,]+", inner)
+        return [_scalar(item) for item in items if item.strip()] if inner else []
     if value in ("", "null", "~"):
         return ""
     return value

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -59,7 +59,8 @@ def _scalar(raw: str):
 
 
 def parse_frontmatter(text: str) -> dict:
-    """Parse a frontmatter block. Block lists and nested mappings are read whole."""
+    """Parse a frontmatter block. Block lists, nested mappings, and block scalars
+    (`key: |` / `key: >`) are read whole."""
     data: dict = {}
     lines = text.split("\n")
     i = 0
@@ -69,6 +70,16 @@ def parse_frontmatter(text: str) -> dict:
         if not match:
             continue
         key, rest = match.group(1), match.group(2)
+        indicator = rest.split("#", 1)[0].strip()
+        if indicator in ("|", "|-", "|+", ">", ">-", ">+"):
+            # A block scalar: the indented lines that follow are the value.
+            scalar: list[str] = []
+            while i < len(lines) and (not lines[i].strip() or lines[i][:1] in (" ", "\t")):
+                scalar.append(lines[i].strip())
+                i += 1
+            joiner = "\n" if indicator[0] == "|" else " "
+            data[key] = joiner.join(s for s in scalar if s).strip()
+            continue
         if rest.strip() and not rest.strip().startswith("#"):
             data[key] = _scalar(rest)
             continue

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -1,10 +1,11 @@
-"""Frontmatter and YAML-fence parsing for lint_vault.py.
+"""Frontmatter, fence, and code-span parsing for lint_vault.py.
 
 Reads a note as UTF-8 with line endings normalized, splits its frontmatter from
 its body, and parses the frontmatter as a block: inline values, inline lists,
 block lists (indented or at column 0), and one-level nested mappings. Also
-extracts the top-level ```yaml fences of a SCHEMA.md. Stdlib only; imported by
-lint_vault.py in this directory.
+extracts the top-level ```yaml fences of a SCHEMA.md, and masks fenced code
+blocks and inline code so a literal `[[link]]` shown as an example is not a
+link. Stdlib only; imported by lint_vault.py in this directory.
 """
 
 from __future__ import annotations
@@ -13,6 +14,9 @@ import re
 from pathlib import Path
 
 KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
+FENCE_OPEN_RE = re.compile(r"^(`{3,}|~{3,})\s*(\S*)")
+CODE_FENCE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[^\n]*\n.*?^[ \t]{0,3}\1[ \t]*$", re.MULTILINE | re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 
 
 def read_text(path: Path) -> str:
@@ -104,19 +108,32 @@ def note_type(fm: dict | None) -> str | None:
 
 
 def yaml_fences(text: str) -> list[str]:
-    """Bodies of the top-level ```yaml fences. A ```yaml line inside an open fence is content."""
+    """Bodies of the top-level ```yaml fences.
+
+    A fence closes only at a delimiter of its own character and at least its own
+    length (CommonMark), so a ```yaml inside a ```` illustration fence is content
+    and the illustration's own closer does not open a fence that swallows the
+    rest of the file.
+    """
     fences: list[str] = []
-    info: str | None = None
+    marker: str | None = None
+    info = ""
     buf: list[str] = []
     for line in text.split("\n"):
         stripped = line.strip()
-        if info is None:
-            if stripped.startswith("```"):
-                info, buf = stripped[3:].strip().lower(), []
-        elif stripped == "```":
+        if marker is None:
+            match = FENCE_OPEN_RE.match(stripped)
+            if match:
+                marker, info, buf = match.group(1), match.group(2).lower(), []
+        elif re.fullmatch(rf"{re.escape(marker[0])}{{{len(marker)},}}", stripped):
             if info in ("yaml", "yml"):
                 fences.append("\n".join(buf))
-            info = None
+            marker = None
         else:
             buf.append(line)
     return fences
+
+
+def strip_code(text: str) -> str:
+    """The text with fenced code blocks and inline code spans removed."""
+    return INLINE_CODE_RE.sub("", CODE_FENCE_RE.sub("", text))

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
 FENCE_OPEN_RE = re.compile(r"^(`{3,}|~{3,})\s*(\S*)")
-CODE_FENCE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[^\n]*\n.*?^[ \t]{0,3}\1[ \t]*$", re.MULTILINE | re.DOTALL)
 INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 
 
@@ -107,33 +106,46 @@ def note_type(fm: dict | None) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-def yaml_fences(text: str) -> list[str]:
-    """Bodies of the top-level ```yaml fences.
-
-    A fence closes only at a delimiter of its own character and at least its own
-    length (CommonMark), so a ```yaml inside a ```` illustration fence is content
-    and the illustration's own closer does not open a fence that swallows the
-    rest of the file.
+def _walk_fences(text: str):
+    """Yield (state, info, line) per line: `text` outside any fence; `open`, `body`,
+    `close` inside one. A fence closes only at a delimiter of its own character and
+    at least its own length (CommonMark), so a ```yaml inside a ```` illustration
+    fence is body, the illustration's closer does not open a new fence, and a
+    ``` fence closed by ```` ends where the longer delimiter is.
     """
-    fences: list[str] = []
     marker: str | None = None
     info = ""
-    buf: list[str] = []
     for line in text.split("\n"):
         stripped = line.strip()
         if marker is None:
             match = FENCE_OPEN_RE.match(stripped)
             if match:
-                marker, info, buf = match.group(1), match.group(2).lower(), []
+                marker, info = match.group(1), match.group(2).lower()
+                yield "open", info, line
+            else:
+                yield "text", "", line
         elif re.fullmatch(rf"{re.escape(marker[0])}{{{len(marker)},}}", stripped):
-            if info in ("yaml", "yml"):
-                fences.append("\n".join(buf))
+            yield "close", info, line
             marker = None
         else:
+            yield "body", info, line
+
+
+def yaml_fences(text: str) -> list[str]:
+    """Bodies of the top-level ```yaml fences (see _walk_fences for nesting)."""
+    fences: list[str] = []
+    buf: list[str] = []
+    for state, info, line in _walk_fences(text):
+        if state == "open":
+            buf = []
+        elif state == "body":
             buf.append(line)
+        elif state == "close" and info in ("yaml", "yml"):
+            fences.append("\n".join(buf))
     return fences
 
 
 def strip_code(text: str) -> str:
     """The text with fenced code blocks and inline code spans removed."""
-    return INLINE_CODE_RE.sub("", CODE_FENCE_RE.sub("", text))
+    kept = [line for state, _, line in _walk_fences(text) if state == "text"]
+    return INLINE_CODE_RE.sub("", "\n".join(kept))

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -115,6 +115,11 @@ def note_type(fm: dict | None) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def is_raw_source(fm: dict | None) -> bool:
+    """A Raw Source note to the script: carries `sha256` and no `type:`."""
+    return fm is not None and "sha256" in fm and note_type(fm) is None
+
+
 def _walk_fences(text: str):
     """Yield (state, info, line, quoted) per line: `text` outside any fence; `open`,
     `body`, `close` inside one; `quoted` when the fence sits in a blockquote or

--- a/skills/core/maintaining-obsidian/references/vault_frontmatter.py
+++ b/skills/core/maintaining-obsidian/references/vault_frontmatter.py
@@ -16,7 +16,9 @@ from pathlib import Path
 KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
 HEADING_RE = re.compile(r"^#{1,6}\s+(.*\S)")
 # A fence delimiter may be indented by at most three spaces (CommonMark); four
-# is an indented code block whose backticks are literal text.
+# is an indented code block whose backticks are literal text. A fence inside a
+# blockquote or Obsidian callout carries the container's `> ` prefix.
+QUOTE_PREFIX_RE = re.compile(r"^(?: {0,3}> ?)+")
 FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(\S*)")
 # A code span opens with a run of backticks and closes with a run of the same
 # length: `a`, ``a ` b``, ```a``` — never a run of another length. It may cross
@@ -118,23 +120,30 @@ def _walk_fences(text: str):
     at least its own length (CommonMark), so a ```yaml inside a ```` illustration
     fence is body, the illustration's closer does not open a new fence, and a
     ``` fence closed by ```` ends where the longer delimiter is. A delimiter
-    indented four spaces or more is literal text, not a fence.
+    indented four spaces or more is literal text, not a fence. A fence inside a
+    blockquote or callout (`> ```yaml`) is recognised, its body yielded with the
+    `> ` prefix removed.
     """
     marker: str | None = None
     info = ""
+    prefix = ""
     for line in text.split("\n"):
         if marker is None:
-            match = FENCE_OPEN_RE.match(line.rstrip())
+            quoted = QUOTE_PREFIX_RE.match(line)
+            prefix = quoted.group(0) if quoted else ""
+            match = FENCE_OPEN_RE.match(line[len(prefix):].rstrip())
             if match:
                 marker, info = match.group(1), match.group(2).lower()
                 yield "open", info, line
             else:
                 yield "text", "", line
-        elif re.fullmatch(rf" {{0,3}}{re.escape(marker[0])}{{{len(marker)},}}\s*", line):
+            continue
+        inner = line[len(prefix):] if line.startswith(prefix) else line
+        if re.fullmatch(rf" {{0,3}}{re.escape(marker[0])}{{{len(marker)},}}\s*", inner):
             yield "close", info, line
             marker = None
         else:
-            yield "body", info, line
+            yield "body", info, inner
 
 
 def yaml_fences(text: str) -> list[tuple[str, str]]:

--- a/skills/core/maintaining-obsidian/references/vault_links.py
+++ b/skills/core/maintaining-obsidian/references/vault_links.py
@@ -1,0 +1,201 @@
+"""Link graph and Raw Source provenance facts for lint_vault.py.
+
+The graph is the wiki layer's: a `[[wikilink]]` in a note's body outside code,
+or in a parsed frontmatter value, is an edge unless it is an attachment embed,
+a link to a Raw Source capture (provenance), or the note itself. Provenance
+resolves a typed note's `sha256` to the capture it was ingested from. Stdlib
+only; imported by lint_vault.py in this directory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from vault_frontmatter import (
+    is_raw_source,
+    note_type,
+    parse_frontmatter,
+    read_text,
+    split_frontmatter,
+    strip_code,
+)
+
+WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
+# A link target with an explicit extension other than .md is an attachment
+# embed, not a note relationship — unless a note of that exact name exists
+# (`[[Node.js]]` is a note when Node.js.md is).
+EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]+$")
+
+
+def _frontmatter_values(value) -> list[str]:
+    """Every string inside a parsed frontmatter value (scalar, list, or mapping)."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [s for item in value for s in _frontmatter_values(item)]
+    if isinstance(value, dict):
+        return [s for item in value.values() for s in _frontmatter_values(item)]
+    return []
+
+
+def link_text(note: dict) -> str:
+    """What the graph scans: the body outside code, plus the parsed frontmatter
+    values — a `[[link]]` in a YAML comment is not a link."""
+    values = _frontmatter_values(note["fm"] or {})
+    return strip_code(note["body"]) + "\n" + "\n".join(values)
+
+
+def link_facts(notes: list[dict], scoped: list[dict], raw: list[dict]) -> dict:
+    """Link graph over the wiki-layer `notes`; a link to one of the `raw` captures is
+    provenance, not a relationship, and counts for neither side."""
+    by_rel = {note["rel"] for note in notes}
+    by_stem: dict[str, list[str]] = defaultdict(list)
+    for note in notes:
+        by_stem[Path(note["rel"]).stem.lower()].append(note["rel"])
+    raw_rels = {note["rel"] for note in raw}
+    raw_stems = {Path(note["rel"]).stem.lower() for note in raw}
+
+    def resolve(target: str, source: str = "") -> str | None:
+        # A link with a path resolves by that path only. A bare name resolves by
+        # basename; when several notes share it, the one in the source note's
+        # own folder wins, and otherwise the link stays unresolved rather than
+        # being handed to whichever note sorts first (search-strategies.md:
+        # an ambiguous match is left unresolved).
+        name = target[:-3] if target.endswith(".md") else target
+        if "/" in name:
+            return f"{name}.md" if f"{name}.md" in by_rel else None
+        hits = by_stem.get(name.lower(), [])
+        if len(hits) == 1:
+            return hits[0]
+        same_folder = [rel for rel in hits if Path(rel).parent == Path(source).parent]
+        return same_folder[0] if len(same_folder) == 1 else None
+
+    def is_attachment(target: str, source: str) -> bool:
+        ext = EXTENSION_RE.search(target)
+        return bool(ext) and ext.group(0).lower() != ".md" and resolve(target, source) is None
+
+    def is_raw_capture(target: str, source: str) -> bool:
+        # Provenance is a link that can only mean a capture: by path, or by a
+        # bare name no wiki note has. An ambiguous wiki name stays a wiki link.
+        name = target[:-3] if target.endswith(".md") else target
+        if "/" in name:
+            return f"{name}.md" in raw_rels
+        return name.lower() in raw_stems and name.lower() not in by_stem
+
+    outbound: dict[str, int] = {}
+    inbound: Counter = Counter()
+    for note in notes:
+        targets = set()
+        for match in WIKILINK_RE.finditer(link_text(note)):
+            target = match.group(1).strip()
+            if (
+                target
+                and not is_attachment(target, note["rel"])
+                and not is_raw_capture(target, note["rel"])
+            ):
+                targets.add(target)
+        resolved = {resolve(target, note["rel"]) for target in targets}
+        # A link to the note itself, under any spelling, is not an outbound edge.
+        outbound[note["rel"]] = sum(1 for target in targets if resolve(target, note["rel"]) != note["rel"])
+        for rel in resolved - {None, note["rel"]}:
+            inbound[rel] += 1
+
+    per_note = {
+        note["rel"]: {"inbound": inbound[note["rel"]], "outbound": outbound[note["rel"]]}
+        for note in scoped
+    }
+    orphans = sorted(
+        rel for rel, counts in per_note.items() if not counts["inbound"] and not counts["outbound"]
+    )
+    return {"orphans": orphans, "notes": per_note}
+
+
+def sha256_body(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """A note's body digest per raw-sources.md; a non-note file's raw bytes."""
+    if path.suffix == ".md":
+        return sha256_body(split_frontmatter(read_text(path))[1])
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_url_file(note: dict, files: dict[str, Path]) -> Path | None:
+    """The vault file `source_url` names, when it names one (not a URL, not the note itself)."""
+    source_url = note["fm"].get("source_url")
+    if not isinstance(source_url, str) or not source_url or "://" in source_url:
+        return None
+    candidate = files.get(source_url.lstrip("/")) or files.get(
+        (Path(note["rel"]).parent / source_url).as_posix()
+    )
+    return candidate if candidate is not None and candidate != note["path"] else None
+
+
+def _linked_raw_source(note: dict, files: dict[str, Path], md_by_stem: dict) -> Path | None:
+    """The Raw Source note (`sha256`, no `type:`) the body wikilinks — when it links exactly one.
+    A link with a path resolves by that path only; a bare name by basename, and only
+    when every note of that name is a capture (a wiki note of the same name makes
+    the link a wiki relationship, not provenance)."""
+
+    def frontmatter_of(rel: str) -> dict | None:
+        fm_text, _ = split_frontmatter(read_text(files[rel]))
+        return parse_frontmatter(fm_text) if fm_text is not None else None
+
+    hits: set[Path] = set()
+    for match in WIKILINK_RE.finditer(strip_code(note["body"])):
+        target = match.group(1).strip()
+        name = target[:-3] if target.endswith(".md") else target
+        if "/" in name:
+            rels = [f"{name}.md"] if f"{name}.md" in files else []
+        else:
+            rels = md_by_stem.get(name.lower(), [])
+            if not all(is_raw_source(frontmatter_of(rel)) for rel in rels):
+                continue
+        for rel in rels:
+            if is_raw_source(frontmatter_of(rel)):
+                hits.add(files[rel])
+    return hits.pop() if len(hits) == 1 else None
+
+
+def raw_source_facts(scoped: list[dict], vault: Path, files: dict[str, Path]) -> list[dict]:
+    md_by_stem: dict[str, list[str]] = defaultdict(list)
+    for rel in files:
+        if rel.endswith(".md"):
+            md_by_stem[Path(rel).stem.lower()].append(rel)
+    out = []
+    for note in scoped:
+        fm = note["fm"]
+        if fm is None or "sha256" not in fm:
+            continue
+        stored = fm["sha256"] if isinstance(fm["sha256"], str) else ""
+        # The provenance pair: a typed note's digest is of the Raw Source it was
+        # ingested from, never of its own synthesized body.
+        target = _source_url_file(note, files)
+        if target is None and note_type(fm) is not None:
+            target = _linked_raw_source(note, files, md_by_stem)
+        if target is not None:
+            hashed_file, recomputed = target.relative_to(vault).as_posix(), sha256_file(target)
+        elif note_type(fm) is None:
+            hashed_file, recomputed = note["rel"], sha256_body(note["body"])
+        else:
+            hashed_file, recomputed = None, None
+        if recomputed is None:
+            status = "unresolved"
+        elif not stored:
+            status = "unhashed"
+        else:
+            status = "fresh" if stored == recomputed else "drift"
+        out.append(
+            {
+                "path": note["rel"],
+                "hashed_file": hashed_file,
+                "status": status,
+                "stored": stored,
+                "recomputed": recomputed,
+            }
+        )
+    return out

--- a/skills/core/maintaining-obsidian/references/vault_links.py
+++ b/skills/core/maintaining-obsidian/references/vault_links.py
@@ -10,6 +10,7 @@ only; imported by lint_vault.py in this directory.
 from __future__ import annotations
 
 import hashlib
+import posixpath
 import re
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -129,9 +130,11 @@ def _source_url_file(note: dict, files: dict[str, Path]) -> Path | None:
     source_url = note["fm"].get("source_url")
     if not isinstance(source_url, str) or not source_url or "://" in source_url:
         return None
-    candidate = files.get(source_url.lstrip("/")) or files.get(
-        (Path(note["rel"]).parent / source_url).as_posix()
-    )
+    # Vault-relative first, then note-relative with `..` normalised away — and
+    # never a path that climbs out of the vault.
+    relative = posixpath.normpath(posixpath.join(posixpath.dirname(note["rel"]), source_url))
+    inside = relative != ".." and not relative.startswith("../")
+    candidate = files.get(source_url.lstrip("/")) or (files.get(relative) if inside else None)
     return candidate if candidate is not None and candidate != note["path"] else None
 
 

--- a/skills/core/maintaining-obsidian/references/visuals-decision-tree.md
+++ b/skills/core/maintaining-obsidian/references/visuals-decision-tree.md
@@ -34,9 +34,8 @@ Q4: Is the spatial/architectural layout complex enough to warrant manual positio
 
 ## Conservative defaults
 
-If you reach Q3 = yes, generate Mermaid. Do not second-guess with "but
-text could also work" — the question is whether the shape communicates
-faster. Mermaid is cheap; Canvas and Excalidraw are expensive tiers
-that wait for user approval.
+If Q3 is yes, generate Mermaid: for relationship content the shape
+communicates faster than text. Mermaid is cheap; Canvas and Excalidraw
+are expensive tiers that wait for user approval.
 
 When in doubt, skip visuals. Noise diagrams are worse than none.

--- a/skills/core/tdd/references/testing-anti-patterns.md
+++ b/skills/core/tdd/references/testing-anti-patterns.md
@@ -6,10 +6,6 @@
 
 Tests must verify real behavior, not mock behavior. Mocks are a means to isolate, not the thing being tested.
 
-**Core principle:** Test what the code does, not what the mocks do.
-
-**Following strict TDD prevents these anti-patterns.**
-
 ## The Iron Laws
 
 ```
@@ -44,18 +40,6 @@ test('renders sidebar', () => {
 
 // OR if sidebar must be mocked for isolation:
 // Don't assert on the mock - test Page's behavior with sidebar present
-```
-
-### Gate Function
-
-```
-BEFORE asserting on any mock element:
-  Ask: "Am I testing real component behavior or just mock existence?"
-
-  IF testing mock existence:
-    STOP - Delete the assertion or unmock the component
-
-  Test real behavior instead
 ```
 
 ## Anti-Pattern 2: Test-Only Methods in Production
@@ -97,21 +81,7 @@ export async function cleanupSession(session: Session) {
 afterEach(() => cleanupSession(session));
 ```
 
-### Gate Function
-
-```
-BEFORE adding any method to production class:
-  Ask: "Is this only used by tests?"
-
-  IF yes:
-    STOP - Don't add it
-    Put it in test utilities instead
-
-  Ask: "Does this class own this resource's lifecycle?"
-
-  IF no:
-    STOP - Wrong class for this method
-```
+A method only tests call belongs in test utilities; a method that manages a resource belongs on the class that owns that resource's lifecycle.
 
 ## Anti-Pattern 3: Mocking Without Understanding
 
@@ -146,31 +116,7 @@ test('detects duplicate server', () => {
 });
 ```
 
-### Gate Function
-
-```
-BEFORE mocking any method:
-  STOP - Don't mock yet
-
-  1. Ask: "What side effects does the real method have?"
-  2. Ask: "Does this test depend on any of those side effects?"
-  3. Ask: "Do I fully understand what this test needs?"
-
-  IF depends on side effects:
-    Mock at lower level (the actual slow/external operation)
-    OR use test doubles that preserve necessary behavior
-    NOT the high-level method the test depends on
-
-  IF unsure what test depends on:
-    Run test with real implementation FIRST
-    Observe what actually needs to happen
-    THEN add minimal mocking at the right level
-
-  Red flags:
-    - "I'll mock this to be safe"
-    - "This might be slow, better mock it"
-    - Mocking without understanding the dependency chain
-```
+Mock the slow or external operation, not the high-level method whose side effects the test depends on. When you do not know what the test depends on, run it against the real implementation first and mock only what that run shows is slow or external.
 
 ## Anti-Pattern 4: Incomplete Mocks
 
@@ -205,47 +151,6 @@ const mockResponse = {
 };
 ```
 
-### Gate Function
-
-```
-BEFORE creating mock responses:
-  Check: "What fields does the real API response contain?"
-
-  Actions:
-    1. Examine actual API response from docs/examples
-    2. Include ALL fields system might consume downstream
-    3. Verify mock matches real response schema completely
-
-  Critical:
-    If you're creating a mock, you must understand the ENTIRE structure
-    Partial mocks fail silently when code depends on omitted fields
-
-  If uncertain: Include all documented fields
-```
-
-## Anti-Pattern 5: Integration Tests as Afterthought
-
-**The violation:**
-```
-✅ Implementation complete
-❌ No tests written
-"Ready for testing"
-```
-
-**Why this is wrong:**
-- Testing is part of implementation, not optional follow-up
-- TDD would have caught this
-- Can't claim complete without tests
-
-**The fix:**
-```
-TDD cycle:
-1. Write failing test
-2. Implement to pass
-3. Refactor
-4. THEN claim complete
-```
-
 ## When Mocks Become Too Complex
 
 **Warning signs:**
@@ -256,16 +161,6 @@ TDD cycle:
 
 **Consider:** Integration tests with real components often simpler than complex mocks
 
-## TDD Prevents These Anti-Patterns
-
-**Why TDD helps:**
-1. Write test first
-2. Watch it fail
-3. Minimal implementation
-4. Real dependencies
-
-If you're testing mock behavior, you violated TDD.
-
 ## Quick Reference
 
 | Anti-Pattern | Fix |
@@ -274,7 +169,6 @@ If you're testing mock behavior, you violated TDD.
 | Test-only methods in production | Move to test utilities |
 | Mock without understanding | Understand dependencies first, mock minimally |
 | Incomplete mocks | Mirror real API completely |
-| Tests as afterthought | TDD - tests first |
 | Over-complex mocks | Consider integration tests |
 
 ## Red Flags
@@ -285,11 +179,3 @@ If you're testing mock behavior, you violated TDD.
 - Test fails when you remove mock
 - Can't explain why mock is needed
 - Mocking "just to be safe"
-
-## The Bottom Line
-
-Mocks are tools to isolate, not things to test.
-
-If TDD reveals you're testing mock behavior, you've gone wrong.
-
-Fix: Test real behavior or question why you're mocking at all.

--- a/tests/skills/conftest.py
+++ b/tests/skills/conftest.py
@@ -1,0 +1,10 @@
+"""Shared fixtures for tests/skills/."""
+
+import pytest
+
+from .lint_vault_support import build_vault
+
+
+@pytest.fixture
+def vault(tmp_path):
+    return build_vault(tmp_path)

--- a/tests/skills/lint_vault_support.py
+++ b/tests/skills/lint_vault_support.py
@@ -1,0 +1,172 @@
+"""Fixture vault, constants, and the subprocess runner shared by the lint_vault tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = PROJECT_ROOT / "skills" / "core" / "maintaining-obsidian" / "references" / "lint_vault.py"
+
+SCHEMA = """---
+type: schema
+created: 2026-05-06
+---
+
+# Test vault — schema
+
+## Universal Frontmatter
+
+```yaml
+---
+type: source | entity
+created: YYYY-MM-DD
+tags: []
+---
+```
+
+## Source
+
+```yaml
+---
+type: source
+source_url: ""
+source_author: ""          # author or organization
+sha256: ""
+---
+```
+
+## Entity
+
+```yaml
+---
+type: entity
+aliases: []
+---
+```
+
+## Tag Taxonomy
+
+- `arcforge` — project tag
+- `entity` — entity notes (`entity/tool`, ...)
+
+LINT checks:
+- Unknown top-level tags → flag.
+
+## Audit Thresholds
+
+- Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
+"""
+
+ALPHA_BODY = "# Alpha\n\nSee [[alpha-note-draft|the draft]] and ![[diagram.png]].\n"
+ALPHA = (
+    "---\n"
+    "type: source\n"
+    "created: 2026-05-06\n"
+    "tags:\n"
+    "  - arcforge\n"
+    "  - tdd\n"
+    'source_url: "https://example.com/alpha"\n'
+    'source_author: ""\n'
+    f'sha256: "{"0" * 64}"\n'
+    "---\n"
+    f"{ALPHA_BODY}"
+)
+
+DRAFT = """---
+type: source
+created: 2026-05-07
+tags: [arcforge]
+source_url: "https://example.com/alpha-draft"
+sha256: ""
+---
+# Alpha (draft)
+
+Supersedes [[Wiki/alpha-note]].
+"""
+
+GAMMA = """---
+type: entity
+created: 2026-05-08
+tags: [entity, entity/tool, tdd]
+aliases: []
+extra_field: yes
+---
+# Gamma
+
+Nothing links here and this links nowhere.
+"""
+
+LOG = """# Log
+
+## [2026-05-06] create | source | Wiki/alpha-note.md
+## [2026-05-07] create | entity | Wiki/deleted-note.md
+## [2026-05-08] query | how does alpha work?
+"""
+
+
+RAW_BODY = "# Fed statement\n\nRates unchanged.\n"
+RAW_DIGEST = hashlib.sha256(RAW_BODY.encode("utf-8")).hexdigest()
+
+
+PRESETS = Path(__file__).resolve().parents[2] / "skills" / "core" / "maintaining-obsidian" / "presets"
+
+
+GENERIC_SOURCE = (
+    "---\ntype: source\ncreated: 2026-05-06\nlangs: [en, zh]\n"
+    "source_url: https://example.com/{n}\nsource_author: Someone\nsha256: {digest}\n"
+    "tags: [source]\naliases: []\n---\nbody\n"
+)
+PAPER_SOURCE = (
+    "---\ntype: source\ncreated: 2026-05-06\nlangs: [en, zh]\n"
+    "source_url: https://arxiv.org/abs/1\nsource_author: [A, B]\nsha256: {digest}\n"
+    "venue: NeurIPS\nyear: 2025\nmethodology: ''\nreading_status: queued\n"
+    "cites: []\ncited_by: []\ntags: [paper]\naliases: []\n---\nbody\n"
+)
+
+
+def build_vault(tmp_path: Path) -> Path:
+    (tmp_path / "SCHEMA.md").write_text(SCHEMA, encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "log.md").write_text(LOG, encoding="utf-8")
+    wiki = tmp_path / "Wiki"
+    wiki.mkdir()
+    (wiki / "alpha-note.md").write_text(ALPHA, encoding="utf-8")
+    (wiki / "alpha-note-draft.md").write_text(DRAFT, encoding="utf-8")
+    (wiki / "gamma-orphan.md").write_text(GAMMA, encoding="utf-8")
+    return tmp_path
+
+
+def _run(vault: Path, *extra: str) -> dict:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(vault), "--scope", "all", "--json", *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _pair(report: dict, a: str, b: str) -> dict:
+    return next(d for d in report["duplicate_titles"] if {d["a"], d["b"]} == {a, b})
+
+
+def _news_shaped_pair(vault: Path) -> Path:
+    raw_dir = vault / "Raw" / "2026-05-06"
+    raw_dir.mkdir(parents=True)
+    raw = raw_dir / "bloomberg-fed.md"
+    raw.write_text(
+        f"---\nsource_url: https://example.com/fed\nsha256: {RAW_DIGEST}\n---\n{RAW_BODY}",
+        encoding="utf-8",
+    )
+    (vault / "Wiki" / "fed-article.md").write_text(
+        "---\ntype: source\ncreated: 2026-05-06\n"
+        f"source_url: https://example.com/fed\nsha256: {RAW_DIGEST}\n---\n"
+        "# Fed\n\n## Lead\nRates held.\n\n## Source\n[[Raw/2026-05-06/bloomberg-fed]] (immutable original)\n",
+        encoding="utf-8",
+    )
+    return raw

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -1,0 +1,256 @@
+"""Contract test for maintaining-obsidian's LINT script.
+
+Builds a tiny vault in tmp_path, runs `references/lint_vault.py --json` the way
+the skill runs it (a subprocess), and asserts the facts it reports: block-list
+frontmatter reads as filled, undeclared fields are counted against SCHEMA.md,
+the orphan graph, sha256 drift and unhashed Raw Sources, log entries naming
+missing files, tag counts, duplicate-title candidates, and the threshold flags.
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = PROJECT_ROOT / "skills" / "core" / "maintaining-obsidian" / "references" / "lint_vault.py"
+
+SCHEMA = """---
+type: schema
+created: 2026-05-06
+---
+
+# Test vault — schema
+
+## Universal Frontmatter
+
+```yaml
+---
+type: source | entity
+created: YYYY-MM-DD
+tags: []
+---
+```
+
+## Source
+
+```yaml
+---
+type: source
+source_url: ""
+source_author: ""          # author or organization
+sha256: ""
+---
+```
+
+## Entity
+
+```yaml
+---
+type: entity
+aliases: []
+---
+```
+
+## Audit Thresholds
+
+- Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
+"""
+
+ALPHA_BODY = "# Alpha\n\nSee [[alpha-note-draft|the draft]] and ![[diagram.png]].\n"
+ALPHA = (
+    "---\n"
+    "type: source\n"
+    "created: 2026-05-06\n"
+    "tags:\n"
+    "  - arcforge\n"
+    "  - tdd\n"
+    'source_url: "https://example.com/alpha"\n'
+    'source_author: ""\n'
+    f'sha256: "{"0" * 64}"\n'
+    "---\n"
+    f"{ALPHA_BODY}"
+)
+
+DRAFT = """---
+type: source
+created: 2026-05-07
+tags: [arcforge]
+source_url: "https://example.com/alpha-draft"
+sha256: ""
+---
+# Alpha (draft)
+
+Supersedes [[Wiki/alpha-note]].
+"""
+
+GAMMA = """---
+type: entity
+created: 2026-05-08
+tags: [entity]
+aliases: []
+extra_field: yes
+---
+# Gamma
+
+Nothing links here and this links nowhere.
+"""
+
+LOG = """# Log
+
+## [2026-05-06] create | source | Wiki/alpha-note.md
+## [2026-05-07] create | entity | Wiki/deleted-note.md
+## [2026-05-08] query | how does alpha work?
+"""
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / "SCHEMA.md").write_text(SCHEMA, encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "log.md").write_text(LOG, encoding="utf-8")
+    wiki = tmp_path / "Wiki"
+    wiki.mkdir()
+    (wiki / "alpha-note.md").write_text(ALPHA, encoding="utf-8")
+    (wiki / "alpha-note-draft.md").write_text(DRAFT, encoding="utf-8")
+    (wiki / "gamma-orphan.md").write_text(GAMMA, encoding="utf-8")
+    return tmp_path
+
+
+def _run(vault: Path, *extra: str) -> dict:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(vault), "--scope", "all", "--json", *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _pair(report: dict, a: str, b: str) -> dict:
+    return next(d for d in report["duplicate_titles"] if {d["a"], d["b"]} == {a, b})
+
+
+def test_scans_only_notes_and_reads_declared_types(vault):
+    report = _run(vault)
+    assert report["notes"] == {"total": 3, "in_scope": 3}
+    assert report["schema"] == {"path": "SCHEMA.md", "declared_types": ["entity", "source"]}
+    assert report["untyped"] == []
+
+
+def test_block_list_frontmatter_reads_as_filled(vault):
+    tags = _run(vault)["types"]["source"]["fields"]["tags"]
+    assert tags == {"present": 2, "filled": 2, "empty": 0, "empty_pct": 0.0, "exceeds": None}
+
+
+def test_unindented_block_list_reads_as_filled(vault):
+    # Valid YAML: sequence items at column 0 under the key (PyYAML reads a list).
+    (vault / "Wiki" / "delta-note.md").write_text(
+        "---\ntype: source\ntitle: Delta\ntags:\n- arcforge\n- tdd\n---\nbody\n",
+        encoding="utf-8",
+    )
+    tags = _run(vault)["types"]["source"]["fields"]["tags"]
+    assert tags == {"present": 3, "filled": 3, "empty": 0, "empty_pct": 0.0, "exceeds": None}
+
+
+def test_raw_source_note_without_type_is_drift_checked_not_untyped(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    (raw / "article.md").write_text(
+        "---\nsource_url: https://example.com/a\nsha256: " + "0" * 64 + "\n---\nraw text\n",
+        encoding="utf-8",
+    )
+    report = _run(vault)
+    assert report["untyped"] == []
+    by_path = {item["path"]: item for item in report["raw_sources"]}
+    assert by_path["Raw/article.md"]["status"] == "drift"
+
+
+def test_undeclared_fields_are_counted_against_schema(vault):
+    entity = _run(vault)["types"]["entity"]
+    assert entity["declared"] == ["aliases", "created", "tags", "type"]
+    assert entity["undeclared"] == {"extra_field": {"present": 1, "present_pct": 100.0, "exceeds": None}}
+
+
+def test_orphan_graph(vault):
+    links = _run(vault)["links"]
+    assert links["orphans"] == ["Wiki/gamma-orphan.md"]
+    assert links["notes"]["Wiki/alpha-note.md"] == {"inbound": 1, "outbound": 1}
+    assert links["notes"]["Wiki/alpha-note-draft.md"] == {"inbound": 1, "outbound": 1}
+
+
+def test_raw_source_drift_and_unhashed(vault):
+    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
+    alpha = by_path["Wiki/alpha-note.md"]
+    assert alpha["status"] == "drift"
+    assert alpha["stored"] == "0" * 64
+    assert alpha["recomputed"] == hashlib.sha256(ALPHA_BODY.encode("utf-8")).hexdigest()
+    assert alpha["hashed_file"] == "Wiki/alpha-note.md"
+    assert by_path["Wiki/alpha-note-draft.md"]["status"] == "unhashed"
+
+
+def test_log_entries_naming_missing_files(vault):
+    log = _run(vault)["log"]
+    assert log["entries"] == 3
+    assert log["missing_files"] == [{"line": 4, "file": "Wiki/deleted-note.md"}]
+
+
+def test_tag_counts(vault):
+    tags = _run(vault)["tags"]
+    assert {tag: facts["count"] for tag, facts in tags.items()} == {"arcforge": 2, "entity": 1, "tdd": 1}
+
+
+def test_duplicate_title_candidates_carry_a_ratio(vault):
+    pair = _pair(_run(vault), "Wiki/alpha-note.md", "Wiki/alpha-note-draft.md")
+    assert 0.6 <= pair["ratio"] < 1.0
+    assert pair["exceeds"] is None
+
+
+def test_threshold_flags_set_exceeds(vault):
+    report = _run(vault, "--title-match", "0.7", "--field-empty-pct", "90", "--tag-min", "2")
+    assert report["thresholds"] == {
+        "field_empty_pct": 90.0,
+        "undeclared_pct": None,
+        "tag_min": 2,
+        "title_match": 0.7,
+    }
+    assert _pair(report, "Wiki/alpha-note.md", "Wiki/alpha-note-draft.md")["exceeds"] is True
+    assert report["types"]["source"]["fields"]["source_author"]["exceeds"] is True
+    assert report["types"]["source"]["fields"]["tags"]["exceeds"] is False
+    assert report["tags"]["arcforge"]["exceeds"] is True
+    assert report["tags"]["tdd"]["exceeds"] is False
+
+
+def test_recent_scope_limits_subjects_but_not_the_graph(vault):
+    draft = vault / "Wiki" / "alpha-note-draft.md"
+    newest = max(p.stat().st_mtime for p in (vault / "Wiki").iterdir()) + 10
+    os.utime(draft, (newest, newest))
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(vault), "--scope", "recent:1", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(proc.stdout)
+    assert report["notes"] == {"total": 3, "in_scope": 1}
+    assert list(report["links"]["notes"]) == ["Wiki/alpha-note-draft.md"]
+    assert report["links"]["notes"]["Wiki/alpha-note-draft.md"]["inbound"] == 1
+
+
+def test_skip_drops_a_folder_and_bad_scope_is_rejected(vault):
+    report = _run(vault, "--skip", "Wiki")
+    assert report["notes"] == {"total": 0, "in_scope": 0}
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(vault), "--scope", "latest"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "scope must be" in proc.stderr

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -1,14 +1,10 @@
-"""Contract test for maintaining-obsidian's LINT script.
+"""Contract test for maintaining-obsidian's LINT script — schema, scope, tags, log, titles, thresholds.
 
-Builds a tiny vault in tmp_path, runs `references/lint_vault.py --json` the way
-the skill runs it (a subprocess), and asserts the facts it reports: block-list
-frontmatter reads as filled, undeclared fields are counted against SCHEMA.md,
-the orphan graph, sha256 drift / unhashed / unresolved provenance, log entries
-naming missing files, tag counts against the taxonomy, duplicate-title
-candidates, and the threshold flags.
+Runs `references/lint_vault.py --json` the way the skill runs it (a subprocess) on
+the fixture vault from lint_vault_support and asserts the facts it reports. The
+link graph and Raw Source provenance are covered by test_vault_links.py.
 """
 
-import hashlib
 import json
 import os
 import subprocess
@@ -17,132 +13,16 @@ from pathlib import Path
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = PROJECT_ROOT / "skills" / "core" / "maintaining-obsidian" / "references" / "lint_vault.py"
-
-SCHEMA = """---
-type: schema
-created: 2026-05-06
----
-
-# Test vault — schema
-
-## Universal Frontmatter
-
-```yaml
----
-type: source | entity
-created: YYYY-MM-DD
-tags: []
----
-```
-
-## Source
-
-```yaml
----
-type: source
-source_url: ""
-source_author: ""          # author or organization
-sha256: ""
----
-```
-
-## Entity
-
-```yaml
----
-type: entity
-aliases: []
----
-```
-
-## Tag Taxonomy
-
-- `arcforge` — project tag
-- `entity` — entity notes (`entity/tool`, ...)
-
-LINT checks:
-- Unknown top-level tags → flag.
-
-## Audit Thresholds
-
-- Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
-"""
-
-ALPHA_BODY = "# Alpha\n\nSee [[alpha-note-draft|the draft]] and ![[diagram.png]].\n"
-ALPHA = (
-    "---\n"
-    "type: source\n"
-    "created: 2026-05-06\n"
-    "tags:\n"
-    "  - arcforge\n"
-    "  - tdd\n"
-    'source_url: "https://example.com/alpha"\n'
-    'source_author: ""\n'
-    f'sha256: "{"0" * 64}"\n'
-    "---\n"
-    f"{ALPHA_BODY}"
+from .lint_vault_support import (
+    SCRIPT,
+    SCHEMA,
+    GAMMA,
+    PRESETS,
+    GENERIC_SOURCE,
+    PAPER_SOURCE,
+    _run,
+    _pair,
 )
-
-DRAFT = """---
-type: source
-created: 2026-05-07
-tags: [arcforge]
-source_url: "https://example.com/alpha-draft"
-sha256: ""
----
-# Alpha (draft)
-
-Supersedes [[Wiki/alpha-note]].
-"""
-
-GAMMA = """---
-type: entity
-created: 2026-05-08
-tags: [entity, entity/tool, tdd]
-aliases: []
-extra_field: yes
----
-# Gamma
-
-Nothing links here and this links nowhere.
-"""
-
-LOG = """# Log
-
-## [2026-05-06] create | source | Wiki/alpha-note.md
-## [2026-05-07] create | entity | Wiki/deleted-note.md
-## [2026-05-08] query | how does alpha work?
-"""
-
-
-@pytest.fixture
-def vault(tmp_path: Path) -> Path:
-    (tmp_path / "SCHEMA.md").write_text(SCHEMA, encoding="utf-8")
-    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
-    (tmp_path / "log.md").write_text(LOG, encoding="utf-8")
-    wiki = tmp_path / "Wiki"
-    wiki.mkdir()
-    (wiki / "alpha-note.md").write_text(ALPHA, encoding="utf-8")
-    (wiki / "alpha-note-draft.md").write_text(DRAFT, encoding="utf-8")
-    (wiki / "gamma-orphan.md").write_text(GAMMA, encoding="utf-8")
-    return tmp_path
-
-
-def _run(vault: Path, *extra: str) -> dict:
-    proc = subprocess.run(
-        [sys.executable, str(SCRIPT), str(vault), "--scope", "all", "--json", *extra],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert proc.returncode == 0, proc.stderr
-    return json.loads(proc.stdout)
-
-
-def _pair(report: dict, a: str, b: str) -> dict:
-    return next(d for d in report["duplicate_titles"] if {d["a"], d["b"]} == {a, b})
 
 
 def test_scans_only_notes_and_reads_declared_types(vault):
@@ -182,118 +62,11 @@ def test_unindented_block_list_reads_as_filled(vault):
     assert tags == {"expected": 3, "present": 3, "filled": 3, "empty": 0, "empty_pct": 0.0, "exceeds": None}
 
 
-def test_raw_source_note_without_type_is_drift_checked_not_untyped(vault):
-    raw = vault / "Raw"
-    raw.mkdir()
-    (raw / "article.md").write_text(
-        "---\nsource_url: https://example.com/a\nsha256: " + "0" * 64 + "\n---\nraw text\n",
-        encoding="utf-8",
-    )
-    report = _run(vault)
-    assert report["untyped"] == []
-    by_path = {item["path"]: item for item in report["raw_sources"]}
-    assert by_path["Raw/article.md"]["status"] == "drift"
-
-
 def test_undeclared_fields_are_counted_against_schema(vault):
     entity = _run(vault)["types"]["entity"]
     assert entity["declared"] == ["aliases", "created", "tags", "type"]
     assert entity["variants"] == 1
     assert entity["undeclared"] == {"extra_field": {"present": 1, "present_pct": 100.0, "exceeds": None}}
-
-
-def test_orphan_graph(vault):
-    links = _run(vault)["links"]
-    assert links["orphans"] == ["Wiki/gamma-orphan.md"]
-    assert links["notes"]["Wiki/alpha-note.md"] == {"inbound": 1, "outbound": 1}
-    assert links["notes"]["Wiki/alpha-note-draft.md"] == {"inbound": 1, "outbound": 1}
-
-
-def test_typed_note_with_remote_source_and_no_raw_link_is_unresolved_not_drift(vault):
-    # A typed note's sha256 is the Raw Source's digest (B-4), never its own body's:
-    # hashing the synthesized body would report drift on every correct ingest.
-    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
-    assert by_path["Wiki/alpha-note.md"] == {
-        "path": "Wiki/alpha-note.md",
-        "hashed_file": None,
-        "status": "unresolved",
-        "stored": "0" * 64,
-        "recomputed": None,
-    }
-    # An empty digest with nothing to backfill from is unresolved too, not unhashed.
-    assert by_path["Wiki/alpha-note-draft.md"]["status"] == "unresolved"
-
-
-RAW_BODY = "# Fed statement\n\nRates unchanged.\n"
-RAW_DIGEST = hashlib.sha256(RAW_BODY.encode("utf-8")).hexdigest()
-
-
-def _news_shaped_pair(vault: Path) -> Path:
-    raw_dir = vault / "Raw" / "2026-05-06"
-    raw_dir.mkdir(parents=True)
-    raw = raw_dir / "bloomberg-fed.md"
-    raw.write_text(
-        f"---\nsource_url: https://example.com/fed\nsha256: {RAW_DIGEST}\n---\n{RAW_BODY}",
-        encoding="utf-8",
-    )
-    (vault / "Wiki" / "fed-article.md").write_text(
-        "---\ntype: source\ncreated: 2026-05-06\n"
-        f"source_url: https://example.com/fed\nsha256: {RAW_DIGEST}\n---\n"
-        "# Fed\n\n## Lead\nRates held.\n\n## Source\n[[Raw/2026-05-06/bloomberg-fed]] (immutable original)\n",
-        encoding="utf-8",
-    )
-    return raw
-
-
-def test_typed_note_hashes_the_raw_source_its_body_links(vault):
-    raw = _news_shaped_pair(vault)
-    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
-    assert by_path["Wiki/fed-article.md"] == {
-        "path": "Wiki/fed-article.md",
-        "hashed_file": "Raw/2026-05-06/bloomberg-fed.md",
-        "status": "fresh",
-        "stored": RAW_DIGEST,
-        "recomputed": RAW_DIGEST,
-    }
-    assert by_path["Raw/2026-05-06/bloomberg-fed.md"]["status"] == "fresh"
-    # A legacy empty digest on a note whose capture resolves is unhashed: backfill from it.
-    (vault / "Wiki" / "fed-article-legacy.md").write_text(
-        "---\ntype: source\nsource_url: https://example.com/fed\nsha256: \"\"\n---\n"
-        "## Source\n[[Raw/2026-05-06/bloomberg-fed]]\n",
-        encoding="utf-8",
-    )
-    legacy = {item["path"]: item for item in _run(vault)["raw_sources"]}["Wiki/fed-article-legacy.md"]
-    assert legacy["status"] == "unhashed" and legacy["recomputed"] == RAW_DIGEST
-    # --skip Raw takes the capture out of the note set, not out of the drift
-    # check, and its link is still provenance rather than a wiki edge.
-    skipped = _run(vault, "--skip", "Raw")
-    by_path = {item["path"]: item for item in skipped["raw_sources"]}
-    assert by_path["Wiki/fed-article.md"]["status"] == "fresh"
-    assert by_path["Raw/2026-05-06/bloomberg-fed.md"]["status"] == "fresh"
-    assert "Wiki/fed-article.md" in skipped["links"]["orphans"]
-    # The publisher edits the article: the re-captured body drifts from the pair.
-    raw.write_text(raw.read_text(encoding="utf-8") + "\nCorrection appended.\n", encoding="utf-8")
-    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
-    assert by_path["Wiki/fed-article.md"]["status"] == "drift"
-    assert by_path["Wiki/fed-article.md"]["hashed_file"] == "Raw/2026-05-06/bloomberg-fed.md"
-
-
-def test_raw_sources_are_drift_checked_but_never_scope_subjects(vault):
-    raw = vault / "Raw"
-    raw.mkdir()
-    (raw / "alpha-capture.md").write_text(
-        "---\ntitle: Alpha\nsource_url: https://example.com/alpha\nsha256: " + "0" * 64 + "\n---\nraw text\n",
-        encoding="utf-8",
-    )
-    newest = max(p.stat().st_mtime for p in (vault / "Wiki").iterdir()) + 10
-    os.utime(raw / "alpha-capture.md", (newest, newest))
-    report = _run(vault, "--scope", "recent:1")
-    # The newest file is the capture, yet the one subject is a wiki note.
-    assert report["notes"] == {"total": 3, "raw_sources": 1, "in_scope": 1}
-    assert list(report["links"]["notes"]) != ["Raw/alpha-capture.md"]
-    assert {item["path"] for item in report["raw_sources"]} >= {"Raw/alpha-capture.md"}
-    # A capture titled like its note is not a duplicate-title candidate.
-    assert not any("Raw/" in d["a"] or "Raw/" in d["b"] for d in _run(vault)["duplicate_titles"])
 
 
 def test_audit_reports_are_never_scope_subjects(vault):
@@ -308,70 +81,10 @@ def test_audit_reports_are_never_scope_subjects(vault):
     assert "audit-report" not in result["types"]
 
 
-def test_wikilinks_inside_code_are_examples_not_links(vault):
-    (vault / "Wiki" / "gamma-orphan.md").write_text(
-        # A double-backtick span, and a fence that opens with ``` and closes with
-        # ```` — a longer delimiter CommonMark accepts.
-        GAMMA + "\nExample: `[[alpha-note]]`, ``[[alpha-note]]`` and\n\n```\n[[alpha-note-draft]]\n````\n",
-        encoding="utf-8",
-    )
-    links = _run(vault)["links"]
-    assert "Wiki/gamma-orphan.md" in links["orphans"]
-    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
-
-
 def test_log_entries_naming_missing_files(vault):
     log = _run(vault)["log"]
     assert log["entries"] == 3
     assert log["missing_files"] == [{"line": 4, "file": "Wiki/deleted-note.md"}]
-
-
-def test_raw_captures_and_attachment_embeds_are_not_edges(vault):
-    raw = vault / "Raw"
-    raw.mkdir()
-    # Captured text mentioning the orphan is the source's link, not the vault's.
-    (raw / "capture.md").write_text(
-        "---\nsource_url: https://example.com/c\nsha256: " + "0" * 64 + "\n---\nSee [[Wiki/gamma-orphan]] and [[alpha-note]].\n",
-        encoding="utf-8",
-    )
-    # Attachments of any extension are embeds; a dotted note name still resolves.
-    (vault / "Wiki" / "Node.js.md").write_text("---\ntype: entity\n---\nabout node\n", encoding="utf-8")
-    (vault / "Wiki" / "gamma-orphan.md").write_text(
-        GAMMA + "\n![[recording.mp3]] ![[clip.webp]] ![[deck.pdf]]\n", encoding="utf-8"
-    )
-    (vault / "Wiki" / "alpha-note-draft.md").write_text(DRAFT + "\nRuntime: [[Node.js]].\n", encoding="utf-8")
-    links = _run(vault)["links"]
-    assert "Wiki/gamma-orphan.md" in links["orphans"]
-    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
-    assert links["notes"]["Wiki/Node.js.md"]["inbound"] == 1
-    assert links["notes"]["Wiki/alpha-note-draft.md"]["outbound"] == 2
-
-
-def test_links_in_yaml_comments_are_not_edges_but_links_in_values_are(vault):
-    (vault / "Wiki" / "gamma-orphan.md").write_text(
-        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: []   # e.g. [[alpha-note]]\n"),
-        encoding="utf-8",
-    )
-    links = _run(vault)["links"]
-    assert "Wiki/gamma-orphan.md" in links["orphans"]
-    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
-    (vault / "Wiki" / "gamma-orphan.md").write_text(
-        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: \"[[alpha-note]]\"\n"),
-        encoding="utf-8",
-    )
-    links = _run(vault)["links"]
-    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
-    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 2
-
-
-def test_self_links_under_any_spelling_are_not_edges(vault):
-    (vault / "Wiki" / "gamma-orphan.md").write_text(
-        GAMMA + "\nSelf: [[gamma-orphan]] and [[Wiki/gamma-orphan]] and [[gamma-orphan#Heading|me]].\n",
-        encoding="utf-8",
-    )
-    links = _run(vault)["links"]
-    assert links["notes"]["Wiki/gamma-orphan.md"] == {"inbound": 0, "outbound": 0}
-    assert "Wiki/gamma-orphan.md" in links["orphans"]
 
 
 def test_fenced_examples_under_the_taxonomy_declare_nothing(vault):
@@ -388,56 +101,6 @@ def test_fenced_examples_under_the_taxonomy_declare_nothing(vault):
     assert report["tags"]["ghost"] == {"count": 1, "declared": False, "exceeds": True}
 
 
-def test_ambiguous_bare_links_resolve_by_folder_or_not_at_all(vault):
-    for folder in ("A", "B"):
-        (vault / folder).mkdir()
-        (vault / folder / "foo.md").write_text(f"---\ntype: entity\n---\n{folder} foo\n", encoding="utf-8")
-    (vault / "B" / "source.md").write_text("---\ntype: entity\n---\nSee [[foo]].\n", encoding="utf-8")
-    (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nAlso [[foo]].\n", encoding="utf-8")
-    links = _run(vault)["links"]
-    assert links["notes"]["B/foo.md"]["inbound"] == 1      # same folder as B/source.md
-    assert links["notes"]["A/foo.md"]["inbound"] == 0      # not handed the link by sort order
-    assert "A/foo.md" in links["orphans"]
-    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1   # ambiguous from Wiki/: unresolved, still a link
-    assert "Wiki/gamma-orphan.md" not in links["orphans"]
-    # The same-folder rule also decides the attachment and provenance prefilters:
-    # a dotted name shared by two folders, and a bare name a capture also has.
-    for folder in ("A", "B"):
-        (vault / folder / "Node.js.md").write_text("---\ntype: entity\n---\nnode\n", encoding="utf-8")
-    (vault / "Raw").mkdir()
-    (vault / "Raw" / "foo.md").write_text("---\nsource_url: https://x/foo\nsha256: " + "0" * 64 + "\n---\ncapture\n", encoding="utf-8")
-    (vault / "B" / "source.md").write_text("---\ntype: entity\n---\nSee [[foo]] and [[Node.js]].\n", encoding="utf-8")
-    links = _run(vault)["links"]
-    assert links["notes"]["B/Node.js.md"]["inbound"] == 1
-    assert links["notes"]["B/foo.md"]["inbound"] == 1
-    assert links["notes"]["B/source.md"]["outbound"] == 2
-    # With a wiki `foo` in two folders and a capture `foo`, the ambiguous link
-    # from Wiki/ is still a wiki link (unresolved), not provenance.
-    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
-
-
-def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):
-    _news_shaped_pair(vault)
-    # The Article's only link is its `## Source` line: no wiki relationship, so
-    # it is an orphan, while its provenance still resolves for the drift check.
-    report = _run(vault)
-    assert "Wiki/fed-article.md" in report["links"]["orphans"]
-    assert {i["path"]: i["status"] for i in report["raw_sources"]}["Wiki/fed-article.md"] == "fresh"
-    # A long attachment extension and a code span crossing a line break are
-    # embeds and examples too.
-    (vault / "Wiki" / "gamma-orphan.md").write_text(
-        GAMMA + "\n![[diagram.excalidraw]] and ``literal\n[[alpha-note]]`` here.\n"
-        "\n> [!note]\n> ```md\n> [[alpha-note]] inside a callout fence\n>```\n\nAfter the callout: [[Node.js]].\n",
-        encoding="utf-8",
-    )
-    # The callout fence closes on `>``` ` (no space), and text after it is text again.
-    (vault / "Wiki" / "Node.js.md").write_text("---\ntype: entity\n---\nnode\n", encoding="utf-8")
-    links = _run(vault)["links"]
-    assert "Wiki/gamma-orphan.md" not in links["orphans"]
-    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
-    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
-
-
 def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
     # `Wiki/deleted-note.md` stays missing when only `Archive/deleted-note.md`
     # exists; a bare basename in the log still matches any file of that name.
@@ -449,12 +112,15 @@ def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
         log.write("## [2026-05-11] schema | bump to v1.2\n")
         log.write("## [2026-05-12] create | entity | Wiki/My Note.md\n")
         log.write("## [2026-05-13] query | summarize Wiki/alpha-note.md and Wiki/gone.md\n")
+        log.write("## [2026-05-14] schema | updated SCHEMA.md\n")
+        log.write("## [2026-05-15] create | entity | ./My Root Note.md\n")
     report = _run(vault)["log"]
-    assert report["entries"] == 8
+    assert report["entries"] == 10
     assert report["missing_files"] == [
         {"line": 4, "file": "Wiki/deleted-note.md"},
         {"line": 7, "file": "Raw/recording.mp3"},
         {"line": 9, "file": "Wiki/My Note.md"},
+        {"line": 12, "file": "./My Root Note.md"},
     ]
 
 
@@ -530,9 +196,6 @@ def test_skip_drops_a_folder_and_bad_scope_is_rejected(vault):
     assert "scope must be" in proc.stderr
 
 
-PRESETS = Path(__file__).resolve().parents[2] / "skills" / "core" / "maintaining-obsidian" / "presets"
-
-
 @pytest.mark.parametrize("preset,type_name", [("llm-wiki", "source"), ("news", "article")])
 def test_preset_source_types_declare_the_provenance_pair(tmp_path, preset, type_name):
     # obsidian.md B-4: the typed note carries source_url and sha256; a preset whose
@@ -561,19 +224,6 @@ def test_preset_taxonomies_declare_their_top_level_tags(tmp_path, preset, type_n
     assert tag.split("/")[0] in report["schema"]["declared_tags"]
     assert report["tags"][tag] == {"count": 1, "declared": True, "exceeds": False}
     assert report["tags"]["made-up"] == {"count": 1, "declared": False, "exceeds": True}
-
-
-GENERIC_SOURCE = (
-    "---\ntype: source\ncreated: 2026-05-06\nlangs: [en, zh]\n"
-    "source_url: https://example.com/{n}\nsource_author: Someone\nsha256: {digest}\n"
-    "tags: [source]\naliases: []\n---\nbody\n"
-)
-PAPER_SOURCE = (
-    "---\ntype: source\ncreated: 2026-05-06\nlangs: [en, zh]\n"
-    "source_url: https://arxiv.org/abs/1\nsource_author: [A, B]\nsha256: {digest}\n"
-    "venue: NeurIPS\nyear: 2025\nmethodology: ''\nreading_status: queued\n"
-    "cites: []\ncited_by: []\ntags: [paper]\naliases: []\n---\nbody\n"
-)
 
 
 def test_variant_only_fields_are_expected_of_the_notes_fitting_that_variant(tmp_path):
@@ -651,19 +301,6 @@ def test_variant_fences_under_subheadings_keep_their_type_section(tmp_path):
     assert "venue" not in source["fields"]
 
 
-def test_bare_provenance_link_colliding_with_a_wiki_name_is_unresolved(vault):
-    raw = vault / "Raw"
-    raw.mkdir()
-    (raw / "foo.md").write_text("---\nsource_url: https://x/foo\nsha256: " + "0" * 64 + "\n---\ncapture\n", encoding="utf-8")
-    (vault / "Wiki" / "foo.md").write_text("---\ntype: entity\n---\nwiki foo\n", encoding="utf-8")
-    (vault / "Wiki" / "typed.md").write_text(
-        "---\ntype: source\nsource_url: https://x/t\nsha256: " + "0" * 64 + "\n---\nSee [[foo]].\n", encoding="utf-8"
-    )
-    by_path = {i["path"]: i for i in _run(vault)["raw_sources"]}
-    assert by_path["Wiki/typed.md"]["status"] == "unresolved"
-    assert by_path["Wiki/typed.md"]["hashed_file"] is None
-
-
 def test_a_heading_naming_the_type_as_a_substring_is_still_a_base(tmp_path):
     # `## Catalog defaults` contains "log" but does not name the type `log`.
     (tmp_path / "SCHEMA.md").write_text(
@@ -678,26 +315,6 @@ def test_a_heading_naming_the_type_as_a_substring_is_still_a_base(tmp_path):
     types = _run(tmp_path)["types"]
     assert types["log"]["variants"] == 1 and types["log"]["fields"]["created"]["empty"] == 1
     assert types["daily-aggregate"]["variants"] == 1
-
-
-def test_links_with_a_path_resolve_by_that_path_only(vault):
-    raw = _news_shaped_pair(vault)
-    # The Article's link names the wrong day: the only bloomberg-fed.md lives
-    # under 2026-05-06, and it must not stand in for the missing capture.
-    article = vault / "Wiki" / "fed-article.md"
-    article.write_text(
-        article.read_text(encoding="utf-8").replace("[[Raw/2026-05-06/bloomberg-fed]]", "[[Raw/2026-05-07/bloomberg-fed]]"),
-        encoding="utf-8",
-    )
-    report = _run(vault)
-    assert {i["path"]: i["status"] for i in report["raw_sources"]}["Wiki/fed-article.md"] == "unresolved"
-    assert raw.exists()
-    # The same rule in the link graph: a path link to a note that is not there
-    # gives the same-named note elsewhere no backlink.
-    (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nSee [[Archive/alpha-note]].\n", encoding="utf-8")
-    links = _run(vault)["links"]["notes"]
-    assert links["Wiki/alpha-note.md"]["inbound"] == 1
-    assert links["Wiki/gamma-orphan.md"]["outbound"] == 1
 
 
 def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):
@@ -723,3 +340,4 @@ def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):
         schema.write("\nIndented example:\n\n    ```yaml\n    type: ghost\n    ```\n")
         schema.write("\n> [!example]\n> ```yaml\n> type: ghost\n> ```\n")
     assert _run(tmp_path)["schema"]["declared_types"] == ["book"]
+

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -571,6 +571,35 @@ def test_single_type_universal_fence_is_a_base_not_a_variant(tmp_path):
     assert book["fields"]["tags"]["empty"] == 1
 
 
+def test_variant_fences_under_subheadings_keep_their_type_section(tmp_path):
+    # `## Source` / `### Frontmatter` and `## Source — Paper Variant` /
+    # `### Frontmatter`: the enclosing section names the type, so both fences
+    # are variants of `source`, not a union under "Frontmatter".
+    (tmp_path / "SCHEMA.md").write_text(
+        "# Schema\n\n## Source\n\n### Frontmatter\n\n```yaml\n---\ntype: source\nsource_url: \"\"\n---\n```\n\n"
+        "## Source — Paper Variant\n\n### Frontmatter\n\n```yaml\n---\ntype: source\nsource_url: \"\"\nvenue: \"\"\n---\n```\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "plain.md").write_text("---\ntype: source\nsource_url: https://x/p\n---\nbody\n", encoding="utf-8")
+    source = _run(tmp_path, "--field-empty-pct", "90")["types"]["source"]
+    assert source["variants"] == 2 and source["variant_notes"] == [1, 0]
+    assert "venue" not in source["fields"]
+
+
+def test_bare_provenance_link_colliding_with_a_wiki_name_is_unresolved(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    (raw / "foo.md").write_text("---\nsource_url: https://x/foo\nsha256: " + "0" * 64 + "\n---\ncapture\n", encoding="utf-8")
+    (vault / "Wiki" / "foo.md").write_text("---\ntype: entity\n---\nwiki foo\n", encoding="utf-8")
+    (vault / "Wiki" / "typed.md").write_text(
+        "---\ntype: source\nsource_url: https://x/t\nsha256: " + "0" * 64 + "\n---\nSee [[foo]].\n", encoding="utf-8"
+    )
+    by_path = {i["path"]: i for i in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/typed.md"]["status"] == "unresolved"
+    assert by_path["Wiki/typed.md"]["hashed_file"] is None
+
+
 def test_links_with_a_path_resolve_by_that_path_only(vault):
     raw = _news_shaped_pair(vault)
     # The Article's link names the wrong day: the only bloomberg-fed.md lives
@@ -608,7 +637,9 @@ def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):
     report = _run(tmp_path)
     assert report["schema"]["declared_types"] == ["book"]
     assert report["types"]["typename"]["declared"] is None
-    # A fence indented four spaces is an indented code block, not a declaration.
+    # A fence indented four spaces is an indented code block, and a fence inside
+    # a callout is an illustration: neither declares.
     with (tmp_path / "SCHEMA.md").open("a", encoding="utf-8") as schema:
         schema.write("\nIndented example:\n\n    ```yaml\n    type: ghost\n    ```\n")
+        schema.write("\n> [!example]\n> ```yaml\n> type: ghost\n> ```\n")
     assert _run(tmp_path)["schema"]["declared_types"] == ["book"]

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -3,8 +3,9 @@
 Builds a tiny vault in tmp_path, runs `references/lint_vault.py --json` the way
 the skill runs it (a subprocess), and asserts the facts it reports: block-list
 frontmatter reads as filled, undeclared fields are counted against SCHEMA.md,
-the orphan graph, sha256 drift and unhashed Raw Sources, log entries naming
-missing files, tag counts, duplicate-title candidates, and the threshold flags.
+the orphan graph, sha256 drift / unhashed / unresolved provenance, log entries
+naming missing files, tag counts against the taxonomy, duplicate-title
+candidates, and the threshold flags.
 """
 
 import hashlib
@@ -56,6 +57,14 @@ aliases: []
 ---
 ```
 
+## Tag Taxonomy
+
+- `arcforge` — project tag
+- `entity` — entity notes (`entity/tool`, ...)
+
+LINT checks:
+- Unknown top-level tags → flag.
+
 ## Audit Thresholds
 
 - Field empty in 90%+ of a type → EVOLVE candidate (`--field-empty-pct 90`).
@@ -91,7 +100,7 @@ Supersedes [[Wiki/alpha-note]].
 GAMMA = """---
 type: entity
 created: 2026-05-08
-tags: [entity]
+tags: [entity, entity/tool, tdd]
 aliases: []
 extra_field: yes
 ---
@@ -139,7 +148,11 @@ def _pair(report: dict, a: str, b: str) -> dict:
 def test_scans_only_notes_and_reads_declared_types(vault):
     report = _run(vault)
     assert report["notes"] == {"total": 3, "in_scope": 3}
-    assert report["schema"] == {"path": "SCHEMA.md", "declared_types": ["entity", "source"]}
+    assert report["schema"] == {
+        "path": "SCHEMA.md",
+        "declared_types": ["entity", "source"],
+        "declared_tags": ["arcforge", "entity"],
+    }
     assert report["untyped"] == []
 
 
@@ -184,14 +197,60 @@ def test_orphan_graph(vault):
     assert links["notes"]["Wiki/alpha-note-draft.md"] == {"inbound": 1, "outbound": 1}
 
 
-def test_raw_source_drift_and_unhashed(vault):
+def test_typed_note_with_remote_source_and_no_raw_link_is_unresolved_not_drift(vault):
+    # A typed note's sha256 is the Raw Source's digest (B-4), never its own body's:
+    # hashing the synthesized body would report drift on every correct ingest.
     by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
-    alpha = by_path["Wiki/alpha-note.md"]
-    assert alpha["status"] == "drift"
-    assert alpha["stored"] == "0" * 64
-    assert alpha["recomputed"] == hashlib.sha256(ALPHA_BODY.encode("utf-8")).hexdigest()
-    assert alpha["hashed_file"] == "Wiki/alpha-note.md"
+    assert by_path["Wiki/alpha-note.md"] == {
+        "path": "Wiki/alpha-note.md",
+        "hashed_file": None,
+        "status": "unresolved",
+        "stored": "0" * 64,
+        "recomputed": None,
+    }
     assert by_path["Wiki/alpha-note-draft.md"]["status"] == "unhashed"
+
+
+RAW_BODY = "# Fed statement\n\nRates unchanged.\n"
+RAW_DIGEST = hashlib.sha256(RAW_BODY.encode("utf-8")).hexdigest()
+
+
+def _news_shaped_pair(vault: Path) -> Path:
+    raw_dir = vault / "Raw" / "2026-05-06"
+    raw_dir.mkdir(parents=True)
+    raw = raw_dir / "bloomberg-fed.md"
+    raw.write_text(
+        f"---\nsource_url: https://example.com/fed\nsha256: {RAW_DIGEST}\n---\n{RAW_BODY}",
+        encoding="utf-8",
+    )
+    (vault / "Wiki" / "fed-article.md").write_text(
+        "---\ntype: source\ncreated: 2026-05-06\n"
+        f"source_url: https://example.com/fed\nsha256: {RAW_DIGEST}\n---\n"
+        "# Fed\n\n## Lead\nRates held.\n\n## Source\n[[Raw/2026-05-06/bloomberg-fed]] (immutable original)\n",
+        encoding="utf-8",
+    )
+    return raw
+
+
+def test_typed_note_hashes_the_raw_source_its_body_links(vault):
+    raw = _news_shaped_pair(vault)
+    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/fed-article.md"] == {
+        "path": "Wiki/fed-article.md",
+        "hashed_file": "Raw/2026-05-06/bloomberg-fed.md",
+        "status": "fresh",
+        "stored": RAW_DIGEST,
+        "recomputed": RAW_DIGEST,
+    }
+    assert by_path["Raw/2026-05-06/bloomberg-fed.md"]["status"] == "fresh"
+    # --skip Raw takes the capture out of the note set, not out of the drift check.
+    by_path = {item["path"]: item for item in _run(vault, "--skip", "Raw")["raw_sources"]}
+    assert by_path["Wiki/fed-article.md"]["status"] == "fresh"
+    # The publisher edits the article: the re-captured body drifts from the pair.
+    raw.write_text(raw.read_text(encoding="utf-8") + "\nCorrection appended.\n", encoding="utf-8")
+    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/fed-article.md"]["status"] == "drift"
+    assert by_path["Wiki/fed-article.md"]["hashed_file"] == "Raw/2026-05-06/bloomberg-fed.md"
 
 
 def test_log_entries_naming_missing_files(vault):
@@ -200,9 +259,22 @@ def test_log_entries_naming_missing_files(vault):
     assert log["missing_files"] == [{"line": 4, "file": "Wiki/deleted-note.md"}]
 
 
-def test_tag_counts(vault):
+def test_tag_counts_and_taxonomy_membership(vault):
     tags = _run(vault)["tags"]
-    assert {tag: facts["count"] for tag, facts in tags.items()} == {"arcforge": 2, "entity": 1, "tdd": 1}
+    assert {tag: facts["count"] for tag, facts in tags.items()} == {
+        "arcforge": 2,
+        "entity": 1,
+        "entity/tool": 1,
+        "tdd": 2,
+    }
+    # A sub-tag is declared through its top-level segment; a bare "- Unknown top-level
+    # tags → flag." line under the taxonomy heading is not a tag.
+    assert {tag: facts["declared"] for tag, facts in tags.items()} == {
+        "arcforge": True,
+        "entity": True,
+        "entity/tool": True,
+        "tdd": False,
+    }
 
 
 def test_duplicate_title_candidates_carry_a_ratio(vault):
@@ -222,8 +294,11 @@ def test_threshold_flags_set_exceeds(vault):
     assert _pair(report, "Wiki/alpha-note.md", "Wiki/alpha-note-draft.md")["exceeds"] is True
     assert report["types"]["source"]["fields"]["source_author"]["exceeds"] is True
     assert report["types"]["source"]["fields"]["tags"]["exceeds"] is False
-    assert report["tags"]["arcforge"]["exceeds"] is True
-    assert report["tags"]["tdd"]["exceeds"] is False
+    # --tag-min flags a tag outside the taxonomy only: `arcforge` is declared and
+    # sits at the threshold, `tdd` is undeclared at the same count.
+    assert report["tags"]["arcforge"] == {"count": 2, "declared": True, "exceeds": False}
+    assert report["tags"]["tdd"] == {"count": 2, "declared": False, "exceeds": True}
+    assert report["tags"]["entity/tool"]["exceeds"] is False
 
 
 def test_recent_scope_limits_subjects_but_not_the_graph(vault):
@@ -271,3 +346,31 @@ def test_preset_source_types_declare_the_provenance_pair(tmp_path, preset, type_
     )
     undeclared = _run(tmp_path)["types"][type_name]["undeclared"]
     assert "sha256" not in undeclared and "source_url" not in undeclared
+
+
+@pytest.mark.parametrize(
+    "preset,type_name,tag",
+    [("llm-wiki", "entity", "entity/model"), ("news", "article", "region/us"), ("project-tracker", "task", "area/infra")],
+)
+def test_preset_taxonomies_declare_their_top_level_tags(tmp_path, preset, type_name, tag):
+    (tmp_path / "SCHEMA.md").write_text((PRESETS / preset / "SCHEMA.md").read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "note.md").write_text(
+        f"---\ntype: {type_name}\ntags: [{tag}, made-up]\n---\nbody\n", encoding="utf-8"
+    )
+    report = _run(tmp_path, "--tag-min", "1")
+    assert tag.split("/")[0] in report["schema"]["declared_tags"]
+    assert report["tags"][tag] == {"count": 1, "declared": True, "exceeds": False}
+    assert report["tags"]["made-up"] == {"count": 1, "declared": False, "exceeds": True}
+
+
+def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):
+    # The minimal SCHEMA.md declares no types: its universal fence carries the
+    # placeholder `<one of the types declared below>` and its `type: typename`
+    # skeleton sits inside an illustration fence.
+    (tmp_path / "SCHEMA.md").write_text((PRESETS / "minimal" / "SCHEMA.md").read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "note.md").write_text("---\ntype: typename\ntags: [x]\n---\nbody\n", encoding="utf-8")
+    report = _run(tmp_path)
+    assert report["schema"] == {"path": "SCHEMA.md", "declared_types": [], "declared_tags": []}
+    assert report["types"]["typename"]["declared"] is None

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -332,6 +332,20 @@ def test_raw_captures_and_attachment_embeds_are_not_edges(vault):
     assert links["notes"]["Wiki/alpha-note-draft.md"]["outbound"] == 2
 
 
+def test_ambiguous_bare_links_resolve_by_folder_or_not_at_all(vault):
+    for folder in ("A", "B"):
+        (vault / folder).mkdir()
+        (vault / folder / "foo.md").write_text(f"---\ntype: entity\n---\n{folder} foo\n", encoding="utf-8")
+    (vault / "B" / "source.md").write_text("---\ntype: entity\n---\nSee [[foo]].\n", encoding="utf-8")
+    (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nAlso [[foo]].\n", encoding="utf-8")
+    links = _run(vault)["links"]
+    assert links["notes"]["B/foo.md"]["inbound"] == 1      # same folder as B/source.md
+    assert links["notes"]["A/foo.md"]["inbound"] == 0      # not handed the link by sort order
+    assert "A/foo.md" in links["orphans"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1   # ambiguous from Wiki/: unresolved, still a link
+    assert "Wiki/gamma-orphan.md" not in links["orphans"]
+
+
 def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):
     _news_shaped_pair(vault)
     # The Article's only link is its `## Source` line: no wiki relationship, so

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -481,6 +481,43 @@ def test_paper_missing_every_paper_field_still_fits_the_paper_variant(tmp_path):
     assert source["fields"]["source_author"]["expected"] == 2
 
 
+def test_single_type_universal_fence_is_a_base_not_a_variant(tmp_path):
+    # A vault with one type: the universal fence says `type: book` too, so by name
+    # count alone it would be a second variant and a Book missing `created` or
+    # `tags` would never be reported.
+    (tmp_path / "SCHEMA.md").write_text(
+        "# Schema\n\n## Universal Frontmatter\n\n```yaml\n---\ntype: book\ncreated: YYYY-MM-DD\ntags: []\n---\n```\n\n"
+        "## Book\n\n```yaml\n---\ntype: book\nauthor: \"\"\n---\n```\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "dune.md").write_text("---\ntype: book\nauthor: Herbert\n---\nbody\n", encoding="utf-8")
+    book = _run(tmp_path)["types"]["book"]
+    assert book["variants"] == 1 and book["declared"] == ["author", "created", "tags", "type"]
+    assert book["fields"]["created"] == {"expected": 1, "present": 0, "filled": 0, "empty": 1, "empty_pct": 100.0, "exceeds": None}
+    assert book["fields"]["tags"]["empty"] == 1
+
+
+def test_links_with_a_path_resolve_by_that_path_only(vault):
+    raw = _news_shaped_pair(vault)
+    # The Article's link names the wrong day: the only bloomberg-fed.md lives
+    # under 2026-05-06, and it must not stand in for the missing capture.
+    article = vault / "Wiki" / "fed-article.md"
+    article.write_text(
+        article.read_text(encoding="utf-8").replace("[[Raw/2026-05-06/bloomberg-fed]]", "[[Raw/2026-05-07/bloomberg-fed]]"),
+        encoding="utf-8",
+    )
+    report = _run(vault)
+    assert {i["path"]: i["status"] for i in report["raw_sources"]}["Wiki/fed-article.md"] == "unresolved"
+    assert raw.exists()
+    # The same rule in the link graph: a path link to a note that is not there
+    # gives the same-named note elsewhere no backlink.
+    (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nSee [[Archive/alpha-note]].\n", encoding="utf-8")
+    links = _run(vault)["links"]["notes"]
+    assert links["Wiki/alpha-note.md"]["inbound"] == 1
+    assert links["Wiki/gamma-orphan.md"]["outbound"] == 1
+
+
 def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):
     # The minimal SCHEMA.md declares no types: its universal fence carries the
     # placeholder `<one of the types declared below>` and its `type: typename`

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -114,13 +114,15 @@ def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
         log.write("## [2026-05-13] query | summarize Wiki/alpha-note.md and Wiki/gone.md\n")
         log.write("## [2026-05-14] schema | updated SCHEMA.md\n")
         log.write("## [2026-05-15] create | entity | My Root Note.md\n")
+        log.write("## [2026-05-16] drift | My Raw Note.md | sha=0000→1111\n")
     report = _run(vault)["log"]
-    assert report["entries"] == 10
+    assert report["entries"] == 11
     assert report["missing_files"] == [
         {"line": 4, "file": "Wiki/deleted-note.md"},
         {"line": 7, "file": "Raw/recording.mp3"},
         {"line": 9, "file": "Wiki/My Note.md"},
         {"line": 12, "file": "My Root Note.md"},
+        {"line": 13, "file": "My Raw Note.md"},
     ]
 
 

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -283,7 +283,8 @@ def test_raw_sources_are_drift_checked_but_never_scope_subjects(vault):
 
 def test_wikilinks_inside_code_are_examples_not_links(vault):
     (vault / "Wiki" / "gamma-orphan.md").write_text(
-        GAMMA + "\nExample: `[[alpha-note]]` and\n\n```\n[[alpha-note-draft]]\n```\n",
+        # The fence opens with ``` and closes with ````, a longer delimiter CommonMark accepts.
+        GAMMA + "\nExample: `[[alpha-note]]` and\n\n```\n[[alpha-note-draft]]\n````\n",
         encoding="utf-8",
     )
     links = _run(vault)["links"]

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -161,6 +161,17 @@ def test_block_list_frontmatter_reads_as_filled(vault):
     assert tags == {"expected": 2, "present": 2, "filled": 2, "empty": 0, "empty_pct": 0.0, "exceeds": None}
 
 
+def test_comment_lines_inside_a_block_are_not_items(vault):
+    (vault / "Wiki" / "delta-note.md").write_text(
+        "---\ntype: source\ntags:\n  # grouping\n  - project\nsource_author:\n  # none yet\n---\nbody\n",
+        encoding="utf-8",
+    )
+    report = _run(vault)
+    assert report["tags"]["project"]["count"] == 1
+    assert not any(t.startswith("#") or t.startswith("- ") for t in report["tags"])
+    assert report["types"]["source"]["fields"]["source_author"]["filled"] == 0
+
+
 def test_unindented_block_list_reads_as_filled(vault):
     # Valid YAML: sequence items at column 0 under the key (PyYAML reads a list).
     (vault / "Wiki" / "delta-note.md").write_text(
@@ -371,11 +382,14 @@ def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):
     # embeds and examples too.
     (vault / "Wiki" / "gamma-orphan.md").write_text(
         GAMMA + "\n![[diagram.excalidraw]] and ``literal\n[[alpha-note]]`` here.\n"
-        "\n> [!note]\n> ```md\n> [[alpha-note]] inside a callout fence\n> ```\n",
+        "\n> [!note]\n> ```md\n> [[alpha-note]] inside a callout fence\n>```\n\nAfter the callout: [[Node.js]].\n",
         encoding="utf-8",
     )
+    # The callout fence closes on `>``` ` (no space), and text after it is text again.
+    (vault / "Wiki" / "Node.js.md").write_text("---\ntype: entity\n---\nnode\n", encoding="utf-8")
     links = _run(vault)["links"]
-    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert "Wiki/gamma-orphan.md" not in links["orphans"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
     assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
 
 
@@ -388,9 +402,11 @@ def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
         log.write("## [2026-05-09] create | entity | deleted-note.md\n")
         log.write("## [2026-05-10] ingest | raw | Raw/recording.mp3\n")
         log.write("## [2026-05-11] schema | bump to v1.2\n")
+        log.write("## [2026-05-12] create | entity | Wiki/My Note.md\n")
     assert _run(vault)["log"]["missing_files"] == [
         {"line": 4, "file": "Wiki/deleted-note.md"},
         {"line": 7, "file": "Raw/recording.mp3"},
+        {"line": 9, "file": "Wiki/My Note.md"},
     ]
 
 

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -340,6 +340,10 @@ def test_ambiguous_bare_links_resolve_by_folder_or_not_at_all(vault):
     (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nAlso [[foo]].\n", encoding="utf-8")
     links = _run(vault)["links"]
     assert links["notes"]["B/foo.md"]["inbound"] == 1      # same folder as B/source.md
+    assert links["notes"]["A/foo.md"]["inbound"] == 0      # not handed the link by sort order
+    assert "A/foo.md" in links["orphans"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1   # ambiguous from Wiki/: unresolved, still a link
+    assert "Wiki/gamma-orphan.md" not in links["orphans"]
     # The same-folder rule also decides the attachment and provenance prefilters:
     # a dotted name shared by two folders, and a bare name a capture also has.
     for folder in ("A", "B"):
@@ -351,10 +355,9 @@ def test_ambiguous_bare_links_resolve_by_folder_or_not_at_all(vault):
     assert links["notes"]["B/Node.js.md"]["inbound"] == 1
     assert links["notes"]["B/foo.md"]["inbound"] == 1
     assert links["notes"]["B/source.md"]["outbound"] == 2
-    assert links["notes"]["A/foo.md"]["inbound"] == 0      # not handed the link by sort order
-    assert "A/foo.md" in links["orphans"]
-    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1   # ambiguous from Wiki/: unresolved, still a link
-    assert "Wiki/gamma-orphan.md" not in links["orphans"]
+    # With a wiki `foo` in two folders and a capture `foo`, the ambiguous link
+    # from Wiki/ is still a wiki link (unresolved), not provenance.
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
 
 
 def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -332,6 +332,23 @@ def test_raw_captures_and_attachment_embeds_are_not_edges(vault):
     assert links["notes"]["Wiki/alpha-note-draft.md"]["outbound"] == 2
 
 
+def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):
+    _news_shaped_pair(vault)
+    # The Article's only link is its `## Source` line: no wiki relationship, so
+    # it is an orphan, while its provenance still resolves for the drift check.
+    report = _run(vault)
+    assert "Wiki/fed-article.md" in report["links"]["orphans"]
+    assert {i["path"]: i["status"] for i in report["raw_sources"]}["Wiki/fed-article.md"] == "fresh"
+    # A long attachment extension and a code span crossing a line break are
+    # embeds and examples too.
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\n![[diagram.excalidraw]] and ``literal\n[[alpha-note]]`` here.\n", encoding="utf-8"
+    )
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+
+
 def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
     # `Wiki/deleted-note.md` stays missing when only `Archive/deleted-note.md`
     # exists; a bare basename in the log still matches any file of that name.

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -347,6 +347,23 @@ def test_raw_captures_and_attachment_embeds_are_not_edges(vault):
     assert links["notes"]["Wiki/alpha-note-draft.md"]["outbound"] == 2
 
 
+def test_links_in_yaml_comments_are_not_edges_but_links_in_values_are(vault):
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: []   # e.g. [[alpha-note]]\n"),
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: \"[[alpha-note]]\"\n"),
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 2
+
+
 def test_self_links_under_any_spelling_are_not_edges(vault):
     (vault / "Wiki" / "gamma-orphan.md").write_text(
         GAMMA + "\nSelf: [[gamma-orphan]] and [[Wiki/gamma-orphan]] and [[gamma-orphan#Heading|me]].\n",
@@ -431,7 +448,10 @@ def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
         log.write("## [2026-05-10] ingest | raw | Raw/recording.mp3\n")
         log.write("## [2026-05-11] schema | bump to v1.2\n")
         log.write("## [2026-05-12] create | entity | Wiki/My Note.md\n")
-    assert _run(vault)["log"]["missing_files"] == [
+        log.write("## [2026-05-13] query | summarize Wiki/alpha-note.md and Wiki/gone.md\n")
+    report = _run(vault)["log"]
+    assert report["entries"] == 8
+    assert report["missing_files"] == [
         {"line": 4, "file": "Wiki/deleted-note.md"},
         {"line": 7, "file": "Raw/recording.mp3"},
         {"line": 9, "file": "Wiki/My Note.md"},

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -209,7 +209,8 @@ def test_typed_note_with_remote_source_and_no_raw_link_is_unresolved_not_drift(v
         "stored": "0" * 64,
         "recomputed": None,
     }
-    assert by_path["Wiki/alpha-note-draft.md"]["status"] == "unhashed"
+    # An empty digest with nothing to backfill from is unresolved too, not unhashed.
+    assert by_path["Wiki/alpha-note-draft.md"]["status"] == "unresolved"
 
 
 RAW_BODY = "# Fed statement\n\nRates unchanged.\n"
@@ -244,6 +245,14 @@ def test_typed_note_hashes_the_raw_source_its_body_links(vault):
         "recomputed": RAW_DIGEST,
     }
     assert by_path["Raw/2026-05-06/bloomberg-fed.md"]["status"] == "fresh"
+    # A legacy empty digest on a note whose capture resolves is unhashed: backfill from it.
+    (vault / "Wiki" / "fed-article-legacy.md").write_text(
+        "---\ntype: source\nsource_url: https://example.com/fed\nsha256: \"\"\n---\n"
+        "## Source\n[[Raw/2026-05-06/bloomberg-fed]]\n",
+        encoding="utf-8",
+    )
+    legacy = {item["path"]: item for item in _run(vault)["raw_sources"]}["Wiki/fed-article-legacy.md"]
+    assert legacy["status"] == "unhashed" and legacy["recomputed"] == RAW_DIGEST
     # --skip Raw takes the capture out of the note set, not out of the drift check.
     by_path = {item["path"]: item for item in _run(vault, "--skip", "Raw")["raw_sources"]}
     assert by_path["Wiki/fed-article.md"]["status"] == "fresh"
@@ -388,7 +397,7 @@ def test_variant_only_fields_are_expected_of_the_notes_fitting_that_variant(tmp_
         (tmp_path / f"source-{n}.md").write_text(GENERIC_SOURCE.format(n=n, digest="0" * 64), encoding="utf-8")
     (tmp_path / "paper.md").write_text(PAPER_SOURCE.format(digest="1" * 64), encoding="utf-8")
     source = _run(tmp_path, "--field-empty-pct", "90")["types"]["source"]
-    assert source["notes"] == 4 and source["variants"] == 2
+    assert source["notes"] == 4 and source["variants"] == 2 and source["variant_notes"] == [3, 1]
     assert source["undeclared"] == {}
     fields = source["fields"]
     assert fields["source_author"]["expected"] == 4 and fields["sha256"]["expected"] == 4
@@ -402,6 +411,22 @@ def test_variant_only_fields_are_expected_of_the_notes_fitting_that_variant(tmp_
     )
     fields = _run(tmp_path)["types"]["source"]["fields"]
     assert fields["venue"] == {"expected": 2, "present": 2, "filled": 2, "empty": 0, "empty_pct": 0.0, "exceeds": None}
+
+
+def test_paper_missing_every_paper_field_still_fits_the_paper_variant(tmp_path):
+    # By keys alone a malformed paper is a generic Source; the Paper fence's
+    # `tags: [paper]` is its discriminator, so the missing fields are expected.
+    (tmp_path / "SCHEMA.md").write_text((PRESETS / "llm-wiki" / "SCHEMA.md").read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "source-0.md").write_text(GENERIC_SOURCE.format(n=0, digest="0" * 64), encoding="utf-8")
+    (tmp_path / "malformed-paper.md").write_text(
+        GENERIC_SOURCE.format(n=1, digest="1" * 64).replace("tags: [source]", "tags: [source/paper]"),
+        encoding="utf-8",
+    )
+    source = _run(tmp_path, "--field-empty-pct", "90")["types"]["source"]
+    assert source["variant_notes"] == [1, 1]
+    assert source["fields"]["venue"] == {"expected": 1, "present": 0, "filled": 0, "empty": 1, "empty_pct": 100.0, "exceeds": True}
+    assert source["fields"]["source_author"]["expected"] == 2
 
 
 def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -356,7 +356,9 @@ def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):
     # A long attachment extension and a code span crossing a line break are
     # embeds and examples too.
     (vault / "Wiki" / "gamma-orphan.md").write_text(
-        GAMMA + "\n![[diagram.excalidraw]] and ``literal\n[[alpha-note]]`` here.\n", encoding="utf-8"
+        GAMMA + "\n![[diagram.excalidraw]] and ``literal\n[[alpha-note]]`` here.\n"
+        "\n> [!note]\n> ```md\n> [[alpha-note]] inside a callout fence\n> ```\n",
+        encoding="utf-8",
     )
     links = _run(vault)["links"]
     assert "Wiki/gamma-orphan.md" in links["orphans"]

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -113,14 +113,14 @@ def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
         log.write("## [2026-05-12] create | entity | Wiki/My Note.md\n")
         log.write("## [2026-05-13] query | summarize Wiki/alpha-note.md and Wiki/gone.md\n")
         log.write("## [2026-05-14] schema | updated SCHEMA.md\n")
-        log.write("## [2026-05-15] create | entity | ./My Root Note.md\n")
+        log.write("## [2026-05-15] create | entity | My Root Note.md\n")
     report = _run(vault)["log"]
     assert report["entries"] == 10
     assert report["missing_files"] == [
         {"line": 4, "file": "Wiki/deleted-note.md"},
         {"line": 7, "file": "Raw/recording.mp3"},
         {"line": 9, "file": "Wiki/My Note.md"},
-        {"line": 12, "file": "./My Root Note.md"},
+        {"line": 12, "file": "My Root Note.md"},
     ]
 
 

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -343,6 +343,30 @@ def test_raw_captures_and_attachment_embeds_are_not_edges(vault):
     assert links["notes"]["Wiki/alpha-note-draft.md"]["outbound"] == 2
 
 
+def test_self_links_under_any_spelling_are_not_edges(vault):
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\nSelf: [[gamma-orphan]] and [[Wiki/gamma-orphan]] and [[gamma-orphan#Heading|me]].\n",
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert links["notes"]["Wiki/gamma-orphan.md"] == {"inbound": 0, "outbound": 0}
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+
+
+def test_fenced_examples_under_the_taxonomy_declare_nothing(vault):
+    schema = vault / "SCHEMA.md"
+    schema.write_text(
+        schema.read_text(encoding="utf-8").replace(
+            "LINT checks:\n", "Example of a bad entry:\n\n```\n- `ghost` — not a real tag\n```\n\nLINT checks:\n"
+        ),
+        encoding="utf-8",
+    )
+    (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA.replace("tags: [entity, entity/tool, tdd]", "tags: [ghost]"), encoding="utf-8")
+    report = _run(vault, "--tag-min", "1")
+    assert report["schema"]["declared_tags"] == ["arcforge", "entity"]
+    assert report["tags"]["ghost"] == {"count": 1, "declared": False, "exceeds": True}
+
+
 def test_ambiguous_bare_links_resolve_by_folder_or_not_at_all(vault):
     for folder in ("A", "B"):
         (vault / folder).mkdir()

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -340,6 +340,17 @@ def test_ambiguous_bare_links_resolve_by_folder_or_not_at_all(vault):
     (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nAlso [[foo]].\n", encoding="utf-8")
     links = _run(vault)["links"]
     assert links["notes"]["B/foo.md"]["inbound"] == 1      # same folder as B/source.md
+    # The same-folder rule also decides the attachment and provenance prefilters:
+    # a dotted name shared by two folders, and a bare name a capture also has.
+    for folder in ("A", "B"):
+        (vault / folder / "Node.js.md").write_text("---\ntype: entity\n---\nnode\n", encoding="utf-8")
+    (vault / "Raw").mkdir()
+    (vault / "Raw" / "foo.md").write_text("---\nsource_url: https://x/foo\nsha256: " + "0" * 64 + "\n---\ncapture\n", encoding="utf-8")
+    (vault / "B" / "source.md").write_text("---\ntype: entity\n---\nSee [[foo]] and [[Node.js]].\n", encoding="utf-8")
+    links = _run(vault)["links"]
+    assert links["notes"]["B/Node.js.md"]["inbound"] == 1
+    assert links["notes"]["B/foo.md"]["inbound"] == 1
+    assert links["notes"]["B/source.md"]["outbound"] == 2
     assert links["notes"]["A/foo.md"]["inbound"] == 0      # not handed the link by sort order
     assert "A/foo.md" in links["orphans"]
     assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1   # ambiguous from Wiki/: unresolved, still a link
@@ -372,7 +383,12 @@ def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
     (vault / "Archive" / "deleted-note.md").write_text("---\ntype: entity\n---\nmoved\n", encoding="utf-8")
     with (vault / "log.md").open("a", encoding="utf-8") as log:
         log.write("## [2026-05-09] create | entity | deleted-note.md\n")
-    assert _run(vault)["log"]["missing_files"] == [{"line": 4, "file": "Wiki/deleted-note.md"}]
+        log.write("## [2026-05-10] ingest | raw | Raw/recording.mp3\n")
+        log.write("## [2026-05-11] schema | bump to v1.2\n")
+    assert _run(vault)["log"]["missing_files"] == [
+        {"line": 4, "file": "Wiki/deleted-note.md"},
+        {"line": 7, "file": "Raw/recording.mp3"},
+    ]
 
 
 def test_tag_counts_and_taxonomy_membership(vault):

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -254,3 +254,20 @@ def test_skip_drops_a_folder_and_bad_scope_is_rejected(vault):
     )
     assert proc.returncode != 0
     assert "scope must be" in proc.stderr
+
+
+PRESETS = Path(__file__).resolve().parents[2] / "skills" / "core" / "maintaining-obsidian" / "presets"
+
+
+@pytest.mark.parametrize("preset,type_name", [("llm-wiki", "source"), ("news", "article")])
+def test_preset_source_types_declare_the_provenance_pair(tmp_path, preset, type_name):
+    # obsidian.md B-4: the typed note carries source_url and sha256; a preset whose
+    # schema omits sha256 makes every conformant note an undeclared-field finding.
+    (tmp_path / "SCHEMA.md").write_text((PRESETS / preset / "SCHEMA.md").read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "note.md").write_text(
+        f"---\ntype: {type_name}\nsource_url: https://example.com/x\nsha256: {'0' * 64}\n---\nbody\n",
+        encoding="utf-8",
+    )
+    undeclared = _run(tmp_path)["types"][type_name]["undeclared"]
+    assert "sha256" not in undeclared and "source_url" not in undeclared

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -311,6 +311,27 @@ def test_log_entries_naming_missing_files(vault):
     assert log["missing_files"] == [{"line": 4, "file": "Wiki/deleted-note.md"}]
 
 
+def test_raw_captures_and_attachment_embeds_are_not_edges(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    # Captured text mentioning the orphan is the source's link, not the vault's.
+    (raw / "capture.md").write_text(
+        "---\nsource_url: https://example.com/c\nsha256: " + "0" * 64 + "\n---\nSee [[Wiki/gamma-orphan]] and [[alpha-note]].\n",
+        encoding="utf-8",
+    )
+    # Attachments of any extension are embeds; a dotted note name still resolves.
+    (vault / "Wiki" / "Node.js.md").write_text("---\ntype: entity\n---\nabout node\n", encoding="utf-8")
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\n![[recording.mp3]] ![[clip.webp]] ![[deck.pdf]]\n", encoding="utf-8"
+    )
+    (vault / "Wiki" / "alpha-note-draft.md").write_text(DRAFT + "\nRuntime: [[Node.js]].\n", encoding="utf-8")
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+    assert links["notes"]["Wiki/Node.js.md"]["inbound"] == 1
+    assert links["notes"]["Wiki/alpha-note-draft.md"]["outbound"] == 2
+
+
 def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
     # `Wiki/deleted-note.md` stays missing when only `Archive/deleted-note.md`
     # exists; a bare basename in the log still matches any file of that name.

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -281,10 +281,23 @@ def test_raw_sources_are_drift_checked_but_never_scope_subjects(vault):
     assert not any("Raw/" in d["a"] or "Raw/" in d["b"] for d in _run(vault)["duplicate_titles"])
 
 
+def test_audit_reports_are_never_scope_subjects(vault):
+    reports = vault / "_audits"
+    reports.mkdir()
+    report = reports / "audit-2026-05-09-all.md"
+    report.write_text("---\ntype: audit-report\ncreated: 2026-05-09\n---\n# Audit\n", encoding="utf-8")
+    newest = max(p.stat().st_mtime for p in (vault / "Wiki").iterdir()) + 10
+    os.utime(report, (newest, newest))
+    result = _run(vault, "--scope", "recent:1")
+    assert result["notes"] == {"total": 3, "raw_sources": 0, "in_scope": 1}
+    assert "audit-report" not in result["types"]
+
+
 def test_wikilinks_inside_code_are_examples_not_links(vault):
     (vault / "Wiki" / "gamma-orphan.md").write_text(
-        # The fence opens with ``` and closes with ````, a longer delimiter CommonMark accepts.
-        GAMMA + "\nExample: `[[alpha-note]]` and\n\n```\n[[alpha-note-draft]]\n````\n",
+        # A double-backtick span, and a fence that opens with ``` and closes with
+        # ```` — a longer delimiter CommonMark accepts.
+        GAMMA + "\nExample: `[[alpha-note]]`, ``[[alpha-note]]`` and\n\n```\n[[alpha-note-draft]]\n````\n",
         encoding="utf-8",
     )
     links = _run(vault)["links"]
@@ -485,3 +498,7 @@ def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):
     report = _run(tmp_path)
     assert report["schema"]["declared_types"] == ["book"]
     assert report["types"]["typename"]["declared"] is None
+    # A fence indented four spaces is an indented code block, not a declaration.
+    with (tmp_path / "SCHEMA.md").open("a", encoding="utf-8") as schema:
+        schema.write("\nIndented example:\n\n    ```yaml\n    type: ghost\n    ```\n")
+    assert _run(tmp_path)["schema"]["declared_types"] == ["book"]

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -158,7 +158,7 @@ def test_scans_only_notes_and_reads_declared_types(vault):
 
 def test_block_list_frontmatter_reads_as_filled(vault):
     tags = _run(vault)["types"]["source"]["fields"]["tags"]
-    assert tags == {"present": 2, "filled": 2, "empty": 0, "empty_pct": 0.0, "exceeds": None}
+    assert tags == {"expected": 2, "present": 2, "filled": 2, "empty": 0, "empty_pct": 0.0, "exceeds": None}
 
 
 def test_unindented_block_list_reads_as_filled(vault):
@@ -168,7 +168,7 @@ def test_unindented_block_list_reads_as_filled(vault):
         encoding="utf-8",
     )
     tags = _run(vault)["types"]["source"]["fields"]["tags"]
-    assert tags == {"present": 3, "filled": 3, "empty": 0, "empty_pct": 0.0, "exceeds": None}
+    assert tags == {"expected": 3, "present": 3, "filled": 3, "empty": 0, "empty_pct": 0.0, "exceeds": None}
 
 
 def test_raw_source_note_without_type_is_drift_checked_not_untyped(vault):
@@ -187,6 +187,7 @@ def test_raw_source_note_without_type_is_drift_checked_not_untyped(vault):
 def test_undeclared_fields_are_counted_against_schema(vault):
     entity = _run(vault)["types"]["entity"]
     assert entity["declared"] == ["aliases", "created", "tags", "type"]
+    assert entity["variants"] == 1
     assert entity["undeclared"] == {"extra_field": {"present": 1, "present_pct": 100.0, "exceeds": None}}
 
 
@@ -362,6 +363,45 @@ def test_preset_taxonomies_declare_their_top_level_tags(tmp_path, preset, type_n
     assert tag.split("/")[0] in report["schema"]["declared_tags"]
     assert report["tags"][tag] == {"count": 1, "declared": True, "exceeds": False}
     assert report["tags"]["made-up"] == {"count": 1, "declared": False, "exceeds": True}
+
+
+GENERIC_SOURCE = (
+    "---\ntype: source\ncreated: 2026-05-06\nlangs: [en, zh]\n"
+    "source_url: https://example.com/{n}\nsource_author: Someone\nsha256: {digest}\n"
+    "tags: [source]\naliases: []\n---\nbody\n"
+)
+PAPER_SOURCE = (
+    "---\ntype: source\ncreated: 2026-05-06\nlangs: [en, zh]\n"
+    "source_url: https://arxiv.org/abs/1\nsource_author: [A, B]\nsha256: {digest}\n"
+    "venue: NeurIPS\nyear: 2025\nmethodology: ''\nreading_status: queued\n"
+    "cites: []\ncited_by: []\ntags: [paper]\naliases: []\n---\nbody\n"
+)
+
+
+def test_variant_only_fields_are_expected_of_the_notes_fitting_that_variant(tmp_path):
+    # llm-wiki declares Source twice — the generic fence and the Paper variant —
+    # both as `type: source`. Paper-only fields are measured over the notes that
+    # fit the Paper variant, not reported 100% empty across every Source.
+    (tmp_path / "SCHEMA.md").write_text((PRESETS / "llm-wiki" / "SCHEMA.md").read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    for n in range(3):
+        (tmp_path / f"source-{n}.md").write_text(GENERIC_SOURCE.format(n=n, digest="0" * 64), encoding="utf-8")
+    (tmp_path / "paper.md").write_text(PAPER_SOURCE.format(digest="1" * 64), encoding="utf-8")
+    source = _run(tmp_path, "--field-empty-pct", "90")["types"]["source"]
+    assert source["notes"] == 4 and source["variants"] == 2
+    assert source["undeclared"] == {}
+    fields = source["fields"]
+    assert fields["source_author"]["expected"] == 4 and fields["sha256"]["expected"] == 4
+    assert fields["venue"] == {"expected": 1, "present": 1, "filled": 1, "empty": 0, "empty_pct": 0.0, "exceeds": False}
+    assert fields["methodology"] == {"expected": 1, "present": 1, "filled": 0, "empty": 1, "empty_pct": 100.0, "exceeds": True}
+    assert fields["cites"]["exceeds"] is True  # the paper's own empty list, over one expected note
+    # A generic Source that carries a paper-only field anyway is counted for it.
+    (tmp_path / "source-0.md").write_text(
+        GENERIC_SOURCE.format(n=0, digest="0" * 64).replace("aliases: []", "aliases: []\nvenue: Blog"),
+        encoding="utf-8",
+    )
+    fields = _run(tmp_path)["types"]["source"]["fields"]
+    assert fields["venue"] == {"expected": 2, "present": 2, "filled": 2, "empty": 0, "empty_pct": 0.0, "exceeds": None}
 
 
 def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -269,6 +269,16 @@ def test_log_entries_naming_missing_files(vault):
     assert log["missing_files"] == [{"line": 4, "file": "Wiki/deleted-note.md"}]
 
 
+def test_log_path_tokens_are_not_satisfied_by_a_basename_elsewhere(vault):
+    # `Wiki/deleted-note.md` stays missing when only `Archive/deleted-note.md`
+    # exists; a bare basename in the log still matches any file of that name.
+    (vault / "Archive").mkdir()
+    (vault / "Archive" / "deleted-note.md").write_text("---\ntype: entity\n---\nmoved\n", encoding="utf-8")
+    with (vault / "log.md").open("a", encoding="utf-8") as log:
+        log.write("## [2026-05-09] create | entity | deleted-note.md\n")
+    assert _run(vault)["log"]["missing_files"] == [{"line": 4, "file": "Wiki/deleted-note.md"}]
+
+
 def test_tag_counts_and_taxonomy_membership(vault):
     tags = _run(vault)["tags"]
     assert {tag: facts["count"] for tag, facts in tags.items()} == {

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -264,9 +264,13 @@ def test_typed_note_hashes_the_raw_source_its_body_links(vault):
     )
     legacy = {item["path"]: item for item in _run(vault)["raw_sources"]}["Wiki/fed-article-legacy.md"]
     assert legacy["status"] == "unhashed" and legacy["recomputed"] == RAW_DIGEST
-    # --skip Raw takes the capture out of the note set, not out of the drift check.
-    by_path = {item["path"]: item for item in _run(vault, "--skip", "Raw")["raw_sources"]}
+    # --skip Raw takes the capture out of the note set, not out of the drift
+    # check, and its link is still provenance rather than a wiki edge.
+    skipped = _run(vault, "--skip", "Raw")
+    by_path = {item["path"]: item for item in skipped["raw_sources"]}
     assert by_path["Wiki/fed-article.md"]["status"] == "fresh"
+    assert by_path["Raw/2026-05-06/bloomberg-fed.md"]["status"] == "fresh"
+    assert "Wiki/fed-article.md" in skipped["links"]["orphans"]
     # The publisher edits the article: the re-captured body drifts from the pair.
     raw.write_text(raw.read_text(encoding="utf-8") + "\nCorrection appended.\n", encoding="utf-8")
     by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
@@ -638,6 +642,22 @@ def test_bare_provenance_link_colliding_with_a_wiki_name_is_unresolved(vault):
     by_path = {i["path"]: i for i in _run(vault)["raw_sources"]}
     assert by_path["Wiki/typed.md"]["status"] == "unresolved"
     assert by_path["Wiki/typed.md"]["hashed_file"] is None
+
+
+def test_a_heading_naming_the_type_as_a_substring_is_still_a_base(tmp_path):
+    # `## Catalog defaults` contains "log" but does not name the type `log`.
+    (tmp_path / "SCHEMA.md").write_text(
+        "# Schema\n\n## Catalog defaults\n\n```yaml\n---\ntype: log\ncreated: YYYY-MM-DD\n---\n```\n\n"
+        "## Log\n\n```yaml\n---\ntype: log\nlevel: \"\"\n---\n```\n\n"
+        "## Daily Aggregate\n\n```yaml\n---\ntype: daily-aggregate\nday: \"\"\n---\n```\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "AGENTS.md").write_text("# Contract\n", encoding="utf-8")
+    (tmp_path / "entry.md").write_text("---\ntype: log\nlevel: info\n---\nbody\n", encoding="utf-8")
+    (tmp_path / "day.md").write_text("---\ntype: daily-aggregate\nday: 2026-05-06\n---\nbody\n", encoding="utf-8")
+    types = _run(tmp_path)["types"]
+    assert types["log"]["variants"] == 1 and types["log"]["fields"]["created"]["empty"] == 1
+    assert types["daily-aggregate"]["variants"] == 1
 
 
 def test_links_with_a_path_resolve_by_that_path_only(vault):

--- a/tests/skills/test_lint_vault.py
+++ b/tests/skills/test_lint_vault.py
@@ -147,7 +147,7 @@ def _pair(report: dict, a: str, b: str) -> dict:
 
 def test_scans_only_notes_and_reads_declared_types(vault):
     report = _run(vault)
-    assert report["notes"] == {"total": 3, "in_scope": 3}
+    assert report["notes"] == {"total": 3, "raw_sources": 0, "in_scope": 3}
     assert report["schema"] == {
         "path": "SCHEMA.md",
         "declared_types": ["entity", "source"],
@@ -263,6 +263,34 @@ def test_typed_note_hashes_the_raw_source_its_body_links(vault):
     assert by_path["Wiki/fed-article.md"]["hashed_file"] == "Raw/2026-05-06/bloomberg-fed.md"
 
 
+def test_raw_sources_are_drift_checked_but_never_scope_subjects(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    (raw / "alpha-capture.md").write_text(
+        "---\ntitle: Alpha\nsource_url: https://example.com/alpha\nsha256: " + "0" * 64 + "\n---\nraw text\n",
+        encoding="utf-8",
+    )
+    newest = max(p.stat().st_mtime for p in (vault / "Wiki").iterdir()) + 10
+    os.utime(raw / "alpha-capture.md", (newest, newest))
+    report = _run(vault, "--scope", "recent:1")
+    # The newest file is the capture, yet the one subject is a wiki note.
+    assert report["notes"] == {"total": 3, "raw_sources": 1, "in_scope": 1}
+    assert list(report["links"]["notes"]) != ["Raw/alpha-capture.md"]
+    assert {item["path"] for item in report["raw_sources"]} >= {"Raw/alpha-capture.md"}
+    # A capture titled like its note is not a duplicate-title candidate.
+    assert not any("Raw/" in d["a"] or "Raw/" in d["b"] for d in _run(vault)["duplicate_titles"])
+
+
+def test_wikilinks_inside_code_are_examples_not_links(vault):
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\nExample: `[[alpha-note]]` and\n\n```\n[[alpha-note-draft]]\n```\n",
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+
+
 def test_log_entries_naming_missing_files(vault):
     log = _run(vault)["log"]
     assert log["entries"] == 3
@@ -333,14 +361,14 @@ def test_recent_scope_limits_subjects_but_not_the_graph(vault):
     )
     assert proc.returncode == 0, proc.stderr
     report = json.loads(proc.stdout)
-    assert report["notes"] == {"total": 3, "in_scope": 1}
+    assert report["notes"] == {"total": 3, "raw_sources": 0, "in_scope": 1}
     assert list(report["links"]["notes"]) == ["Wiki/alpha-note-draft.md"]
     assert report["links"]["notes"]["Wiki/alpha-note-draft.md"]["inbound"] == 1
 
 
 def test_skip_drops_a_folder_and_bad_scope_is_rejected(vault):
     report = _run(vault, "--skip", "Wiki")
-    assert report["notes"] == {"total": 0, "in_scope": 0}
+    assert report["notes"] == {"total": 0, "raw_sources": 0, "in_scope": 0}
     proc = subprocess.run(
         [sys.executable, str(SCRIPT), str(vault), "--scope", "latest"],
         capture_output=True,
@@ -448,4 +476,11 @@ def test_minimal_preset_placeholders_declare_no_types_or_tags(tmp_path):
     (tmp_path / "note.md").write_text("---\ntype: typename\ntags: [x]\n---\nbody\n", encoding="utf-8")
     report = _run(tmp_path)
     assert report["schema"] == {"path": "SCHEMA.md", "declared_types": [], "declared_tags": []}
+    assert report["types"]["typename"]["declared"] is None
+    # A real type added after the illustration is read: the illustration's closer
+    # does not open a fence that swallows the rest of the file.
+    with (tmp_path / "SCHEMA.md").open("a", encoding="utf-8") as schema:
+        schema.write("\n## Book\n\n```yaml\n---\ntype: book\nauthor: \"\"\n---\n```\n")
+    report = _run(tmp_path)
+    assert report["schema"]["declared_types"] == ["book"]
     assert report["types"]["typename"]["declared"] is None

--- a/tests/skills/test_vault_links.py
+++ b/tests/skills/test_vault_links.py
@@ -1,0 +1,243 @@
+"""Contract test for the LINT script's link graph and Raw Source provenance
+(`references/vault_links.py`, driven through lint_vault.py as the skill runs it).
+"""
+
+import os
+from pathlib import Path
+
+from .lint_vault_support import (
+    DRAFT,
+    GAMMA,
+    RAW_DIGEST,
+    _run,
+    _news_shaped_pair,
+)
+
+
+def test_raw_source_note_without_type_is_drift_checked_not_untyped(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    (raw / "article.md").write_text(
+        "---\nsource_url: https://example.com/a\nsha256: " + "0" * 64 + "\n---\nraw text\n",
+        encoding="utf-8",
+    )
+    report = _run(vault)
+    assert report["untyped"] == []
+    by_path = {item["path"]: item for item in report["raw_sources"]}
+    assert by_path["Raw/article.md"]["status"] == "drift"
+
+
+def test_orphan_graph(vault):
+    links = _run(vault)["links"]
+    assert links["orphans"] == ["Wiki/gamma-orphan.md"]
+    assert links["notes"]["Wiki/alpha-note.md"] == {"inbound": 1, "outbound": 1}
+    assert links["notes"]["Wiki/alpha-note-draft.md"] == {"inbound": 1, "outbound": 1}
+
+
+def test_typed_note_with_remote_source_and_no_raw_link_is_unresolved_not_drift(vault):
+    # A typed note's sha256 is the Raw Source's digest (B-4), never its own body's:
+    # hashing the synthesized body would report drift on every correct ingest.
+    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/alpha-note.md"] == {
+        "path": "Wiki/alpha-note.md",
+        "hashed_file": None,
+        "status": "unresolved",
+        "stored": "0" * 64,
+        "recomputed": None,
+    }
+    # An empty digest with nothing to backfill from is unresolved too, not unhashed.
+    assert by_path["Wiki/alpha-note-draft.md"]["status"] == "unresolved"
+
+
+def test_typed_note_hashes_the_raw_source_its_body_links(vault):
+    raw = _news_shaped_pair(vault)
+    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/fed-article.md"] == {
+        "path": "Wiki/fed-article.md",
+        "hashed_file": "Raw/2026-05-06/bloomberg-fed.md",
+        "status": "fresh",
+        "stored": RAW_DIGEST,
+        "recomputed": RAW_DIGEST,
+    }
+    assert by_path["Raw/2026-05-06/bloomberg-fed.md"]["status"] == "fresh"
+    # A legacy empty digest on a note whose capture resolves is unhashed: backfill from it.
+    (vault / "Wiki" / "fed-article-legacy.md").write_text(
+        "---\ntype: source\nsource_url: https://example.com/fed\nsha256: \"\"\n---\n"
+        "## Source\n[[Raw/2026-05-06/bloomberg-fed]]\n",
+        encoding="utf-8",
+    )
+    legacy = {item["path"]: item for item in _run(vault)["raw_sources"]}["Wiki/fed-article-legacy.md"]
+    assert legacy["status"] == "unhashed" and legacy["recomputed"] == RAW_DIGEST
+    # --skip Raw takes the capture out of the note set, not out of the drift
+    # check, and its link is still provenance rather than a wiki edge.
+    skipped = _run(vault, "--skip", "Raw")
+    by_path = {item["path"]: item for item in skipped["raw_sources"]}
+    assert by_path["Wiki/fed-article.md"]["status"] == "fresh"
+    assert by_path["Raw/2026-05-06/bloomberg-fed.md"]["status"] == "fresh"
+    assert "Wiki/fed-article.md" in skipped["links"]["orphans"]
+    # The publisher edits the article: the re-captured body drifts from the pair.
+    raw.write_text(raw.read_text(encoding="utf-8") + "\nCorrection appended.\n", encoding="utf-8")
+    by_path = {item["path"]: item for item in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/fed-article.md"]["status"] == "drift"
+    assert by_path["Wiki/fed-article.md"]["hashed_file"] == "Raw/2026-05-06/bloomberg-fed.md"
+
+
+def test_raw_sources_are_drift_checked_but_never_scope_subjects(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    (raw / "alpha-capture.md").write_text(
+        "---\ntitle: Alpha\nsource_url: https://example.com/alpha\nsha256: " + "0" * 64 + "\n---\nraw text\n",
+        encoding="utf-8",
+    )
+    newest = max(p.stat().st_mtime for p in (vault / "Wiki").iterdir()) + 10
+    os.utime(raw / "alpha-capture.md", (newest, newest))
+    report = _run(vault, "--scope", "recent:1")
+    # The newest file is the capture, yet the one subject is a wiki note.
+    assert report["notes"] == {"total": 3, "raw_sources": 1, "in_scope": 1}
+    assert list(report["links"]["notes"]) != ["Raw/alpha-capture.md"]
+    assert {item["path"] for item in report["raw_sources"]} >= {"Raw/alpha-capture.md"}
+    # A capture titled like its note is not a duplicate-title candidate.
+    assert not any("Raw/" in d["a"] or "Raw/" in d["b"] for d in _run(vault)["duplicate_titles"])
+
+
+def test_wikilinks_inside_code_are_examples_not_links(vault):
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        # A double-backtick span, and a fence that opens with ``` and closes with
+        # ```` — a longer delimiter CommonMark accepts.
+        GAMMA + "\nExample: `[[alpha-note]]`, ``[[alpha-note]]`` and\n\n```\n[[alpha-note-draft]]\n````\n",
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+
+
+def test_raw_captures_and_attachment_embeds_are_not_edges(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    # Captured text mentioning the orphan is the source's link, not the vault's.
+    (raw / "capture.md").write_text(
+        "---\nsource_url: https://example.com/c\nsha256: " + "0" * 64 + "\n---\nSee [[Wiki/gamma-orphan]] and [[alpha-note]].\n",
+        encoding="utf-8",
+    )
+    # Attachments of any extension are embeds; a dotted note name still resolves.
+    (vault / "Wiki" / "Node.js.md").write_text("---\ntype: entity\n---\nabout node\n", encoding="utf-8")
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\n![[recording.mp3]] ![[clip.webp]] ![[deck.pdf]]\n", encoding="utf-8"
+    )
+    (vault / "Wiki" / "alpha-note-draft.md").write_text(DRAFT + "\nRuntime: [[Node.js]].\n", encoding="utf-8")
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+    assert links["notes"]["Wiki/Node.js.md"]["inbound"] == 1
+    assert links["notes"]["Wiki/alpha-note-draft.md"]["outbound"] == 2
+
+
+def test_links_in_yaml_comments_are_not_edges_but_links_in_values_are(vault):
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: []   # e.g. [[alpha-note]]\n"),
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: \"[[alpha-note]]\"\n"),
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 2
+
+
+def test_self_links_under_any_spelling_are_not_edges(vault):
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\nSelf: [[gamma-orphan]] and [[Wiki/gamma-orphan]] and [[gamma-orphan#Heading|me]].\n",
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert links["notes"]["Wiki/gamma-orphan.md"] == {"inbound": 0, "outbound": 0}
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+
+
+def test_ambiguous_bare_links_resolve_by_folder_or_not_at_all(vault):
+    for folder in ("A", "B"):
+        (vault / folder).mkdir()
+        (vault / folder / "foo.md").write_text(f"---\ntype: entity\n---\n{folder} foo\n", encoding="utf-8")
+    (vault / "B" / "source.md").write_text("---\ntype: entity\n---\nSee [[foo]].\n", encoding="utf-8")
+    (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nAlso [[foo]].\n", encoding="utf-8")
+    links = _run(vault)["links"]
+    assert links["notes"]["B/foo.md"]["inbound"] == 1      # same folder as B/source.md
+    assert links["notes"]["A/foo.md"]["inbound"] == 0      # not handed the link by sort order
+    assert "A/foo.md" in links["orphans"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1   # ambiguous from Wiki/: unresolved, still a link
+    assert "Wiki/gamma-orphan.md" not in links["orphans"]
+    # The same-folder rule also decides the attachment and provenance prefilters:
+    # a dotted name shared by two folders, and a bare name a capture also has.
+    for folder in ("A", "B"):
+        (vault / folder / "Node.js.md").write_text("---\ntype: entity\n---\nnode\n", encoding="utf-8")
+    (vault / "Raw").mkdir()
+    (vault / "Raw" / "foo.md").write_text("---\nsource_url: https://x/foo\nsha256: " + "0" * 64 + "\n---\ncapture\n", encoding="utf-8")
+    (vault / "B" / "source.md").write_text("---\ntype: entity\n---\nSee [[foo]] and [[Node.js]].\n", encoding="utf-8")
+    links = _run(vault)["links"]
+    assert links["notes"]["B/Node.js.md"]["inbound"] == 1
+    assert links["notes"]["B/foo.md"]["inbound"] == 1
+    assert links["notes"]["B/source.md"]["outbound"] == 2
+    # With a wiki `foo` in two folders and a capture `foo`, the ambiguous link
+    # from Wiki/ is still a wiki link (unresolved), not provenance.
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
+
+
+def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):
+    _news_shaped_pair(vault)
+    # The Article's only link is its `## Source` line: no wiki relationship, so
+    # it is an orphan, while its provenance still resolves for the drift check.
+    report = _run(vault)
+    assert "Wiki/fed-article.md" in report["links"]["orphans"]
+    assert {i["path"]: i["status"] for i in report["raw_sources"]}["Wiki/fed-article.md"] == "fresh"
+    # A long attachment extension and a code span crossing a line break are
+    # embeds and examples too.
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\n![[diagram.excalidraw]] and ``literal\n[[alpha-note]]`` here.\n"
+        "\n> [!note]\n> ```md\n> [[alpha-note]] inside a callout fence\n>```\n\nAfter the callout: [[Node.js]].\n",
+        encoding="utf-8",
+    )
+    # The callout fence closes on `>``` ` (no space), and text after it is text again.
+    (vault / "Wiki" / "Node.js.md").write_text("---\ntype: entity\n---\nnode\n", encoding="utf-8")
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" not in links["orphans"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+
+
+def test_bare_provenance_link_colliding_with_a_wiki_name_is_unresolved(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    (raw / "foo.md").write_text("---\nsource_url: https://x/foo\nsha256: " + "0" * 64 + "\n---\ncapture\n", encoding="utf-8")
+    (vault / "Wiki" / "foo.md").write_text("---\ntype: entity\n---\nwiki foo\n", encoding="utf-8")
+    (vault / "Wiki" / "typed.md").write_text(
+        "---\ntype: source\nsource_url: https://x/t\nsha256: " + "0" * 64 + "\n---\nSee [[foo]].\n", encoding="utf-8"
+    )
+    by_path = {i["path"]: i for i in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/typed.md"]["status"] == "unresolved"
+    assert by_path["Wiki/typed.md"]["hashed_file"] is None
+
+
+def test_links_with_a_path_resolve_by_that_path_only(vault):
+    raw = _news_shaped_pair(vault)
+    # The Article's link names the wrong day: the only bloomberg-fed.md lives
+    # under 2026-05-06, and it must not stand in for the missing capture.
+    article = vault / "Wiki" / "fed-article.md"
+    article.write_text(
+        article.read_text(encoding="utf-8").replace("[[Raw/2026-05-06/bloomberg-fed]]", "[[Raw/2026-05-07/bloomberg-fed]]"),
+        encoding="utf-8",
+    )
+    report = _run(vault)
+    assert {i["path"]: i["status"] for i in report["raw_sources"]}["Wiki/fed-article.md"] == "unresolved"
+    assert raw.exists()
+    # The same rule in the link graph: a path link to a note that is not there
+    # gives the same-named note elsewhere no backlink.
+    (vault / "Wiki" / "gamma-orphan.md").write_text(GAMMA + "\nSee [[Archive/alpha-note]].\n", encoding="utf-8")
+    links = _run(vault)["links"]["notes"]
+    assert links["Wiki/alpha-note.md"]["inbound"] == 1
+    assert links["Wiki/gamma-orphan.md"]["outbound"] == 1

--- a/tests/skills/test_vault_links.py
+++ b/tests/skills/test_vault_links.py
@@ -159,6 +159,16 @@ def test_links_in_yaml_comments_are_not_edges_but_links_in_values_are(vault):
     assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 2
 
 
+def test_links_inside_obsidian_and_html_comments_are_not_edges(vault):
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA + "\n%% draft: [[alpha-note]] %%\n\n<!-- todo: [[alpha-note-draft]]\nlater -->\n%%\nmulti-line [[alpha-note]]\n%%\n",
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert "Wiki/gamma-orphan.md" in links["orphans"]
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+
+
 def test_self_links_under_any_spelling_are_not_edges(vault):
     (vault / "Wiki" / "gamma-orphan.md").write_text(
         GAMMA + "\nSelf: [[gamma-orphan]] and [[Wiki/gamma-orphan]] and [[gamma-orphan#Heading|me]].\n",

--- a/tests/skills/test_vault_links.py
+++ b/tests/skills/test_vault_links.py
@@ -149,6 +149,15 @@ def test_links_in_yaml_comments_are_not_edges_but_links_in_values_are(vault):
     links = _run(vault)["links"]
     assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
     assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 2
+    # A quoted flow-list item keeps its comma.
+    (vault / "Wiki" / "Smith, John.md").write_text("---\ntype: entity\n---\nperson\n", encoding="utf-8")
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: [\"[[Smith, John]]\", \"[[alpha-note]]\"]\n"),
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert links["notes"]["Wiki/Smith, John.md"]["inbound"] == 1
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 2
     # A block scalar is a value too.
     (vault / "Wiki" / "gamma-orphan.md").write_text(
         GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: |\n  See [[alpha-note]]\n  and more\n"),

--- a/tests/skills/test_vault_links.py
+++ b/tests/skills/test_vault_links.py
@@ -3,6 +3,7 @@
 """
 
 import os
+import hashlib
 from pathlib import Path
 
 from .lint_vault_support import (
@@ -148,6 +149,14 @@ def test_links_in_yaml_comments_are_not_edges_but_links_in_values_are(vault):
     links = _run(vault)["links"]
     assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
     assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 2
+    # A block scalar is a value too.
+    (vault / "Wiki" / "gamma-orphan.md").write_text(
+        GAMMA.replace("extra_field: yes\n", "extra_field: yes\nrelated: |\n  See [[alpha-note]]\n  and more\n"),
+        encoding="utf-8",
+    )
+    links = _run(vault)["links"]
+    assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
+    assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 2
 
 
 def test_self_links_under_any_spelling_are_not_edges(vault):
@@ -208,6 +217,23 @@ def test_provenance_link_to_a_capture_is_not_a_wiki_relationship(vault):
     assert "Wiki/gamma-orphan.md" not in links["orphans"]
     assert links["notes"]["Wiki/gamma-orphan.md"]["outbound"] == 1
     assert links["notes"]["Wiki/alpha-note.md"]["inbound"] == 1
+
+
+def test_note_relative_source_url_normalises_but_never_leaves_the_vault(vault):
+    raw = vault / "Raw"
+    raw.mkdir()
+    (raw / "capture.md").write_text("---\nsource_url: https://x/c\nsha256: " + "0" * 64 + "\n---\ncaptured\n", encoding="utf-8")
+    digest = hashlib.sha256(b"captured\n").hexdigest()
+    (vault / "Wiki" / "typed.md").write_text(
+        f"---\ntype: source\nsource_url: ../Raw/capture.md\nsha256: {digest}\n---\nbody\n", encoding="utf-8"
+    )
+    (vault / "Wiki" / "escape.md").write_text(
+        f"---\ntype: source\nsource_url: ../../capture.md\nsha256: {digest}\n---\nbody\n", encoding="utf-8"
+    )
+    by_path = {i["path"]: i for i in _run(vault)["raw_sources"]}
+    assert by_path["Wiki/typed.md"]["status"] == "fresh"
+    assert by_path["Wiki/typed.md"]["hashed_file"] == "Raw/capture.md"
+    assert by_path["Wiki/escape.md"]["status"] == "unresolved"
 
 
 def test_bare_provenance_link_colliding_with_a_wiki_name_is_unresolved(vault):


### PR DESCRIPTION
## Summary

Lands the skill-side findings of the prompt audit (`/claude-api prompt-audit`, target model: the Claude 5 generation the evals are baselined on). Every finding is a dated prompting pattern or a reference file that disagrees with itself or with its `SKILL.md`; none changes what a skill is for. Nine commits, one per finding group, each byte-equal to the audited patch hunks except the two judgment items (C4 new script + its follow-up, M8 condensation) which carry their own review trail below.

| Findings | What changed |
|---|---|
| A1–A7 `diagramming-obsidian` | `references/depth-enhancements.md` keyed off "Step 0/1/2" headings that `SKILL.md` has not had since 0ec52211 (dead pointers); `layout-heuristics.md` contradicted itself on the grid gap (200 − 180 ≠ 40), the separator gap (200px vs 30px in three other places), and evidence-lane placement; `visual-patterns.md` asked for opacity the palette forbids; `SKILL.md` carried a plan-before-acting scaffold. |
| B1–B3 `executing`, `finishing`, `dispatching` | A cross-reference to dispatching's "model tier" text that no longer exists; a `git 2.52` version pin on behavior every git with worktrees has; an update suppressor in the dispatch card whose job the "Come back only for" list already does. |
| D1–D3 `tdd/references/testing-anti-patterns.md` | Four scripted "Gate Function" blocks (byte-identical since the initial commit, missed by the v5 prose diet), the TDD cycle restated three ways — one variant dropping the "verify RED" step `SKILL.md` marks non-skippable — and the principle stated four times. |
| C1–C3 `maintaining-obsidian` | "Not a template to copy" said eight times plus a 40-line worked example; two prohibitions that quote the hedge they forbid (one shipped into every new llm-wiki vault). |
| C4 `maintaining-obsidian` (new) | `references/lint_vault.py` runs the deterministic LINT scans (frontmatter as a block, orphans, sha256 drift, undeclared fields, log consistency, duplicate titles) and emits facts; thresholds move into each preset's `## Audit Thresholds`; the model keeps the EVOLVE/GROW judgment. `tests/skills/test_lint_vault.py` + `test_vault_links.py` (38 tests over a shared `lint_vault_support.py`) covers it, including the three defects the `qa` agent found in the first cut: an unindented YAML sequence read as empty, `--skip` dropping Raw Sources from the drift check, and the llm-wiki/news presets omitting the `sha256` that B-4 puts on every Source note (now declared, with a preset-schema test). The Codex review then caught three more in the first cut — a typed note with a remote `source_url` hashed its own body and read as drift on every correct ingest, `--tag-min` ignored the taxonomy, and the minimal preset's placeholders declared two phantom types — fixed in 0b7d9488 with five more tests; a second pass caught the llm-wiki Source and Paper-variant fences (both `type: source`) being unioned, so ordinary Sources read as missing every paper-only field — fixed in 9fddeb5c, each field row now carrying its `expected` denominator; a third pass added tag discriminators for variants (`tags: [paper]` on the Paper fence), put `unresolved` ahead of `unhashed`, and named `CANONICAL_FILE` alongside `LOCATIONS` in the releasing skill; a further sixteen review passes on the linter (fence nesting, callouts, code spans, attachments, provenance vs. wiki-name collisions, `_audits/` and Raw captures out of the scope slice, log-field shapes, the size cap twice) are each their own commit with a test — f359d988 (22 tests). |
| M1–M9 contributor surface | `releasing` skill: dead `/arcforge:` invocation in a repo where the plugin is disabled, a hard-coded "9 locations" count that already rotted once, incident narratives, a doubled closing recap, a migration-relative footnote; `product/AGENTS.md`: a phantom "PRD → XML → DAG" comparison, "lightweight ≠ thin" stated three times, and (M8) the check:product mechanics condensed from GFM tutorials to the contract the check enforces — reviewed three times by the `pm` agent against `scripts/lib/product-*.js` regexes; `.claude/rules/testing.md`: the `tests/node/` description now matches `ls tests/node`. |

Not in this PR: the engine-prompt findings E1–E12 (`fix/prompt-audit-eval`), so the evals below ran under the unchanged grader.

## Type

- [x] Skill
- [x] Docs

## Iron Law Compliance (Skills Only)

**RED (Baseline):**
Observed in the audit, with `git blame` provenance for every line: reference files pointing at headings that do not exist (A1, since 2026-04-14), numeric layout rules that contradict the same file's table (A3/A4), a TDD reference whose restated cycle omits the step `SKILL.md:37` says never to skip (D2), and update-suppressor / plan-first / quoted-hedge patterns the target model's documented behavior turns into under-narration, over-planning, and anchoring (B3, A7, C2/C3). None was covered by an eval because trials receive `SKILL.md` only; the references never reach the model under test.

**GREEN (Skill Applied):**
Each hunk does exactly what its REPORT entry says (an independent refuter per package tried to disprove every hunk and failed; the `pm` agent read `product/AGENTS.md` old vs new three times and its five named drops were restored). The four `SKILL.md` edits that an eval can see — executing B1, finishing B2, diagramming A7, and maintaining-obsidian C4 (a fourth the first cut of the ledger missed; the Codex review caught it) — carry harness evidence: see Baseline provenance.

**REFACTOR (Loopholes Closed):**
Prose that could be code became code: `lint_vault.py` replaces model-run percentage scans (C4); the releasing skill points at `LOCATIONS` in `scripts/check-version-sync.js` instead of a count (M2); `product/AGENTS.md` states each bound the check enforces once, verified against the regex that enforces it (M8).

**Baseline provenance:**
- Model + version: harness default model (result rows carry `model: null`, as the standing 2026-08-15 rows do); Claude Code 2.1.263
- Harness + version: `node scripts/cli.js eval ab <scenario> --k 5` on this branch, no `--plugin-dir` (same conditions as the standing A/B rows)
- Eval scenario ID + k (run `20260908-141154`, details in `evals/skill-eval-coverage.md`, section "Prompt audit (2026-09-08)"):
  - `eval-finishing-verify-before-options` k=5 — baseline 0.43 → treatment 1.00, **+0.57 CI[0.57, 0.57]**, PASS on both pre-registered halves (IMPROVED)
  - `eval-executing-verify-decides-done` k=5 (+ a symmetric `--k 1` top-up after one runner-timeout kill per arm) — baseline 0.80 → treatment 1.00, +0.20 CI[−0.36, 0.76], **INCONCLUSIVE**: treatment at ceiling, half 1 (CI lower bound > 0) not met because this run's baseline scored 0.80 with high variance; recorded as not established, not rerun
  - `eval-diagramming-obsidian-unverified-save-claim` k=5 — first run (`20260908-141154`) not evaluable: four of five treatment trials killed at the fixed 900 s runner timeout. Rerun `20260909-015919` with `ARCFORGE_EVAL_TRIAL_TIMEOUT_MS=1800000` (the override lands in `fix/prompt-audit-eval`; three of the five treatment trials ran 841–1171 s): baseline 0.50 → treatment 0.90, **+0.40 CI[0.16, 0.64]**, PASS on both pre-registered halves (IMPROVED)
  - `eval-maintaining-obsidian-audit-runs-lint-script` k=5 (new scenario, skill scope, `non-regression` policy, preflight skipped; v1 run `20260909-070419`, v2 run `20260909-125045` after the Codex review asked for every declared threshold flag to be asserted) — treatment 5/5 at 1.00 both times (mean 284 s / 206 s), all four flags in every trial, no kills, **PASS on the strict bar**; baseline also 5/5 because the fixture carries the skill's `references/` (a skill-scope trial injects `SKILL.md` alone), which is why the verdict is the bar and not a delta (e9dbf34a)

**Follow-ups this PR does not carry:**
- The per-trial timeout override (`ARCFORGE_EVAL_TRIAL_TIMEOUT_MS`) that the diagramming rerun needed ships in `fix/prompt-audit-eval`; the diagramming row's standing benchmark entry should be regenerated with it set, since the row's treatment arm runs past 900 s.
- The release's benchmark regeneration re-measures the executing row at full k.

## Testing

- [x] `npm test` passes (all 5 runners)
- [x] New tests added for new functionality (`tests/skills/test_lint_vault.py`)
- [x] Tested on Claude Code (primary platform)
- [x] The six static checks green (`check:versions`, `check:docs`, `check:cli-consumers`, `check:hooks`, `check:eval-targets`, `check:product`)
