### PR TITLE
fix(hooks): drop the non-schema keys Claude Code warns about

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -102,6 +102,11 @@ Register hooks in `hooks/claude-code.json` — the path
 thing that loads the registry. It is deliberately NOT `hooks/hooks.json`: that
 is the path Codex auto-discovers plugin hooks at, and `npm run check:hooks`
 fails if a file reappears there.
+- A matcher-group carries **only** `matcher` and `hooks`. Claude Code's schema
+  knows no other key: an `id`, a `description` or any other annotation is
+  dropped on load and warned about ("unknown keys ... ignored") at every
+  session start. Names and descriptions for the entries live in
+  `hooks/README.md`; `npm run check:hooks` fails if one returns to the JSON
 - Use `"async": true` for non-blocking hooks (e.g., logging, tracking)
 - Use `${CLAUDE_PLUGIN_ROOT}` (with braces) for all path references
 - Handler types: `command` (shell), `prompt` (LLM evaluation), `agent` (multi-turn subagent)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,7 +6,7 @@ Hooks for extending Claude Code behavior in arcforge.
 
 ```
 hooks/
-├── claude-code.json        # Hook registry (9 entries, each with a stable `id`)
+├── claude-code.json        # Hook registry (9 matcher-groups)
 ├── README.md
 ├── secrets-guard/          # Warn-only scan for hardcoded credentials
 │   └── main.js
@@ -31,9 +31,15 @@ hooks/
 
 ## Active Hooks
 
-`claude-code.json` registers **9 entries**, each with a stable `id`. Every hook
-is its own registration; the observers are async entries so their daemon I/O
-never joins the blocking path.
+`claude-code.json` registers **9 matcher-groups**. Every hook is its own
+registration; the observers are async entries so their daemon I/O never joins
+the blocking path.
+
+A matcher-group carries only the two keys Claude Code's schema knows —
+`matcher` and `hooks`. Annotations such as a name or a description are *not*
+allowed there: the host drops unknown keys and warns about every one of them at
+session start. The names below are this README's handles for the entries, not
+fields in the JSON, and `check:hooks` fails if an annotation creeps back in.
 
 The registry is named for its host rather than by convention. Claude Code loads
 it because `.claude-plugin/plugin.json` declares
@@ -42,8 +48,8 @@ left empty on purpose, because that is the path Codex auto-discovers plugin
 hooks at and these hooks speak Claude Code's protocol. `npm run check:hooks`
 fails if either the declaration or the emptiness goes away.
 
-| Event | id | Kind | What runs |
-|-------|----|------|-----------|
+| Event | Registration | Kind | What runs |
+|-------|--------------|------|-----------|
 | SessionStart | `inject-context` | sync | Loads previous session context / activated instincts |
 | SessionStart | `session-start` | async | Initializes the session file, lazily starts the observer daemon |
 | UserPromptSubmit | `user-message-counter` | sync | Counts user messages (stdin passthrough) |
@@ -76,7 +82,8 @@ its self-gated context.
 ### Registry schema check
 
 `node scripts/check-hooks-schema.js` (npm: `check:hooks`) statically validates
-`hooks/claude-code.json` — known event names, valid matchers, stable unique ids,
+`hooks/claude-code.json` — known event names, valid matchers, no matcher-group
+key outside `matcher`/`hooks`, no command registered twice,
 `${CLAUDE_PLUGIN_ROOT}` command form, and the one-sync-entry-per-blocking-event
 rule. It also checks the registration path itself: that `.claude-plugin/plugin.json`
 declares the registry, that `.codex-plugin/plugin.json` declares no hooks, and

--- a/hooks/__tests__/hooks-schema.test.js
+++ b/hooks/__tests__/hooks-schema.test.js
@@ -3,8 +3,9 @@
  *
  * Proves the shipped hooks/claude-code.json passes the schema linter, and that
  * the linter actually catches the failure classes it exists to guard (unknown
- * event, duplicate id, missing ${CLAUDE_PLUGIN_ROOT}, and an async guard
- * sneaking onto the blocking path).
+ * event, a matcher-group key Claude Code's schema does not know, a duplicate
+ * command, missing ${CLAUDE_PLUGIN_ROOT}, and an async guard sneaking onto the
+ * blocking path).
  *
  * Also proves the registration-path half, which is the leak guard: the Claude
  * Code manifest declares exactly `./hooks/claude-code.json` (the only thing that
@@ -33,8 +34,8 @@ const {
 // biome-ignore lint/suspicious/noTemplateCurlyInString: fixture uses the literal ${CLAUDE_PLUGIN_ROOT} placeholder
 const CMD = '${CLAUDE_PLUGIN_ROOT}/x';
 
-function group(id, extra = {}) {
-  return { id, matcher: '.*', hooks: [{ type: 'command', command: CMD, ...extra }] };
+function group(command = CMD, extra = {}) {
+  return { matcher: '.*', hooks: [{ type: 'command', command, ...extra }] };
 }
 
 describe('check-hooks-schema', () => {
@@ -46,21 +47,29 @@ describe('check-hooks-schema', () => {
   });
 
   it('rejects an unknown event name', () => {
-    const errors = validateHooksJson({ hooks: { NotARealEvent: [group('x')] } });
+    const errors = validateHooksJson({ hooks: { NotARealEvent: [group()] } });
     assert.ok(errors.some((e) => e.includes('unknown hook event')));
   });
 
-  it('rejects duplicate ids', () => {
+  it("rejects a matcher-group key Claude Code's schema does not know", () => {
     const errors = validateHooksJson({
-      hooks: { PreToolUse: [group('dup')], PostToolUse: [group('dup')] },
+      hooks: { Stop: [{ ...group(), id: 'session-end', description: 'annotated' }] },
     });
-    assert.ok(errors.some((e) => e.includes('duplicate id')));
+    assert.ok(errors.some((e) => e.includes('unknown matcher-group keys')));
+    assert.ok(errors.some((e) => e.includes('"id"') && e.includes('"description"')));
+  });
+
+  it('rejects the same command registered twice', () => {
+    const errors = validateHooksJson({
+      hooks: { PreToolUse: [group()], PostToolUse: [group()] },
+    });
+    assert.ok(errors.some((e) => e.includes('duplicate command')));
   });
 
   it('rejects a command that omits the plugin-root placeholder', () => {
     const errors = validateHooksJson({
       hooks: {
-        Stop: [{ id: 'x', matcher: '.*', hooks: [{ type: 'command', command: 'node end.js' }] }],
+        Stop: [{ matcher: '.*', hooks: [{ type: 'command', command: 'node end.js' }] }],
       },
     });
     assert.ok(errors.some((e) => e.includes('CLAUDE_PLUGIN_ROOT')));
@@ -69,8 +78,8 @@ describe('check-hooks-schema', () => {
   it('rejects a blocking event with no single synchronous dispatcher entry', () => {
     const errors = validateHooksJson({
       hooks: {
-        PreToolUse: [group('only-async', { async: true })],
-        PostToolUse: [group('ok')],
+        PreToolUse: [group(`${CMD}/pre`, { async: true })],
+        PostToolUse: [group(`${CMD}/post`)],
       },
     });
     assert.ok(errors.some((e) => e.includes('PreToolUse') && e.includes('synchronous')));

--- a/hooks/claude-code.json
+++ b/hooks/claude-code.json
@@ -2,8 +2,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "id": "inject-context",
-        "description": "Inject resume context (session summary, activated instincts).",
         "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
@@ -13,8 +11,6 @@
         ]
       },
       {
-        "id": "session-start",
-        "description": "Create the session file and lazily start the observer daemon (async).",
         "matcher": "startup|resume|clear",
         "hooks": [
           {
@@ -27,8 +23,6 @@
     ],
     "UserPromptSubmit": [
       {
-        "id": "user-message-counter",
-        "description": "Increment the diary user-message counter (stdin-passthrough).",
         "matcher": ".*",
         "hooks": [
           {
@@ -40,8 +34,6 @@
     ],
     "PreToolUse": [
       {
-        "id": "secrets-guard",
-        "description": "Warn-only scan for hardcoded credentials in Edit/Write content and git commit commands.",
         "matcher": ".*",
         "hooks": [
           {
@@ -51,8 +43,6 @@
         ]
       },
       {
-        "id": "observe-pre",
-        "description": "Append the pre-tool observation (async — daemon I/O stays off the blocking path).",
         "matcher": ".*",
         "hooks": [
           {
@@ -65,8 +55,6 @@
     ],
     "PostToolUse": [
       {
-        "id": "compact-suggester",
-        "description": "Increment the shared diary tool-count on every event and suggest /compact at the threshold.",
         "matcher": ".*",
         "hooks": [
           {
@@ -76,8 +64,6 @@
         ]
       },
       {
-        "id": "observe-post",
-        "description": "Append the post-tool observation (async).",
         "matcher": ".*",
         "hooks": [
           {
@@ -90,8 +76,6 @@
     ],
     "Stop": [
       {
-        "id": "session-end",
-        "description": "Finalize the session and run the threshold-gated diary capture.",
         "matcher": ".*",
         "hooks": [
           {
@@ -103,8 +87,6 @@
     ],
     "PreCompact": [
       {
-        "id": "pre-compact",
-        "description": "Reset the suggester state and run diary-capture before compaction.",
         "matcher": ".*",
         "hooks": [
           {

--- a/scripts/check-hooks-schema.js
+++ b/scripts/check-hooks-schema.js
@@ -12,9 +12,12 @@
  *
  * Validates hooks/claude-code.json:
  *   - every event key is a known Claude Code hook event;
- *   - every matcher-group has a stable string `id`, a valid-regex `matcher`,
- *     and a non-empty `hooks` array;
- *   - `id`s are unique across the whole file;
+ *   - every matcher-group carries ONLY the two keys Claude Code's schema knows
+ *     (`matcher`, `hooks`) — anything else is silently dropped by the host and
+ *     warned about at every session start, so it is a finding here;
+ *   - every matcher-group has a valid-regex `matcher` and a non-empty `hooks`
+ *     array;
+ *   - no command is registered twice across the whole file;
  *   - every command hook uses `type: "command"` and references
  *     `${CLAUDE_PLUGIN_ROOT}`;
  *   - the sync-guard rule: PreToolUse and PostToolUse each expose EXACTLY ONE
@@ -76,6 +79,12 @@ const ALLOWED_EVENTS = new Set([
   'TaskCompleted',
 ]);
 
+// The only keys Claude Code's matcher-group schema recognises. Anything else is
+// stripped on load and reported as "unknown keys ... ignored" in every session,
+// so the registry must not carry annotations here — hook names and descriptions
+// live in hooks/README.md.
+const ALLOWED_GROUP_KEYS = new Set(['matcher', 'hooks']);
+
 // Events whose sync entry blocks the tool call — they must collapse to exactly
 // one synchronous dispatcher entry (the async observers are the only exception).
 const SINGLE_SYNC_EVENTS = ['PreToolUse', 'PostToolUse'];
@@ -94,7 +103,7 @@ function validateHooksJson(config) {
     return ['hooks/claude-code.json must have a top-level "hooks" object'];
   }
 
-  const seenIds = new Set();
+  const seenCommands = new Set();
 
   for (const [event, groups] of Object.entries(config.hooks)) {
     if (!ALLOWED_EVENTS.has(event)) {
@@ -108,12 +117,11 @@ function validateHooksJson(config) {
     for (const [i, group] of groups.entries()) {
       const where = `${event}[${i}]`;
 
-      if (typeof group?.id !== 'string' || !group.id.trim()) {
-        errors.push(`${where}: missing stable string "id"`);
-      } else if (seenIds.has(group.id)) {
-        errors.push(`${where}: duplicate id "${group.id}"`);
-      } else {
-        seenIds.add(group.id);
+      const unknownKeys = Object.keys(group ?? {}).filter((k) => !ALLOWED_GROUP_KEYS.has(k));
+      if (unknownKeys.length > 0) {
+        errors.push(
+          `${where}: unknown matcher-group keys ${unknownKeys.map((k) => `"${k}"`).join(', ')} — Claude Code ignores them and warns at session start`,
+        );
       }
 
       if (typeof group?.matcher !== 'string') {
@@ -137,6 +145,10 @@ function validateHooksJson(config) {
         // biome-ignore lint/suspicious/noTemplateCurlyInString: matching the literal ${CLAUDE_PLUGIN_ROOT} placeholder text
         if (typeof hook?.command !== 'string' || !hook.command.includes('${CLAUDE_PLUGIN_ROOT}')) {
           errors.push(`${where}.hooks[${j}]: command must reference \${CLAUDE_PLUGIN_ROOT}`);
+        } else if (seenCommands.has(hook.command)) {
+          errors.push(`${where}.hooks[${j}]: duplicate command "${hook.command}"`);
+        } else {
+          seenCommands.add(hook.command);
         }
       }
     }


### PR DESCRIPTION
## What was wrong

Every matcher-group in `hooks/claude-code.json` carried an `id` and a `description`. Claude Code's matcher-group schema knows only `matcher` and `hooks`, so it dropped all 18 of them and said so at every session start:

```
arcforge: hooks.json: unknown keys "id" in hooks.SessionStart[0], "description" in
hooks.SessionStart[0], "id" in hooks.SessionStart[1], ... and 13 more ignored
```

`hooks.json` there is the host's generic label for a plugin's hook registry, not a stray file — `check:hooks` still proves neither `hooks.json` nor `hooks/hooks.json` exists. Confirmed by the shape of the message: 18 keys, and an event order (`SessionStart[0]`, `SessionStart[1]`, `UserPromptSubmit[0]`) that matches this tree and not the cached 3.1.0 payload.

Cosmetic — the keys are ignored and every hook still fires — but it is user-facing noise in every session.

## Why the keys were there

Nothing at runtime ever read them. They were arcforge's own:

- **`id`** gave `check-hooks-schema.js` a handle for its uniqueness rule.
- **`description`** was an inline comment JSON has no syntax for.

Both are documentation `hooks/README.md` already carries, paid for with a warning in every user's session.

## What changed

| File | Change |
|---|---|
| `hooks/claude-code.json` | `id` + `description` removed from all 9 groups; `matcher`/`hooks`/`async` untouched |
| `scripts/check-hooks-schema.js` | "must have a stable `id`" → **reject** any matcher-group key outside `matcher`/`hooks`; duplicate-registration rule now keys on the command string |
| `hooks/README.md` | Table column `id` → `Registration`; new paragraph on the closed key set |
| `.claude/rules/hooks.md` | One rule under *Registration* |
| `hooks/__tests__/hooks-schema.test.js` | `duplicate id` test → `unknown matcher-group keys` + `duplicate command` |

The linter now turns the host's warning into a CI failure, per *architecture.md*: "a norm written in prose that could be a check is a drift risk."

The entry names (`inject-context`, `observe-pre`, …) stay as prose in `hooks/README.md`, `docs/guide/hooks-system.md` and `product/specs/hooks.md` — which is where the guide and the spec already referenced them. Neither promised the JSON field, so no spec change is owed.

## Verification

5 test runners (2104 jest / 250 node-test / node / pytest / bash) and all 6 static checks green; Biome clean.

Two limits, stated rather than buried:

1. **Structural, not empirical.** The JSON now carries only schema keys and `check:hooks` fails if that regresses. The warning string could not be found in any locally installed binary (2.1.261–2.1.267), so it was never reproduced under a debugger — but a `claude --plugin-dir .` restart on this branch no longer prints it.
2. **Installed copies keep warning.** Plugin code is cached by version, so a marketplace-installed 6.1.0 is unaffected until the next release. No version bump here; `CHANGELOG` is written at release time, as with #181/#182.
